### PR TITLE
fix: update gemini-cli symlink for v0.36.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -138,7 +138,7 @@ COPY --from=builder /usr/local/bin/claude /usr/local/bin/claude
 
 # Symlink Codex and Gemini CLI tools (COPY dereferences symlinks, breaking Node.js relative imports)
 RUN ln -sf /usr/lib/node_modules/@openai/codex/bin/codex.js /usr/bin/codex \
-    && ln -sf /usr/lib/node_modules/@google/gemini-cli/dist/index.js /usr/bin/gemini
+    && ln -sf /usr/lib/node_modules/@google/gemini-cli/bundle/gemini.js /usr/bin/gemini
 
 # Copy uv (agents may need to create their own environments)
 COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /usr/local/bin/uv


### PR DESCRIPTION
## Summary
- `@google/gemini-cli` v0.36.0 restructured its package, moving the entry point from `dist/index.js` to `bundle/gemini.js`
- The Docker symlink at `/usr/bin/gemini` was pointing to the old path, causing `[Errno 2] No such file or directory: 'gemini'` in the resource finder pipeline
- Updates the symlink target in `docker/Dockerfile` to `bundle/gemini.js`

## Test plan
- [ ] Rebuild Docker image
- [ ] Verify `gemini --version` works inside the container
- [ ] Run a research pipeline with `provider: gemini` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)