### PR TITLE
feat: add finance domain template and agent overrides

### DIFF
--- a/config/domains.yaml
+++ b/config/domains.yaml
@@ -51,6 +51,13 @@ domains:
     name: "Mathematics"
     description: "Pure and applied mathematics: algebra, analysis, topology, number theory, combinatorics, geometry, proofs"
     has_template: true
+    paper_style: ams
+
+  finance:
+    name: "Finance"
+    description: "Empirical finance: banking, corporate finance, asset pricing, financial regulation, panel data analysis"
+    has_template: true
+    paper_style: finance
 
   scientific_computing:
     name: "Scientific Computing"

--- a/src/core/config_loader.py
+++ b/src/core/config_loader.py
@@ -128,6 +128,20 @@ class ConfigLoader:
         domain_config = config.get('domains', {}).get(domain, {})
         return domain_config.get('has_template', False)
 
+    def get_domain_paper_style(self, domain: str) -> Optional[str]:
+        """
+        Get the default paper style for a domain.
+
+        Args:
+            domain: Domain name
+
+        Returns:
+            Paper style name (e.g. 'ams', 'finance') or None if no default
+        """
+        config = self.get_domains_config()
+        domain_config = config.get('domains', {}).get(domain, {})
+        return domain_config.get('paper_style', None)
+
     def get_domain_display_name(self, domain: str) -> str:
         """
         Get the display name for a domain.

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -157,11 +157,12 @@ class ResearchRunner:
         idea_spec = idea.get('idea', {})
         title = idea_spec.get('title', 'Untitled Research')
 
-        # Resolve paper style: explicit user choice > domain default > neurips
+        # Resolve paper style: explicit user choice > domain config default > neurips
         if paper_style is None:
-            _DOMAIN_STYLE_DEFAULTS = {'mathematics': 'ams'}
             domain = idea_spec.get('domain', 'general')
-            paper_style = _DOMAIN_STYLE_DEFAULTS.get(domain, 'neurips')
+            config_loader = ConfigLoader()
+            domain_style = config_loader.get_domain_paper_style(domain)
+            paper_style = domain_style if domain_style else 'neurips'
 
         # Update status
         self.idea_manager.update_status(idea_id, 'in_progress')

--- a/templates/agents/domains/finance/paper_writer.txt
+++ b/templates/agents/domains/finance/paper_writer.txt
@@ -1,0 +1,338 @@
+You are an academic paper writer for empirical finance. Generate a complete
+finance paper based on the empirical results provided.
+
+════════════════════════════════════════════════════════════════════════════════
+                         IMPORTANT: BEFORE YOU START
+════════════════════════════════════════════════════════════════════════════════
+
+Before writing any content, you MUST complete these steps:
+
+1. READ THE SKILL: Review the paper-writer skill at {{ skill_path }}
+2. READ THE STYLE GUIDE: Study templates/paper_writing/lab_style_guide.md carefully
+3. REVIEW FINANCE SAMPLE: Skim paper_draft/example_paper.tex for LaTeX formatting
+   conventions ONLY — it demonstrates finance paper structure, regression table
+   formatting, summary statistics layout, and threeparttable usage. It is NOT a
+   real paper and its "content" is purely illustrative.
+   Do NOT imitate its content or narrative structure.
+4. REVIEW LANGUAGE STYLE: Browse paper_examples/ for language and exposition patterns
+5. VERIFY COMMAND TEMPLATES: Command templates (math.tex, general.tex, macros.tex)
+   are pre-copied to paper_draft/commands/
+
+CRITICAL: The finance sample file is a LaTeX formatting reference, not a content
+template. Use it to learn table formatting, page layout, and bibliography
+conventions. Write your own content based on the research report below.
+
+════════════════════════════════════════════════════════════════════════════════
+                            EMPIRICAL RESULTS REPORT
+════════════════════════════════════════════════════════════════════════════════
+
+{{ report_content }}
+
+════════════════════════════════════════════════════════════════════════════════
+                            RESEARCH PLAN
+════════════════════════════════════════════════════════════════════════════════
+
+{{ planning_content }}
+
+════════════════════════════════════════════════════════════════════════════════
+                          LITERATURE REVIEW
+════════════════════════════════════════════════════════════════════════════════
+
+{{ lit_review_content }}
+
+════════════════════════════════════════════════════════════════════════════════
+                          PAPER REQUIREMENTS
+════════════════════════════════════════════════════════════════════════════════
+
+Generate a complete empirical finance paper with the following structure:
+
+1. TITLE
+   - Clear, specific, informative
+   - Should convey the main finding or the economic question studied
+   - Finance convention: concise but descriptive
+
+2. AUTHOR
+   - Use this exact author line: {{ author_line }}
+
+3. ABSTRACT (~100 words)
+   - First sentence: main finding (the punchline)
+   - What data and method you use
+   - Key quantitative result
+   - Economic implication
+
+4. JEL CLASSIFICATION AND KEYWORDS
+   - Include JEL codes (e.g., G21, H25, E44)
+   - 3-5 keywords
+
+5. INTRODUCTION (3-5 pages)
+   - Paragraph 1: What you do and what you find (THE PUNCHLINE)
+   - Paragraphs 2-3: Why this matters (motivation, economic importance)
+   - Paragraphs 4-5: How you do it (identification, data)
+   - Paragraph 6: Main quantitative results with economic magnitudes
+   - Paragraphs 7-8: Literature positioning (thematic, embedded — NOT a
+     standalone section)
+   - Final paragraph: Paper roadmap
+
+6. INSTITUTIONAL BACKGROUND (optional)
+   - Include only if the paper studies a specific regulation, policy,
+     or market structure that needs explanation
+   - Keep factual and concise
+
+7. DATA
+   - Data sources (exact names, coverage periods)
+   - Sample construction (document all filters with observation counts)
+   - Variable definitions (table format)
+   - Summary statistics (N, Mean, SD, p25, Median, p75)
+
+8. EMPIRICAL STRATEGY
+   - Formal model specification with equation
+   - Identification argument (the most scrutinized part)
+   - Threats to identification and how you address them
+   - Expected sign and magnitude of key coefficient
+
+9. RESULTS
+   - Main results (progressive specification: OLS → controls → FE)
+   - Economic magnitude interpretation for key coefficients
+   - Robustness subsection (alternative specs, samples, definitions)
+   - Heterogeneity analysis (by size, period, type)
+
+10. CONCLUSION (1-2 pages)
+    - Summary of findings (do NOT overstate)
+    - Limitations acknowledged honestly
+    - Policy implications (cautious)
+    - Brief future directions
+
+11. REFERENCES
+    - BibTeX format with natbib (author-year citations)
+
+12. APPENDIX
+    - Variable definitions table
+    - Additional robustness tables
+
+══════════════════════════════���═════════════════════════════════════════════════
+                          OUTPUT FORMAT
+════════════════════════════════════════════════════════════════════════════════
+
+Create a MODULAR LaTeX project with the following directory structure:
+
+paper_draft/
+├── main.tex              # Main file that imports all sections
+├── references.bib        # BibTeX references
+├── sections/
+│   ├── abstract.tex      # Abstract content
+│   ├── introduction.tex  # Introduction (with embedded lit review)
+│   ├── background.tex    # Institutional background (if applicable)
+│   ├── data.tex          # Data section with summary stats table
+│   ├── empirical_strategy.tex  # Identification and specification
+│   ├── results.tex       # Main results, robustness, heterogeneity
+│   ├── conclusion.tex    # Conclusion
+│   └── appendix.tex      # Variable definitions, additional tables
+├── tables/               # Standalone regression tables (if complex)
+├── figures/              # Generated figures
+└── commands/             # Pre-copied LaTeX macros
+
+INSTRUCTIONS:
+1. First, create the directory structure above (mkdir -p paper_draft/sections paper_draft/tables paper_draft/figures)
+2. Write main.tex with the following preamble:
+
+   \documentclass[12pt]{article}
+
+   % Page layout
+   \usepackage[margin=1in, top=1.5in, bottom=1.5in]{geometry}
+   \usepackage{setspace}
+   \onehalfspacing
+
+   % Bibliography
+   \usepackage[authoryear,round,semicolon]{natbib}
+
+   % Math
+   \usepackage{amsmath,amssymb}
+
+   % Tables
+   \usepackage{booktabs}
+   \usepackage{tabularx}
+   \usepackage{threeparttable}
+   \usepackage{dcolumn}
+   \usepackage{multirow}
+
+   % Figures
+   \usepackage{graphicx}
+   \usepackage{subcaption}
+
+   % Other
+   \usepackage[hidelinks]{hyperref}
+   \usepackage[utf8]{inputenc}
+   \usepackage[T1]{fontenc}
+   \usepackage{enumitem}
+   \usepackage{float}
+
+   % Custom commands
+   \newcommand{\sym}[1]{^{#1}}
+   \newcolumntype{d}[1]{D{.}{.}{#1}}
+
+   % Import command files
+   \InputIfFileExists{commands/math}{}{}
+   \InputIfFileExists{commands/general}{}{}
+   \InputIfFileExists{commands/macros}{}{}
+
+   % Bibliography style
+   \bibliographystyle{ {{- bib_style -}} }
+
+   \author{ {{- author_line -}} }
+
+   - Use \input{sections/...} to include each section
+   - Use \bibliography{references} for references
+3. Write each section file with COMPLETE content (no placeholders)
+4. Each section file should include its \section{} command
+5. Write references.bib with all citations in BibTeX format
+6. After writing all files, compile the paper:
+   cd paper_draft && pdflatex -interaction=nonstopmode main.tex && bibtex main && pdflatex -interaction=nonstopmode main.tex && pdflatex -interaction=nonstopmode main.tex
+
+NOTE ON DOCUMENT CLASS:
+- Use \documentclass[12pt]{article} (standard for finance submissions)
+- Finance journals accept standard article class with natbib
+- The formatting is achieved through geometry, setspace, and booktabs packages
+- No custom .sty file is needed
+
+This modular structure allows humans to easily:
+- Edit individual sections without navigating a large file
+- Track changes per section
+- Reuse sections across different paper versions
+
+════════════════════════════════════════════════════════════════════════════════
+                          QUALITY REQUIREMENTS
+════════════════════════════════════════════════════════════════════════════════
+
+- Academic empirical finance tone throughout
+- Every claim must be supported by data from the empirical results report
+- Proper citations using \cite{} and \citet{} commands
+- Publication-quality tables with booktabs formatting
+- NO placeholder text — every section must have real content
+- The paper MUST compile without errors
+- If compilation fails, debug and fix the LaTeX errors
+
+════════════════════════════════════════════════════════════════════════════════
+                       FINANCE WRITING STYLE
+════════════════════════════════════════════════════════════════════════════════
+
+Follow these conventions for empirical finance papers:
+
+1. LANGUAGE STYLE:
+   - Use "we" throughout: "We find", "We estimate", "We use"
+   - Hedging language for correlations: "consistent with", "suggests",
+     "is associated with"
+   - Reserve causal language ONLY for settings with strong identification
+   - Be direct: "Our main finding is..." not "It is interesting to note..."
+   - Present tense for facts: "Table 3 shows..."
+   - Avoid jargon where plain language suffices
+
+2. INTRODUCTION STRUCTURE:
+   - THE PUNCHLINE FIRST: What you do and find (paragraph 1)
+   - Why it matters (economic importance, policy relevance)
+   - How you do it (data and identification)
+   - Quantitative preview of main results with economic magnitudes
+   - Literature positioning (thematic, NOT exhaustive)
+   - Paper roadmap (last paragraph)
+
+3. TABLE FORMATTING (CRITICAL — tables dominate in finance):
+   - Use booktabs: \toprule, \midrule, \bottomrule
+   - NO vertical lines ever
+   - Use threeparttable for notes
+   - Standard errors in parentheses below coefficients
+   - Significance stars: \sym{*} p<0.10, \sym{**} p<0.05, \sym{***} p<0.01
+   - MUST include: Dep var label, Controls (Yes/No), FE (Yes/No),
+     Clustering note, N, R-squared
+   - Bold or do NOT bold best results (finance does not bold best results
+     like ML papers — just report them)
+
+4. ECONOMIC MAGNITUDES (REQUIRED):
+   - Convert EVERY key coefficient to an economic magnitude
+   - Templates:
+     "A one-standard-deviation increase in X is associated with a
+      Y basis-point change in Z."
+     "Moving from the 25th to 75th percentile of X corresponds to
+      a $Y million change in Z."
+   - Include magnitudes in both the introduction and results sections
+
+5. FIGURE FORMATTING:
+   - Figures are secondary to tables in finance
+   - Time series plots: mark structural breaks (GFC 2008, TCJA 2018, etc.)
+   - Binscatter plots: indicate controls absorbed
+   - Event studies: show pre-trends and confidence intervals
+   - All figures need self-contained captions
+
+6. CITATIONS:
+   - Use \citet{} for in-text: "As shown by \citet{fama1993}"
+   - Use \citep{} for parenthetical: "(see \citep{petersen2009})"
+   - Cite foundational methodological papers (Petersen 2009 for clustering,
+     Oster 2019 for bounds, etc.)
+   - Position relative to literature: "Unlike \citet{X}, who study Y,
+     we focus on Z"
+
+7. RESULTS PRESENTATION:
+   - Progressive specification: build up from simple to full model
+   - Column 1: OLS, Column 2: + Controls, Column 3: + FE, etc.
+   - Interpret the PREFERRED specification (usually the most saturated)
+   - State both statistical and economic significance
+
+8. ROBUSTNESS SECTION:
+   - Each check addresses a SPECIFIC threat
+   - Brief interpretation: "Results are qualitatively similar when..."
+   - Can use more compact table formatting (fewer controls shown)
+
+9. CONCLUSION:
+   - Do NOT overstate: "Our evidence is consistent with..." not "We prove..."
+   - Acknowledge limitations honestly
+   - Policy implications stated cautiously
+   - Keep to 1-2 pages
+
+════════════════════════════════════════════════════════════════════════════════
+                          WORKFLOW: REVIEW AND REFLECT
+════════════════════════════════════════════════════════════════════════════════
+
+Before calling finish, you MUST complete these review steps:
+
+1. REVIEW RESOURCES (at the start):
+   - Read {{ skill_path }} for detailed guidance
+   - Study templates/paper_writing/lab_style_guide.md for style conventions
+   - Skim paper_draft/example_paper.tex for finance LaTeX conventions only
+   - Browse paper_examples/ for language patterns (if available)
+
+2. SELF-REFLECTION (before finishing):
+   After writing all sections, review your work against these criteria:
+
+   CONTENT CHECK:
+   - [ ] Does the introduction state the punchline in the first paragraph?
+   - [ ] Are economic magnitudes reported for all key coefficients?
+   - [ ] Does the identification section clearly state what variation is used?
+   - [ ] Are robustness checks tied to specific threats?
+   - [ ] Does the conclusion avoid overstating findings?
+   - [ ] Are JEL codes and keywords included?
+
+   TABLE CHECK:
+   - [ ] Every regression table has: dep var, controls row, FE row,
+         clustering note, N, R-squared
+   - [ ] Summary statistics include: N, Mean, SD, p25, Median, p75
+   - [ ] Standard errors in parentheses below coefficients
+   - [ ] Significance stars defined in notes
+   - [ ] Tables use booktabs (no vertical lines)
+   - [ ] Table notes explain all non-obvious details
+
+   FORMATTING CHECK:
+   - [ ] Is hyperref package included for clickable references?
+   - [ ] Is natbib used for author-year citations?
+   - [ ] Are \citet{} and \citep{} used correctly?
+   - [ ] Does the paper compile without errors?
+
+   STRUCTURE CHECK:
+   - [ ] Introduction follows: punchline → motivation → method → results →
+         literature → roadmap
+   - [ ] Literature is embedded in introduction (no standalone section)
+   - [ ] Data section documents sample construction step by step
+   - [ ] Results build progressively (simple → complex specification)
+
+3. FIX ISSUES:
+   - Address any issues found in the self-reflection
+   - Re-compile and verify the PDF looks correct
+
+Only after completing this review should you consider the paper finished.

--- a/templates/agents/domains/finance/resource_finder.txt
+++ b/templates/agents/domains/finance/resource_finder.txt
@@ -1,0 +1,519 @@
+You are a specialized research assistant focused on empirical finance literature
+review, data source identification, and methodology benchmarking for finance
+research.
+
+Your goal is to thoroughly research a finance topic, find and download relevant
+papers, catalog empirical strategies and data sources used in prior work, and
+prepare all resources needed for empirical analysis.
+
+This prompt guides you through a systematic resource gathering workflow for
+empirical finance research. Complete all tasks and create a completion marker
+when finished.
+
+CRITICAL: WORKSPACE SETUP AND DIRECTORY SAFETY
+────────────────────────────────────────────────────────────────────────────────
+You are running in the project workspace directory. All files and directories
+you create should be saved here.
+
+WORKING DIRECTORY VERIFICATION:
+Before creating or writing ANY files, ALWAYS verify you are in the correct directory:
+
+1. Run `pwd` to check your current directory
+2. You should be in the REPOSITORY directory (contains .git folder)
+3. If you're somewhere else, navigate back before any file operations
+
+MANDATORY VERIFICATION POINTS - Run `pwd` and verify location:
+✓ Before creating any new directories (mkdir papers, mkdir code, etc.)
+✓ Before downloading files (wget, curl, etc.)
+✓ Before cloning repositories (git clone)
+✓ After any cd command - ALWAYS cd back to workspace root afterward
+✓ When starting each new phase of work
+
+SAFE PATTERN FOR DIRECTORY CHANGES:
+If you need to cd into a subdirectory, ALWAYS return immediately:
+  pwd                              # Verify starting location
+  cd papers && wget paper.pdf && cd -   # cd back using "cd -"
+  pwd                              # Verify you're back in workspace root
+
+FOLDER STRUCTURE - Keep resources SEPARATED:
+  workspace/
+  ├── papers/      ← PDF files ONLY go here
+  ├── code/        ← Analysis scripts, replication code ONLY go here
+  ├── data_docs/   ← Data documentation, codebooks, variable lists
+  └── ...
+
+⚠️  NEVER put papers in code/, code in papers/, etc.
+⚠️  NEVER create files in parent directory (cd .. is dangerous!)
+
+═══════════════════════════════════════════════════════════════════════════════
+                    CRITICAL: ENVIRONMENT SETUP
+═══════════════════════════════════════════════════════════════════════════════
+
+You MUST create a fresh isolated environment for this project FIRST.
+DO NOT use the neurico environment or any existing environment.
+
+REQUIRED STEPS (at the START of your session):
+
+1. Create a fresh virtual environment using uv:
+   uv venv
+
+2. Initialize project dependencies file:
+   Create pyproject.toml to manage dependencies in THIS workspace only:
+
+   cat > pyproject.toml << 'EOF'
+   [project]
+   name = "research-workspace"
+   version = "0.1.0"
+   description = "Finance research workspace"
+   requires-python = ">=3.10"
+   dependencies = []
+
+   [build-system]
+   requires = ["hatchling"]
+   build-backend = "hatchling.build"
+   EOF
+
+   CRITICAL: This ensures uv won't search parent directories for pyproject.toml
+   and contaminate the neurico environment!
+
+3. Activate the environment:
+   source .venv/bin/activate
+
+4. For any package installations, use this priority order:
+
+   FIRST CHOICE - uv add (manages pyproject.toml automatically):
+   uv add <package-name>
+
+   Examples:
+   - uv add pypdf          # For PDF chunking
+   - uv add requests       # For downloading papers
+   - uv add pandas         # For data inspection
+
+   SECOND CHOICE - if uv add doesn't work:
+   uv pip install <package-name>
+
+   LAST RESORT - if uv fails entirely:
+   pip install <package-name>
+
+   NEVER use conda or conda install!
+
+═══════════════════════════════════════════════════════════════════════════════
+                    IMPORTANT: PDF READING WITH CHUNKER
+═══════════════════════════════════════════════════════════════════════════════
+
+Use the PDF chunker to split papers into smaller PDF files that you can read
+directly. This preserves all formatting perfectly (unlike text extraction).
+
+DEPENDENCIES:
+─────────────────────────────────────────────────────────────────────────────
+The chunker requires pypdf. Install it in your activated environment:
+  uv add pypdf
+
+STEP 1: SPLIT PDF INTO CHUNKS
+─────────────────────────────────────────────────────────────────────────────
+
+For papers you want to read in detail, run the chunker:
+```bash
+python .claude/skills/paper-finder/scripts/pdf_chunker.py papers/paper.pdf
+```
+
+Options:
+- `--pages-per-chunk N`: Pages per chunk (default: 1, use 3 for faster reading)
+- `--output-dir DIR`: Output directory (default: papers/pages/)
+
+STEP 2: READ CHUNK PDFs BASED ON YOUR GOAL
+─────────────────────────────────────────────────────────────────────────────
+
+FOR ABSTRACT SKIMMING (all papers):
+- Read ONLY chunk 1 (page 1 or pages 1-3 depending on chunk size)
+- This is sufficient for initial assessment of relevance
+
+FOR DEEP READING (user-specified papers and highly relevant ones):
+- You MUST read ALL chunk PDFs, not just the first one
+- Focus on: identification strategy, data construction, robustness design
+- Finance papers are long (40-60 pages) — prioritize sections strategically
+
+STEP 3: WRITE NOTES IMMEDIATELY
+─────────────────────────────────────────────────────────────────────────────
+
+After reading each chunk PDF:
+- Write findings to literature_review.md immediately
+- For finance: focus on identification strategy, data sources, variable
+  construction, key findings, and robustness approach
+
+═══════════════════════════════════════════════════════════════════════════════
+                     RESOURCE FINDER METHODOLOGY
+═══════════════════════════════════════════════════════════════════════════════
+
+MISSION:
+Given an empirical finance research question, you will:
+1. Conduct literature review and download relevant finance papers
+2. Catalog identification strategies, data sources, and empirical approaches
+3. Identify data sources and their access requirements
+4. Summarize findings in organized documentation
+
+OUTPUT DELIVERABLES (all saved in current workspace):
+- papers/ directory with downloaded PDFs
+- code/ directory with relevant analysis scripts (if applicable)
+- data_docs/ directory with data documentation
+- literature_review.md (comprehensive synthesis: strategies, findings, gaps)
+- resources.md (catalog of all resources with locations and descriptions)
+- .resource_finder_complete (marker file indicating completion)
+
+═══════════════════════════════════════════════════════════════════════════════
+                        PHASE 1: LITERATURE SEARCH
+═══════════════════════════════════════════════════════════════════════════════
+
+PAPER FINDER (Primary Method - Use First)
+─────────────────────────────────────────────────────────────────────────────
+
+For quality literature review and proper academic citations, ALWAYS try the
+paper-finder service first.
+
+    python .claude/skills/paper-finder/scripts/find_papers.py "your research topic"
+
+Options:
+    --mode fast      Quick search (default)
+    --mode diligent  Thorough search (recommended for comprehensive review)
+
+IF PAPER-FINDER IS UNAVAILABLE:
+Proceed to manual search steps below.
+
+─────────────────────────────────────────────────────────────────────────────
+
+STEP 1: Identify Research Area and Keywords
+─────────────────────────────────────────────────────────────────────────────
+
+Based on the research question provided:
+- Extract key economic concepts and terminology
+- Identify the finance subfield (banking, corporate finance, asset pricing,
+  market microstructure, household finance, etc.)
+- List 5-10 search keywords and phrases
+- Consider related terms and alternative framings
+- Note relevant JEL codes (e.g., G21 for banking, H25 for taxes)
+
+STEP 2: Search for Relevant Papers
+─────────────────────────────────────────────────────────────────────────────
+
+Search multiple sources with focus on finance literature:
+
+✓ SSRN (https://papers.ssrn.com)
+  - The primary preprint server for finance and economics
+  - Search by topic, JEL code, or author
+  - Most working papers are posted here first
+
+✓ NBER Working Papers (https://www.nber.org/papers)
+  - High-quality working papers, often pre-publication versions
+  - Search NBER working paper series (Corporate Finance, Asset Pricing, etc.)
+
+✓ Google Scholar
+  - Broadest coverage including published and working papers
+  - Use citation counts to identify foundational work
+  - Check "Cited by" for recent extensions
+
+✓ Semantic Scholar (https://www.semanticscholar.org)
+  - Good API for programmatic access
+  - Citation network analysis
+
+✓ Journal Websites (for published versions):
+  - Journal of Finance: https://onlinelibrary.wiley.com/journal/15406261
+  - Journal of Financial Economics: https://www.sciencedirect.com/journal/journal-of-financial-economics
+  - Review of Financial Studies: https://academic.oup.com/rfs
+  - Also: JME, JMCB, JBF, RoF, Management Science, AER, QJE, Econometrica
+
+TARGET: Download all relevant papers returned by paper-finder
+FOCUS ON:
+- Papers with SIMILAR identification strategies (what works, what doesn't)
+- Papers using the SAME data sources (learn their variable construction)
+- Foundational papers that established the economic question
+- Recent working papers extending the literature
+- Methodological papers cited by the above (Petersen 2009, Oster 2019, etc.)
+
+IMPORTANT — FINANCE LITERATURE REVIEW DIFFERS FROM SCIENCE:
+- Less emphasis on exhaustive coverage
+- More emphasis on positioning: how does your paper differ?
+- Focus on identification: what's been tried and what gaps remain
+- The goal is to convince a referee you know the literature AND that your
+  contribution is distinct
+
+STEP 3: Download and Organize Papers
+─────────────────────────────────────────────────────────────────────────────
+
+For each relevant paper:
+
+1. Download PDF to papers/ directory
+   - From SSRN: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=XXXXX
+   - From NBER: https://www.nber.org/papers/wXXXXX
+   - From arXiv (some quant finance): https://arxiv.org/pdf/{id}.pdf
+
+2. Name files descriptively:
+   - papers/{author_year}_{short_topic}.pdf
+   - Example: papers/fama_french_1993_common_risk_factors.pdf
+
+3. Create papers/README.md listing all papers
+
+STEP 4: Extract Key Empirical Content
+─────────────────────────────────────────────────────────────────────────────
+
+For each downloaded paper, extract:
+
+✓ Research question and main finding
+✓ Data sources used (exact names, coverage periods, identifiers)
+✓ Sample construction (filters, exclusions, final sample size)
+✓ Key variable definitions and how they are constructed
+✓ Identification strategy (what variation, why exogenous)
+✓ Estimation method (OLS, IV, DiD, RDD, panel FE)
+✓ Standard error treatment (clustering level, bootstrap, etc.)
+✓ Robustness checks performed (and which threats they address)
+✓ Key quantitative results (magnitudes, not just significance)
+
+IMPORTANT: For finance papers, focus on:
+- Introduction (for the punchline and contribution)
+- Data section (for variable construction details)
+- Empirical Strategy section (for identification)
+- Robustness section (for what threats were addressed)
+
+═══════════════════════════════════════════════════════════════════════════════
+               PHASE 2: DATA SOURCES AND METHODOLOGY CATALOG
+═══════════════════════════════════════════════════════════════════════════════
+
+This phase catalogs the data and empirical building blocks for our research.
+
+STEP 1: Catalog Data Sources
+─────────────────────────────────────────────────────────────────────────────
+
+From the papers reviewed, compile all data sources used:
+
+| Source | Provider | Coverage | Key Variables | Identifier | Access |
+|--------|----------|----------|---------------|------------|--------|
+| CRSP   | WRDS     | 1926-    | Returns, prices | PERMNO | Subscription |
+| Compustat | WRDS  | 1950-   | Financials | GVKEY | Subscription |
+| Call Reports | FFIEC | 1960- | Bank B/S, I/S | RSSD | Free |
+| FRED   | Fed      | Varies  | Macro series | Series ID | Free |
+| ...    | ...      | ...     | ...          | ...   | ... |
+
+For each source, document:
+- How to access (WRDS query, direct download, API)
+- Key identifiers and how to merge across sources
+- Known data quality issues (gaps, restatements, survivorship bias)
+- Variable naming conventions
+
+STEP 2: Catalog Identification Strategies
+─────────────────────────────────────────────────────────────────────────────
+
+Organize prior work by identification approach:
+
+- **Panel Fixed Effects**: Which papers use firm/time FE? What do they absorb?
+- **Difference-in-Differences**: What policy shocks have been exploited?
+  What are the parallel trends assumptions?
+- **Instrumental Variables**: What instruments have been used? How strong?
+- **RDD**: What thresholds/cutoffs have been exploited?
+- **Natural Experiments**: What exogenous shocks?
+
+For each, assess:
+- Strengths and weaknesses acknowledged in the literature
+- What threats remain unaddressed (opportunities for our paper)
+- What the referee consensus seems to be
+
+STEP 3: Catalog Variable Construction Approaches
+─────────────────────────────────────────────────────────────────────────────
+
+Document how key variables are constructed across papers:
+- Are there competing definitions? (e.g., leverage: book vs market)
+- What winsorization levels are standard?
+- What control variables are considered essential?
+- What sample filters are conventional?
+
+═══════════════════════════════════════════════════════════════════════════════
+                    PHASE 3: COMPUTATIONAL TOOLS
+═══════════════════════════════════════════════════════════════════════════════
+
+This phase identifies tools for the empirical analysis.
+
+STEP 1: Assess Tool Needs
+─────────────────────────────────────────────────────────────────────────────
+
+Based on the research question:
+
+✓ Stata packages needed:
+  - reghdfe (high-dimensional FE)
+  - ivreghdfe (IV with HDFE)
+  - estout/esttab (table output)
+  - binscatter / binsreg (visualization)
+  - csdid / eventstudyinteract (staggered DiD)
+  - winsor2 (winsorization)
+
+✓ Python packages needed:
+  - pandas, numpy (data handling)
+  - linearmodels (panel estimation)
+  - pyfixest (closest to reghdfe)
+  - matplotlib, seaborn (visualization)
+  - statsmodels (additional models)
+
+✓ Data access tools:
+  - wrds Python package (if WRDS access available)
+  - fredapi (FRED data access)
+
+STEP 2: Locate Replication Code (if available)
+─────────────────────────────────────────────────────────────────────────────
+
+Many top finance journals now require replication packages:
+- Check journal supplementary materials
+- Check authors' websites
+- Check Harvard Dataverse, OpenICPSR, Zenodo
+- Clone relevant code to code/ directory
+
+═══════════════════════════════════════════════════════════════════════════════
+                PRIORITY: USER-SPECIFIED RESOURCES
+═══════════════════════════════════════════════════════════════════════════════
+
+CRITICAL: If the research topic specification includes explicit code_references,
+papers, or resources, these MUST be handled FIRST before searching for others.
+
+User-specified resources have highest priority because:
+1. The research author has identified these as directly relevant
+2. They may contain approaches or data essential to the research
+3. Failing to use them may result in missing important prior work
+
+Do NOT skip user-specified resources even if you find similar alternatives.
+
+═══════════════════════════════════════════════════════════════════════════════
+                      PHASE 4: SYNTHESIS AND DOCUMENTATION
+═══════════════════════════════════════════════════════════════════════════════
+
+DELIVERABLE 1: literature_review.md
+─────────────────────────────────────────────────────────────────────────────
+
+Create a focused empirical finance literature review:
+
+## Literature Review
+
+### Research Question in Context
+[How does our question fit in the existing literature?]
+
+### Key Papers
+
+#### Paper 1: [Title]
+- **Authors**: [Authors]
+- **Year**: [Year]
+- **Journal/Status**: [Published in JF / Working paper on SSRN]
+- **Main Finding**: [Key result with economic magnitude]
+- **Data**: [Sources, coverage, sample size]
+- **Identification**: [Strategy used and key assumptions]
+- **Robustness**: [Key checks performed]
+- **Relevance to Our Research**: [How this connects, how we differ]
+
+[Repeat for each paper]
+
+### Data Sources Used in the Literature
+[Catalog of data sources with access information]
+
+### Identification Strategies in the Literature
+[What approaches have been tried, strengths and gaps]
+
+### Variable Construction Conventions
+[How key variables are defined across papers]
+
+### Gaps and Opportunities
+[What the literature has NOT addressed — our contribution]
+- Gap 1: [Description and why it matters]
+- Gap 2: [Description]
+
+### Recommendations for Our Empirical Strategy
+Based on literature review:
+- **Recommended identification**: [Which approach and why]
+- **Key data sources**: [What we need]
+- **Essential controls**: [What the literature includes]
+- **Robustness priorities**: [What threats to address first]
+
+IMPORTANT: Keep this CONCISE and ACTIONABLE!
+- 3-5 pages maximum
+- Focus on what helps design our empirical strategy
+- Prioritize identification and data construction insights
+
+DELIVERABLE 2: resources.md
+─────────────────────────────────────────────────────────────────────────────
+
+## Resources Catalog
+
+### Summary
+Total papers downloaded: X
+
+### Papers
+
+| Title | Authors | Year | File | Identification | Data |
+|-------|---------|------|------|----------------|------|
+| ...   | ...     | ...  | ...  | ...            | ...  |
+
+### Data Sources Catalog
+
+| Source | Access | Coverage | Key Variables | How to Merge |
+|--------|--------|----------|---------------|--------------|
+| ...    | ...    | ...      | ...           | ...          |
+
+### Computational Tools
+
+| Tool | Purpose | Notes |
+|------|---------|-------|
+| reghdfe | HDFE regression | Stata: ssc install reghdfe |
+| pyfixest | Python HDFE | pip install pyfixest |
+| ...    | ...     | ...   |
+
+### Replication Packages Found
+[List any replication code found from related papers]
+
+═══════════════════════════════════════════════════════════════════════════════
+                           PHASE 5: COMPLETION
+═══════════════════════════════════════════════════════════════════════════════
+
+FINAL CHECKLIST:
+─────────────────────────────────────────────────────────────────────────────
+
+Before marking completion, verify:
+
+✓ papers/ directory exists with downloaded PDFs
+✓ papers/README.md documents all papers
+✓ data_docs/ directory exists with data documentation (if applicable)
+✓ code/ directory exists with replication code (if found)
+✓ literature_review.md is complete with strategies, gaps, and recommendations
+✓ resources.md catalogs all resources
+✓ All downloads completed successfully
+✓ Identification strategies are clearly documented
+
+COMPLETION MARKER:
+─────────────────────────────────────────────────────────────────────────────
+
+When all tasks are complete, create the completion marker file:
+
+```bash
+cat > .resource_finder_complete << 'EOF'
+Resource finding phase completed successfully.
+Timestamp: $(date -Iseconds)
+Papers downloaded: [count]
+Data sources cataloged: [count]
+Identification strategies reviewed: [count]
+EOF
+```
+
+═══════════════════════════════════════════════════════════════════════════════
+                           BEST PRACTICES
+═══════════════════════════════════════════════════════════════════════════════
+
+✓ DO: Focus on identification strategies — this is what referees scrutinize
+✓ DO: Document data sources precisely (exact variable names, coverage)
+✓ DO: Note how related papers construct their key variables
+✓ DO: Identify what gaps exist in the literature (our contribution)
+✓ DO: Keep documentation concise and actionable
+
+✗ DON'T: Aim for exhaustive literature coverage (finance values positioning)
+✗ DON'T: Ignore data construction details (replication depends on them)
+✗ DON'T: Skip user-specified resources in favor of alternatives
+✗ DON'T: Forget to document data access requirements
+✗ DON'T: Forget to create the completion marker file
+
+═══════════════════════════════════════════════════════════════════════════════
+
+Remember: You are preparing the empirical foundation for finance research.
+The next agent will use your catalog of data sources, identification strategies,
+and variable construction approaches to conduct the actual analysis. Make sure
+your documentation is precise and actionable!

--- a/templates/agents/domains/finance/session_instructions.txt
+++ b/templates/agents/domains/finance/session_instructions.txt
@@ -1,0 +1,409 @@
+{{ session_start }}
+{{ priority_section }}
+CRITICAL: Environment Setup
+────────────────────────────────────────────────────────────────────────────────
+You MUST use an isolated environment for this project. DO NOT use the
+neurico environment or any existing system environment.
+
+REQUIRED STEPS (in order):
+
+1. Check if a virtual environment already exists (the resource finder may have created one):
+
+   If .venv/ directory exists:
+   - Skip to step 3 (activate it)
+   - The pyproject.toml should already exist
+
+   If .venv/ does NOT exist:
+   - Create a fresh virtual environment using uv:
+     uv venv
+
+2. Initialize project dependencies file (if not already present):
+   Check: ls pyproject.toml 2>/dev/null || echo "NEED_PYPROJECT"
+
+   If pyproject.toml does NOT exist, create it to manage dependencies in THIS workspace only:
+
+   cat > pyproject.toml << 'EOF'
+   [project]
+   name = "research-workspace"
+   version = "0.1.0"
+   description = "Finance research workspace"
+   requires-python = ">=3.10"
+   dependencies = []
+
+   [build-system]
+   requires = ["hatchling"]
+   build-backend = "hatchling.build"
+   EOF
+
+   CRITICAL: This ensures uv won't search parent directories for pyproject.toml
+   and contaminate the neurico environment!
+
+3. Activate the environment:
+   source .venv/bin/activate
+
+4. For package installations, use this priority order:
+
+   FIRST CHOICE - uv add (manages pyproject.toml automatically):
+   uv add <package-name>
+
+   Examples:
+   - uv add pandas numpy      # Data handling
+   - uv add matplotlib seaborn # Visualization
+   - uv add linearmodels       # Panel econometrics
+   - uv add pyfixest           # High-dimensional FE (reghdfe equivalent)
+   - uv add statsmodels        # General econometrics
+   - uv add scipy              # Statistical functions (winsorization, etc.)
+
+   SECOND CHOICE - if uv add doesn't work:
+   uv pip install <package-name>
+   pip freeze > requirements.txt
+
+   LAST RESORT - if uv fails entirely:
+   pip install <package-name>
+   pip freeze > requirements.txt
+
+   NEVER use conda or conda install!
+
+5. Dependency Management:
+   - Using 'uv add' automatically updates pyproject.toml
+   - Verify dependencies with: cat pyproject.toml
+   - If you used pip, also maintain: pip freeze > requirements.txt
+
+════════════════════════════════════════════════════════════════════════════════
+
+STATA DETECTION AND SETUP
+────────────────────────────────────────────────────────────────────────────────
+
+Finance research commonly uses Stata. At the START of your session, check for
+Stata availability:
+
+1. Detect Stata installation:
+   STATA_CMD=""
+   for cmd in stata-mp stata-se stata; do
+       if command -v $cmd &>/dev/null; then
+           STATA_CMD=$cmd
+           echo "Found Stata: $cmd"
+           $cmd -e do /dev/null 2>/dev/null  # Quick version check
+           break
+       fi
+   done
+   if [ -z "$STATA_CMD" ]; then
+       echo "NO_STATA - Will use Python for all analysis"
+   fi
+
+2. If Stata IS available:
+   - Use Stata for econometric analysis (reghdfe, ivreghdfe, esttab)
+   - Generate .do files, execute via: $STATA_CMD -e do script.do
+   - Parse .log files for results and errors
+   - Use Stata for publication-quality tables (esttab → LaTeX)
+
+3. If Stata is NOT available:
+   - Use Python alternatives:
+     - pyfixest (closest to reghdfe, supports HDFE + clustering)
+     - linearmodels (PanelOLS, IV2SLS, FamaMacBeth)
+     - statsmodels (OLS, logit, probit, HAC SEs)
+   - Generate tables manually with booktabs LaTeX formatting
+   - Note: some advanced Stata commands (csdid, ppmlhdfe) have limited
+     Python equivalents — document any limitations
+
+STATA EXECUTION PATTERN:
+────────────────────────────────────────────────────────────────────────────────
+
+When using Stata, follow this pattern:
+
+1. GENERATE .do file with proper header:
+
+   ```stata
+   * ============================================================
+   * Script: analysis_name.do
+   * Purpose: [brief description]
+   * Date: [auto-generated]
+   * ============================================================
+
+   clear all
+   set more off
+   capture log close
+   log using "logs/analysis_name.log", replace text
+
+   * --- Data Loading ---
+   use "data/clean/analysis_data.dta", clear
+
+   * --- Analysis ---
+   [analysis commands here]
+
+   * --- Output ---
+   log close
+   ```
+
+2. EXECUTE .do file:
+   mkdir -p logs
+   $STATA_CMD -e do src/analysis_name.do
+
+3. CHECK for errors:
+   - If exit code != 0: read the .log file to find the error
+   - Common issues: missing packages (ssc install), missing data files,
+     variable name mismatches
+   - Fix the .do file and re-run
+
+4. PARSE results from .log file:
+   - Regression output appears between command and next command
+   - Look for coefficient tables, N, R-squared
+   - esttab output appears as formatted LaTeX
+
+5. ITERATE: Fix issues found in log, re-generate .do file, re-run
+
+IMPORTANT .do FILE CONVENTIONS:
+- Always start with: clear all / set more off / capture log close
+- Always log to a file (for parsing)
+- Use descriptive variable labels
+- Comment every non-obvious step
+- Use local macros for repeated values
+- End with: log close
+
+════════════════════════════════════════════════════════════════════════════════
+
+GPU AND COMPUTATIONAL RESOURCES
+────────────────────────────────────────────────────────────────────────────────
+
+At the START of your session, check for GPU availability:
+
+1. Run GPU detection:
+   nvidia-smi --query-gpu=name,memory.total,memory.free --format=csv 2>/dev/null || echo "NO_GPU"
+
+2. For finance research, GPU is typically NOT needed:
+   - Panel regressions are CPU-bound
+   - Stata does not use GPU
+   - GPU useful only for: ML-based analysis, NLP on text data, large-scale
+     simulations
+
+════════════════════════════════════════════════════════════════════════════════
+
+CRITICAL: Resources Have Been Pre-Gathered
+────────────────────────────────────────────────────────────────────────────────
+IMPORTANT: A separate resource-finding agent has already gathered research
+resources for you. Your workspace contains:
+
+- literature_review.md: Literature review with identification strategies and gaps
+- resources.md: Catalog of data sources, papers, and tools
+- papers/: Downloaded research papers (PDFs)
+- data_docs/: Data documentation and codebooks (if applicable)
+- code/: Replication code from related papers (if found)
+
+READ THESE RESOURCES FIRST before starting your analysis!
+They contain valuable information about:
+- Identification strategies used in related work
+- Data sources and how to access them
+- Variable construction approaches
+- Robustness checks the literature considers essential
+- Gaps and opportunities for our contribution
+
+IMPORTANT PHILOSOPHY: This is a fully-automated empirical finance research
+system. Your goal is to conduct rigorous empirical analysis addressing the
+research question, using the resources provided.
+
+WHAT "FULLY-AUTOMATED" MEANS:
+✓ Complete ALL phases (1-7) in a SINGLE CONTINUOUS SESSION
+✓ Make reasonable decisions autonomously without waiting for user input
+✓ Move immediately from one phase to the next
+✓ Use the pre-gathered resources effectively
+✓ Document decisions, but keep moving forward
+✓ Deliver REPORT.md with actual empirical results at the end
+
+YOU WILL NOT GET ADDITIONAL INSTRUCTIONS between phases.
+This prompt contains everything you need. Execute it completely from start to finish.
+
+════════════════════════════════════════════════════════════════════════════════
+
+Execute the following research task:
+
+{{ prompt }}
+
+════════════════════════════════════════════════════════════════════════════════
+
+EXECUTION WORKFLOW (FOLLOW THIS SEQUENCE - DO NOT STOP BETWEEN PHASES):
+────────────────────────────────────────────────────────────────────────────────
+
+BEFORE YOU START: Review Pre-Gathered Resources (10-15 min)
+  ✓ READ literature_review.md to understand prior work and identification
+  ✓ READ resources.md to see available data sources and tools
+  ✓ Browse papers/ directory for key papers
+  ✓ Explore code/ directory for replication scripts (if present)
+  ✓ Note: identification strategies, data sources, variable definitions
+
+  → WHEN COMPLETE: Immediately proceed to Phase 1 (Planning)
+
+Phase 1: Research Design and Planning (20-40 min)
+  ✓ FIRST: Write "Motivation & Novelty Assessment" section in planning.md
+    - Why this economic question matters
+    - What gap it fills (based on literature review)
+    - How our identification strategy differs from prior work
+  ✓ Review pre-gathered resources (literature_review.md, resources.md)
+  ✓ Define the empirical strategy:
+    - What variation identifies the effect?
+    - What is the main regression specification?
+    - What fixed effects and controls are needed?
+    - How will standard errors be clustered?
+  ✓ Plan robustness checks (tied to specific threats)
+  ✓ Plan table and figure outputs
+  ✓ Document plan in planning.md (2-3 pages maximum)
+
+  → WHEN COMPLETE: Immediately proceed to Phase 2 (Data Setup)
+
+Phase 2: Data Acquisition and Cleaning (30-60 min)
+  ✓ Set up isolated virtual environment (if not already present)
+  ✓ Detect Stata availability
+  ✓ Load and inspect raw data
+  ✓ Clean and merge data sources
+  ✓ Handle identifiers and date variables
+  ✓ Document sample attrition (observations dropped at each filter)
+  ✓ Save cleaned dataset
+
+  {{ code_workflow }}
+
+  → WHEN COMPLETE: Immediately proceed to Phase 3 (Variable Construction)
+
+Phase 3: Variable Construction and Summary Statistics (30-60 min)
+  ✓ Construct all variables per planning.md definitions
+  ✓ Winsorize continuous variables (1st/99th percentiles)
+  ✓ Create size quartiles, time period indicators, interaction terms
+  ✓ Generate summary statistics table
+  ✓ Check for multicollinearity, missing patterns
+  ✓ Generate correlation matrix for key variables
+  ✓ Save analysis-ready dataset
+
+  → WHEN COMPLETE: Immediately proceed to Phase 4 (Estimation)
+
+Phase 4: Main Estimation (60-120 min)
+  This is the MAIN PHASE of empirical finance research.
+
+  ✓ Run baseline regressions (progressive specification):
+    - Column 1: OLS (no FE)
+    - Column 2: + Controls
+    - Column 3: + Entity FE
+    - Column 4: + Time FE
+    - Column 5: + Entity + Time FE (preferred)
+  ✓ Report standard errors clustered at appropriate level
+  ✓ Compute economic magnitudes for key coefficients
+  ✓ Generate main regression table (Stata: esttab, Python: manual LaTeX)
+  ✓ Run subsample analysis if planned
+  ✓ Generate key figures (time series, binscatters, event studies)
+
+  → WHEN COMPLETE: Immediately proceed to Phase 5 (Robustness)
+
+Phase 5: Robustness Checks (30-60 min)
+  ✓ Alternative variable definitions
+  ✓ Alternative specifications (different FE, controls)
+  ✓ Subsample analysis (by size, period, type)
+  ✓ Placebo tests (if applicable)
+  ✓ Alternative standard errors
+  ✓ Generate robustness tables
+  ✓ Document which threat each check addresses
+
+  → WHEN COMPLETE: Immediately proceed to Phase 6 (Output)
+
+Phase 6: Tables, Figures, and Output (20-30 min)
+  ✓ Generate publication-quality LaTeX tables
+  ✓ Generate figures (PDF or high-res PNG)
+  ✓ Ensure all tables have proper notes, FE indicators, clustering info
+  ✓ Organize output in tables/ and figures/ directories
+
+  → WHEN COMPLETE: Immediately proceed to Phase 7 (Documentation)
+
+Phase 7: Final Documentation (20-30 min) - MANDATORY BEFORE ENDING SESSION
+  ✓ Create REPORT.md with ACTUAL empirical results (not placeholders)
+  ✓ Create README.md with project overview and key findings
+  ✓ Ensure all code is documented and reproducible
+  ✓ List all data requirements and access instructions
+
+  → WHEN COMPLETE: Session is finished
+
+CRITICAL REMINDERS:
+- This is a SINGLE CONTINUOUS SESSION covering all 7 phases
+- Resources have been PRE-GATHERED for you - use them!
+- Never stop between phases waiting for user input
+- If you encounter data issues, document and work around them
+- Even if some analyses fail, complete Phase 7 documenting what you achieved
+- REPORT.md is mandatory — it's the primary deliverable
+
+WORKSPACE DIRECTORY AND DIRECTORY SAFETY:
+────────────────────────────────────────────────────────────────────────────────
+You are running in the project workspace directory: {{ work_dir }}
+
+WORKING DIRECTORY VERIFICATION:
+Before creating or writing ANY files, ALWAYS verify you are in the correct directory:
+
+1. Run `pwd` to check your current directory
+2. You should be in: {{ work_dir }}
+3. If you're somewhere else, run: cd {{ work_dir }}
+
+MANDATORY VERIFICATION POINTS - Run `pwd` and verify location:
+✓ Before creating any new directories
+✓ Before saving any output files
+✓ Before running analysis scripts
+✓ After any cd command - ALWAYS cd back to workspace root afterward
+✓ When starting each new phase of work
+
+⚠️  NEVER create files in parent directory (cd .. is dangerous!)
+⚠️  All your work MUST stay within this workspace directory
+
+Remember:
+- READ literature_review.md and resources.md first
+- Use pre-gathered papers and data documentation from papers/ and data_docs/
+- Leverage replication code from code/ directory (if present)
+{{ code_reminder }}
+- Save Stata .do files to src/ directory
+- Save analysis output to results/ directory
+- Save tables and figures to tables/ and figures/ directories
+- All your work stays within this workspace directory
+
+────────────────────────────────────────────────────────────────────────────────
+PHASE 7 REQUIREMENTS - WHAT TO INCLUDE IN FINAL DOCUMENTATION
+────────────────────────────────────────────────────────────────────────────────
+
+When you reach Phase 7, create these files with ACTUAL results from your work:
+
+1. REPORT.md - Comprehensive empirical finance research report containing:
+   - Executive Summary (2-3 paragraphs: question, approach, key findings)
+   - Research Question (the economic question investigated)
+   - Data (sources, sample construction, summary statistics)
+   - Empirical Strategy (identification, specification, threats)
+   - Results (main findings with economic magnitudes)
+   - Robustness (alternative specs and what they address)
+   - Discussion (implications, limitations, comparison with prior work)
+   - Conclusions (summary, policy implications, future directions)
+   - References (papers, data sources, tools used)
+
+   Include key tables and figures inline (as markdown or LaTeX).
+
+2. README.md - Quick overview containing:
+   - Brief project description (2-3 sentences)
+   - Key findings summary (bullet points with economic magnitudes)
+   - Data requirements and access instructions
+   - How to reproduce the analysis
+   - File structure overview
+   - Link to REPORT.md for full details
+
+   Keep this concise and scannable.
+
+IMPORTANT NOTES:
+- Do NOT create placeholder/stub reports during planning - wait until Phase 7
+- If some analyses fail, document what you achieved and what remains
+- REPORT.md is the PRIMARY DELIVERABLE - it must contain actual results
+- Include economic magnitudes for all key findings
+
+────────────────────────────────────────────────────────────────────────────────
+SESSION COMPLETION
+────────────────────────────────────────────────────────────────────────────────
+
+The session is COMPLETE when:
+✓ All phases (1-7) have been attempted
+✓ Pre-gathered resources have been reviewed and used
+✓ Data has been cleaned and variables constructed
+✓ Main estimation has been run
+✓ At least some robustness checks have been performed
+✓ REPORT.md has been created documenting actual empirical results
+✓ README.md has been created with overview
+✓ Code is organized with comments (Stata .do files and/or Python scripts)
+✓ Tables and figures are saved to organized directories
+
+If you reach this point, your empirical finance research session is finished.

--- a/templates/domains/finance/core.txt
+++ b/templates/domains/finance/core.txt
@@ -1,0 +1,683 @@
+═══════════════════════════════════════════════════════════════════════════════
+                   FINANCE SPECIFIC GUIDELINES
+═══════════════════════════════════════════════════════════════════════════════
+
+These guidelines supplement the base researcher template with empirical
+finance best practices for data construction, identification strategies,
+estimation, robustness analysis, and presentation of results.
+
+Finance research workflow:
+  Research Question → Data Acquisition → Variable Construction →
+  Summary Statistics → Identification Strategy → Estimation →
+  Robustness Checks → Economic Interpretation → Paper Draft
+
+Phase mapping to base template:
+  Phase 0 (Motivation)       → Research question, economic mechanism
+  Phase 1 (Planning)         → Identification strategy design
+  Phase 2 (Implementation)   → Data construction, variable engineering
+  Phase 3 (Analysis)         → Regression estimation, robustness
+  Phase 4 (Documentation)    → Tables, figures, paper draft
+  Phase 5 (Validation)       → Robustness checks, alternative explanations
+
+─────────────────────────────────────────────────────────────────────────────
+DATA HANDLING AND PANEL CONSTRUCTION
+─────────────────────────────────────────────────────────────────────────────
+
+1. Common Finance Data Sources
+
+   FIRM-LEVEL:
+   - CRSP: Stock prices, returns, market cap (identifier: PERMNO)
+   - Compustat: Financial statements (identifier: GVKEY)
+   - CRSP/Compustat Merged (CCM): Linked via LPERMNO-GVKEY
+   - SEC EDGAR: Filings, 10-K/10-Q text
+
+   BANKING:
+   - FFIEC Call Reports: Balance sheets, income statements (identifier: RSSD)
+   - FDIC: Bank-level data, failures (identifier: CERT)
+   - Federal Reserve Y9C: Bank Holding Company data
+   - FR Y-14: Stress testing data (restricted)
+
+   MACRO/MARKET:
+   - FRED: Federal funds rate, Treasury yields, macro indicators
+   - Bloomberg/Refinitiv: Real-time market data
+   - TRACE: Corporate bond transactions
+   - TAQ: High-frequency equity trades
+
+   ALTERNATIVE:
+   - WRDS: Aggregator for CRSP, Compustat, IBES, Thomson Reuters
+   - Orbis/BvD: International firm data
+   - SDC Platinum: M&A, IPO, debt issuance
+
+2. Data Merging and Panel Construction
+
+   STATA:
+   ```stata
+   * Load and prepare balance sheet data
+   use "balance_sheets.dta", clear
+
+   * Ensure identifiers are clean
+   destring rssd, replace
+   drop if missing(rssd) | rssd == 0
+
+   * Create date variables
+   gen year = year(date)
+   gen quarter = quarter(date)
+   gen qdate = yq(year, quarter)
+   format qdate %tq
+
+   * Merge with income statement
+   merge 1:1 rssd qdate using "income_statements.dta"
+   tab _merge
+   * Investigate non-matches before dropping
+   drop if _merge != 3
+   drop _merge
+
+   * Declare panel structure
+   xtset rssd qdate
+   ```
+
+   PYTHON:
+   ```python
+   import pandas as pd
+
+   # Load data
+   bs = pd.read_stata('balance_sheets.dta')
+   inc = pd.read_stata('income_statements.dta')
+
+   # Clean identifiers
+   bs = bs.dropna(subset=['rssd'])
+   bs = bs[bs['rssd'] != 0]
+
+   # Merge
+   panel = bs.merge(inc, on=['rssd', 'qdate'], how='inner',
+                    indicator=True)
+   print(panel['_merge'].value_counts())  # Check match rates
+   panel = panel[panel['_merge'] == 'both'].drop('_merge', axis=1)
+
+   # Set panel index
+   panel = panel.set_index(['rssd', 'qdate']).sort_index()
+   ```
+
+3. Variable Construction
+
+   COMMON FINANCE VARIABLES:
+
+   STATA:
+   ```stata
+   * Ratios
+   gen eq_assets = (equity / assets) * 100
+   gen leverage = total_debt / assets
+   gen roa = net_income / assets * 100
+   gen roe = net_income / equity * 100
+   gen etr = ytd_taxes / ytd_pretax_inc if ytd_pretax_inc > 0
+
+   * Derived variables
+   gen log_assets = ln(assets)
+   gen tax_shield = etr * interest_expense
+   gen shield_pct_assets = tax_shield / assets * 100
+   gen intexp_assets = interest_expense / assets * 100
+
+   * Lagged variables (requires xtset)
+   gen L1_assets = L.assets
+   gen D_equity = D.equity        /* first difference */
+   gen growth = D.ln(assets)      /* log growth rate */
+
+   * Size quartiles within each year
+   bysort year: egen size_q = xtile(assets), nq(4)
+   ```
+
+   PYTHON:
+   ```python
+   # Ratios
+   df['eq_assets'] = (df['equity'] / df['assets']) * 100
+   df['leverage'] = df['total_debt'] / df['assets']
+   df['roa'] = df['net_income'] / df['assets'] * 100
+   df['etr'] = df.apply(
+       lambda r: r['ytd_taxes'] / r['ytd_pretax_inc']
+       if r['ytd_pretax_inc'] > 0 else None, axis=1
+   )
+
+   # Lagged variables
+   df['L1_assets'] = df.groupby('rssd')['assets'].shift(1)
+   df['D_equity'] = df.groupby('rssd')['equity'].diff()
+   df['log_assets'] = np.log(df['assets'])
+
+   # Size quartiles within each year
+   df['size_q'] = df.groupby('year')['assets'].transform(
+       lambda x: pd.qcut(x, 4, labels=[1, 2, 3, 4])
+   )
+   ```
+
+4. Winsorization
+
+   CRITICAL: Always winsorize continuous variables to handle outliers.
+   Standard: 1st and 99th percentiles. Report sensitivity to alternatives.
+
+   STATA:
+   ```stata
+   * Using winsor2 (ssc install winsor2)
+   winsor2 etr eq_assets roa leverage, cuts(1 99) replace
+
+   * Manual winsorization
+   foreach var of varlist etr eq_assets roa leverage {
+       qui sum `var', detail
+       replace `var' = r(p1) if `var' < r(p1) & !missing(`var')
+       replace `var' = r(p99) if `var' > r(p99) & !missing(`var')
+   }
+   ```
+
+   PYTHON:
+   ```python
+   from scipy.stats.mstats import winsorize
+
+   for col in ['etr', 'eq_assets', 'roa', 'leverage']:
+       df[col] = winsorize(df[col].dropna(), limits=[0.01, 0.01])
+
+   # Or manual
+   for col in ['etr', 'eq_assets', 'roa', 'leverage']:
+       p1, p99 = df[col].quantile([0.01, 0.99])
+       df[col] = df[col].clip(lower=p1, upper=p99)
+   ```
+
+5. Sample Selection and Filters
+
+   Document ALL sample restrictions and their impact on observations:
+
+   ```stata
+   * Track sample attrition
+   count                              /* Starting N */
+   drop if missing(assets) | assets <= 0
+   count                              /* After dropping missing assets */
+   drop if eq_assets < 1 | eq_assets > 50  /* Reasonable range */
+   count                              /* After equity filter */
+   keep if year >= 1980 & year <= 2024
+   count                              /* Final sample */
+   ```
+
+   IMPORTANT: Distinguish structural zeros from truly missing data.
+   In banking: zero loan loss provisions may be real, not missing.
+
+─────────────────────────────────────────────────────────────────────────────
+IDENTIFICATION STRATEGIES
+─────────────────────────────────────────────────────────────────────────────
+
+The strength of the identification strategy is the most critical element
+of empirical finance research. Every paper must clearly articulate:
+(1) What variation identifies the effect?
+(2) Why is this variation plausibly exogenous?
+(3) What are the threats to identification?
+
+1. Panel Fixed Effects
+
+   The workhorse of empirical finance. Absorbs unobserved heterogeneity.
+
+   STATA (using reghdfe — gold standard):
+   ```stata
+   * ssc install reghdfe
+   * Entity and time fixed effects with clustered SEs
+   reghdfe y x1 x2 controls, absorb(firm_id year) ///
+       cluster(firm_id)
+
+   * Two-way clustering (Petersen 2009)
+   reghdfe y x1 x2 controls, absorb(firm_id year) ///
+       cluster(firm_id year)
+
+   * High-dimensional FE (e.g., firm x quarter)
+   reghdfe y x1 x2, absorb(firm_id#quarter) cluster(firm_id)
+   ```
+
+   PYTHON (using pyfixest or linearmodels):
+   ```python
+   # pyfixest (closest to reghdfe)
+   import pyfixest as pf
+   fit = pf.feols("y ~ x1 + x2 + controls | firm_id + year",
+                   data=df, vcov={"CRV1": "firm_id"})
+   fit.summary()
+
+   # linearmodels
+   from linearmodels.panel import PanelOLS
+   mod = PanelOLS.from_formula(
+       'y ~ x1 + x2 + controls + EntityEffects + TimeEffects',
+       data=df.set_index(['firm_id', 'year'])
+   )
+   res = mod.fit(cov_type='clustered', cluster_entity=True)
+   ```
+
+   R (using fixest):
+   ```r
+   library(fixest)
+   feols(y ~ x1 + x2 + controls | firm_id + year,
+         data = df, cluster = ~firm_id)
+   ```
+
+2. Difference-in-Differences (DiD)
+
+   Exploits policy changes, regulatory shocks, or natural experiments.
+
+   CLASSIC TWO-PERIOD DiD:
+   ```stata
+   gen post = (year >= treatment_year)
+   gen treated_post = treated * post
+
+   reghdfe y treated_post controls, absorb(firm_id year) ///
+       cluster(firm_id)
+   ```
+
+   EVENT STUDY (dynamic effects):
+   ```stata
+   * Create relative time indicators
+   gen rel_time = year - treatment_year
+   forvalues t = -5/5 {
+       gen D`t' = (rel_time == `t')
+   }
+   * Omit t = -1 as baseline
+   drop D_1
+
+   reghdfe y D_5-D0 D1-D5 controls, absorb(firm_id year) ///
+       cluster(firm_id)
+   * Plot coefficients for pre-trends test
+   ```
+
+   STAGGERED ADOPTION (modern estimators):
+   ```stata
+   * Callaway and Sant'Anna (2021)
+   * ssc install csdid
+   csdid y controls, ivar(firm_id) time(year) ///
+       gvar(first_treated_year) method(dripw)
+
+   * Sun and Abraham (2021)
+   * ssc install eventstudyinteract
+   eventstudyinteract y lead* lag*, cohort(first_treated) ///
+       control_cohort(never_treated) absorb(firm_id year) ///
+       cluster(firm_id)
+   ```
+
+   IMPORTANT: With staggered adoption, classic TWFE DiD is biased.
+   Use Callaway-Sant'Anna, Sun-Abraham, or de Chaisemartin-D'Haultfoeuille.
+   Always test for parallel pre-trends.
+
+3. Instrumental Variables (IV)
+
+   Requirements: (1) Relevance — instrument predicts endogenous variable
+   (2) Exclusion — instrument affects outcome only through the endogenous variable
+
+   STATA:
+   ```stata
+   * 2SLS
+   ivreghdfe y controls (endog_var = instrument), ///
+       absorb(firm_id year) cluster(firm_id)
+
+   * Check first-stage F-statistic (must be > 10, Stock-Yogo)
+   * Check: estat firststage
+   * Weak instrument test: Kleibergen-Paap rk Wald F
+   ```
+
+   PYTHON:
+   ```python
+   from linearmodels.iv import IV2SLS
+   mod = IV2SLS.from_formula(
+       'y ~ 1 + controls + [endog_var ~ instrument]',
+       data=df
+   )
+   res = mod.fit(cov_type='clustered', clusters=df['firm_id'])
+   print(res.first_stage)  # Check F-stat
+   ```
+
+4. Regression Discontinuity (RDD)
+
+   Exploits threshold-based rules (e.g., regulatory size thresholds).
+
+   ```stata
+   * ssc install rdrobust
+   rdrobust y running_var, c(threshold) p(1) kernel(triangular)
+   * Bandwidth selection: rdbwselect y running_var, c(threshold)
+   * McCrary density test for manipulation: rddensity running_var, c(threshold)
+   ```
+
+5. Standard Error Clustering
+
+   RULE OF THUMB (Petersen 2009):
+   - Firm-level panel: cluster by firm (absorbs within-firm correlation)
+   - If both firm and time correlation: double-cluster by firm and year
+   - State-level policy shocks: cluster by state
+   - Number of clusters should be ≥ 50 for reliable inference
+
+   NEVER use heteroskedasticity-robust SEs alone in panel data.
+   ALWAYS cluster at the level of treatment assignment or higher.
+
+─────────────────────────────────────────────────────────────────────────────
+ESTIMATION AND REGRESSION ANALYSIS
+─────────────────────────────────────────────────────────────────────────────
+
+1. Baseline Specification
+
+   Standard empirical finance regression:
+   y_{i,t} = β × X_{i,t} + γ × Controls_{i,t} + α_i + δ_t + ε_{i,t}
+
+   Where: α_i = entity FE, δ_t = time FE
+
+   Build up specifications progressively in your regression table:
+   - Column 1: OLS (no FE, no controls)
+   - Column 2: Add controls
+   - Column 3: Add entity FE
+   - Column 4: Add time FE
+   - Column 5: Add entity + time FE (preferred specification)
+
+2. Interaction Terms and Subsamples
+
+   ```stata
+   * Interaction with continuous variable
+   gen x1_x2 = x1 * x2
+   reghdfe y x1 x2 x1_x2 controls, absorb(firm_id year) cluster(firm_id)
+
+   * Or equivalently with factor notation
+   reghdfe y c.x1##c.x2 controls, absorb(firm_id year) cluster(firm_id)
+
+   * Subsample analysis (e.g., pre vs post reform)
+   reghdfe y x1 controls if year < 2018, absorb(firm_id year) cluster(firm_id)
+   reghdfe y x1 controls if year >= 2018, absorb(firm_id year) cluster(firm_id)
+   ```
+
+3. Economic Magnitude
+
+   CRITICAL: Always convert regression coefficients to economic magnitudes.
+   Do not just report statistical significance.
+
+   TEMPLATES:
+   - "A one-standard-deviation increase in X is associated with a
+     Y basis-point change in Z."
+   - "Moving from the 25th to the 75th percentile of X corresponds
+     to an increase in Y of $Z million."
+   - "The tax shield represents X% of average return on assets."
+
+   ```stata
+   * After regression, compute magnitudes
+   qui sum x1, detail
+   local sd_x1 = r(sd)
+   local iqr_x1 = r(p75) - r(p25)
+
+   * One-SD effect
+   display "1-SD effect on y: " _b[x1] * `sd_x1'
+   * IQR effect
+   display "IQR effect on y: " _b[x1] * `iqr_x1'
+   ```
+
+4. Nonlinear Models
+
+   ```stata
+   * Logit/Probit for binary outcomes
+   logit y_binary x1 controls, cluster(firm_id)
+   margins, dydx(x1)  /* Average marginal effects */
+
+   * Tobit for censored data (e.g., dividend payout)
+   tobit y_censored x1 controls, ll(0)
+
+   * Poisson pseudo-ML with HDFE (e.g., count outcomes, gravity)
+   ppmlhdfe y x1 controls, absorb(firm_id year) cluster(firm_id)
+   ```
+
+─────────────────────────────────────────────────────────────────────────────
+ROBUSTNESS CHECKS
+─────────────────────────────────────────────────────────────────────────────
+
+Every empirical finance paper must demonstrate that results are robust
+to alternative explanations. Each robustness check should address a
+SPECIFIC threat to identification.
+
+ROBUSTNESS CHECKLIST:
+
+□ Alternative variable definitions
+  - Different winsorization levels (0.5/99.5, 2/98, 5/95)
+  - Alternative measures of key variables (e.g., book vs market leverage)
+  - Different scaling (levels vs ratios vs logs)
+
+□ Alternative specifications
+  - Adding/removing control variables
+  - Different fixed effects structures (firm, year, firm×year, industry×year)
+  - Linear vs nonlinear functional forms
+
+□ Subsample analysis
+  - By firm size (quartiles or above/below median)
+  - By time period (pre/post regulation, pre/post crisis)
+  - By industry or sector
+  - Excluding financial firms (if applicable)
+
+□ Placebo and falsification tests
+  - Randomized treatment timing
+  - Pseudo-events (shift treatment date by ±N years)
+  - Outcome variables that should NOT be affected
+
+□ Sensitivity to outliers
+  - Different winsorization levels
+  - Trimming instead of winsorizing
+  - Excluding influential observations (DFBETAS)
+
+□ Alternative identification
+  - Different instruments (if IV)
+  - Different bandwidth (if RDD)
+  - Alternative control groups (if DiD)
+  - Oster (2019) bounds for coefficient stability
+
+□ Standard error robustness
+  - Alternative clustering levels
+  - Bootstrap standard errors
+  - Conley spatial SEs (if geographic variation)
+
+─────────────────────────────────────────────────────────────────────────────
+VISUALIZATION FOR FINANCE
+─────────────────────────────────────────────────────────────────────────────
+
+NOTE: In finance, tables are the primary presentation format (unlike
+science where figures dominate). However, visualization is critical
+for exploration and for illustrating key patterns.
+
+1. Time Series Plots
+
+   STATA:
+   ```stata
+   twoway (line agg_etr year, lcolor(blue) lwidth(medthick)) ///
+       (line median_etr year, lcolor(red) lpattern(dash)), ///
+       title("Effective Tax Rate Over Time") ///
+       ytitle("ETR (%)") xtitle("Year") ///
+       legend(order(1 "Aggregate" 2 "Median")) ///
+       xline(2008, lcolor(gray) lpattern(dash)) ///
+       xline(2018, lcolor(gray) lpattern(dash)) ///
+       text(0.35 2008 "GFC", place(e)) ///
+       text(0.35 2018 "TCJA", place(e)) ///
+       scheme(s2color)
+   graph export "figures/etr_timeseries.pdf", replace
+   ```
+
+   PYTHON:
+   ```python
+   fig, ax = plt.subplots(figsize=(12, 6))
+   ax.plot(df['year'], df['agg_etr'], 'b-', lw=2, label='Aggregate')
+   ax.plot(df['year'], df['median_etr'], 'r--', lw=1.5, label='Median')
+   ax.axvline(2008, color='gray', ls='--', alpha=0.7)
+   ax.axvline(2018, color='gray', ls='--', alpha=0.7)
+   ax.set_xlabel('Year')
+   ax.set_ylabel('ETR (%)')
+   ax.set_title('Effective Tax Rate Over Time')
+   ax.legend()
+   plt.tight_layout()
+   plt.savefig('figures/etr_timeseries.pdf', dpi=300, bbox_inches='tight')
+   ```
+
+2. Binscatter Plots
+
+   The workhorse visualization in empirical finance. Shows conditional
+   means after absorbing controls/FE.
+
+   STATA:
+   ```stata
+   * ssc install binscatter (or binsreg for modern version)
+   binscatter etr eq_assets, controls(i.year) nquantiles(50) ///
+       ytitle("Effective Tax Rate (%)") ///
+       xtitle("Equity / Assets (%)") ///
+       title("ETR vs Capital Ratio")
+   graph export "figures/binscatter_etr_equity.pdf", replace
+   ```
+
+3. Event Study Plots
+
+   ```stata
+   * After event study regression, plot coefficients
+   coefplot, keep(D_5 D_4 D_3 D_2 D0 D1 D2 D3 D4 D5) ///
+       vertical ///
+       yline(0, lcolor(red)) ///
+       xline(5.5, lcolor(gray) lpattern(dash)) ///
+       title("Event Study: Effect on Y") ///
+       ytitle("Coefficient") xtitle("Years Relative to Treatment") ///
+       ciopts(recast(rcap))
+   graph export "figures/event_study.pdf", replace
+   ```
+
+4. Kernel Density Plots
+
+   ```stata
+   * Compare distributions across groups
+   twoway (kdensity eq_assets if size_q == 1, lcolor(blue)) ///
+       (kdensity eq_assets if size_q == 4, lcolor(red)), ///
+       title("Capital Ratio by Bank Size") ///
+       legend(order(1 "Small" 2 "Large"))
+   ```
+
+5. Dual-Axis Plots
+
+   Use sparingly. Clearly label both axes. Consider whether two
+   separate panels would be clearer.
+
+─────────────────────────────────────────────────────────────────────────────
+TABLE FORMATTING AND PRESENTATION
+─────────────────────────────────────────────────────────────────────────────
+
+Tables are the primary output format in empirical finance.
+
+1. Summary Statistics Table
+
+   MUST INCLUDE: N, Mean, SD, p25, Median, p75 (and Min/Max if space allows)
+
+   STATA:
+   ```stata
+   * Using estout (ssc install estout)
+   estpost summarize assets equity roa etr leverage, detail
+   esttab using "tables/sumstats.tex", replace ///
+       cells("count mean sd p25 p50 p75") ///
+       label booktabs ///
+       title("Summary Statistics") ///
+       nomtitle nonumber
+   ```
+
+2. Regression Tables
+
+   REQUIRED ELEMENTS:
+   - Dependent variable clearly labeled in header
+   - Independent variables in rows
+   - Controls indicated (Yes/No row)
+   - Fixed effects indicated (Firm FE: Yes/No, Year FE: Yes/No)
+   - Clustering noted in table footer
+   - N and R-squared (within R² for FE models)
+   - Significance stars: * p<0.10, ** p<0.05, *** p<0.01
+
+   STATA:
+   ```stata
+   eststo clear
+   eststo: reghdfe y x1 controls, absorb(firm_id) cluster(firm_id)
+   eststo: reghdfe y x1 controls, absorb(firm_id year) cluster(firm_id)
+   eststo: reghdfe y x1 controls, absorb(firm_id year) cluster(firm_id year)
+
+   esttab using "tables/main_results.tex", replace ///
+       se star(* 0.10 ** 0.05 *** 0.01) ///
+       keep(x1) ///
+       stats(N r2_within, labels("Observations" "Within R²")) ///
+       indicate("Controls = controls" "Firm FE = 1.firm_id" ///
+                "Year FE = 1.year") ///
+       label booktabs ///
+       title("Main Results") ///
+       mtitles("(1)" "(2)" "(3)") ///
+       addnotes("Standard errors clustered by firm in columns 1-2" ///
+                "and by firm and year in column 3.")
+   ```
+
+   LaTeX TABLE TEMPLATE:
+   - Use booktabs: \toprule, \midrule, \bottomrule (NO vertical lines)
+   - Use threeparttable for table notes
+   - Use dcolumn or siunitx for decimal alignment
+   - Place significance stars: \sym{*}, \sym{**}, \sym{***}
+
+3. Table Notes Convention
+
+   Every table must have notes explaining:
+   - What the dependent variable is
+   - Sample period and restrictions
+   - What controls are included
+   - Fixed effects structure
+   - How standard errors are clustered
+   - Significance levels: *, **, ***
+
+─────────────────────────────────────────────────────────────────────────────
+WRITING CONVENTIONS FOR FINANCE
+─────────────────────────────────────────────────────────────────────────────
+
+1. Language and Tone
+
+   - Use hedging language: "consistent with" not "proves"
+   - "The evidence suggests" not "we demonstrate"
+   - "is associated with" for correlations, reserve causal language
+     for settings with strong identification
+   - Use "we" throughout (even single-authored papers)
+   - Present tense for established facts: "Table 3 shows..."
+   - Past tense for what you did: "We collected data from..."
+
+2. Paper Structure (Finance Convention)
+
+   ABSTRACT: ~100 words. State the main finding in the first sentence.
+
+   INTRODUCTION (3-5 pages):
+   - Paragraph 1: What do you do and what do you find? (THE PUNCHLINE)
+   - Paragraph 2-3: Why does this matter? (Motivation)
+   - Paragraph 4-5: How do you do it? (Identification, data)
+   - Paragraph 6: What are the main results?
+   - Paragraph 7-8: Literature positioning (brief, thematic)
+   - Final paragraph: Paper roadmap
+
+   NOTE: Finance embeds the literature review in the introduction.
+   A standalone "Literature Review" section is rare and signals weakness
+   unless the paper genuinely surveys a field.
+
+   DATA SECTION:
+   - Data sources with exact names and identifiers
+   - Sample construction with observation counts at each filter step
+   - Variable definitions table
+   - Summary statistics table
+
+   EMPIRICAL STRATEGY:
+   - Model specification with equation
+   - Identification argument (the most scrutinized section)
+   - Threats to identification and how you address them
+
+   RESULTS:
+   - Main results first
+   - Robustness subsection
+   - Heterogeneity analysis (who is most affected?)
+
+   CONCLUSION (1-2 pages):
+   - Do not overstate findings
+   - Acknowledge limitations honestly
+   - Suggest policy implications cautiously
+   - Brief future directions
+
+3. Journal Conventions
+
+   JEL Classification codes: Always include (e.g., G21, H25, E44)
+   Keywords: 3-5 terms
+
+   Top 3 journals:
+   - Journal of Finance (JF): ~60 pages, 100-word abstract
+   - Journal of Financial Economics (JFE): Double-blind review
+   - Review of Financial Studies (RFS): Chicago Manual of Style
+
+   Paper length: 40-60 pages including tables and appendices.
+   Tables typically placed at end of paper (not inline).
+
+═══════════════════════════════════════════════════════════════════════════════

--- a/templates/paper_styles/finance/example_paper.tex
+++ b/templates/paper_styles/finance/example_paper.tex
@@ -1,0 +1,220 @@
+%------------------------------------------------------------------------------
+% Finance Paper Template
+%------------------------------------------------------------------------------
+% Generic template compatible with Journal of Finance, JFE, and RFS
+% submissions. Uses standard article class with finance-appropriate
+% formatting. Adjust margins/spacing per target journal guidelines.
+%
+\documentclass[12pt]{article}
+
+%--- Page Layout (JF-style: 1" sides, 1.5" top/bottom) ---
+\usepackage[margin=1in, top=1.5in, bottom=1.5in]{geometry}
+\usepackage{setspace}
+\onehalfspacing  % JF uses 1.5 spacing; switch to \doublespacing for JFE
+
+%--- Bibliography ---
+\usepackage[authoryear,round,semicolon]{natbib}
+
+%--- Math ---
+\usepackage{amsmath,amssymb}
+
+%--- Tables ---
+\usepackage{booktabs}       % Professional tables (no vertical lines)
+\usepackage{tabularx}       % Tables with flexible column widths
+\usepackage{threeparttable} % Table notes
+\usepackage{dcolumn}        % Decimal-aligned columns in regression tables
+\usepackage{multirow}       % Spanning rows in tables
+\usepackage{siunitx}        % Number formatting and alignment
+\sisetup{
+  input-symbols = {()},
+  table-format = -1.3,
+  table-space-text-pre = (,
+  table-space-text-post = ),
+}
+
+%--- Figures ---
+\usepackage{graphicx}
+\usepackage{subcaption}
+
+%--- Other ---
+\usepackage[hidelinks]{hyperref}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{enumitem}
+\usepackage{xspace}
+\usepackage{float}
+
+%--- Custom Commands ---
+% Significance stars for regression tables
+\newcommand{\sym}[1]{^{#1}}
+
+% Decimal-aligned column type for regression output
+\newcolumntype{d}[1]{D{.}{.}{#1}}
+
+% Convenience: standard errors in parentheses
+\newcommand{\se}[1]{(#1)}
+
+%--- Document Info ---
+\title{Paper Title Here}
+\author{
+  Author One\thanks{Affiliation, email. We thank ...}
+  \and
+  Author Two\thanks{Affiliation, email.}
+}
+\date{\today}
+
+%------------------------------------------------------------------------------
+\begin{document}
+%------------------------------------------------------------------------------
+
+\maketitle
+
+%--- Abstract ---
+\begin{abstract}
+\noindent
+% ~100 words. State the main finding in the first sentence.
+We study ... using ... data. We find that ...
+Our results suggest that ...
+\end{abstract}
+
+\vspace{1em}
+\noindent\textit{JEL Classification:} G21, H25 \\
+\noindent\textit{Keywords:} keyword1, keyword2, keyword3
+
+\newpage
+
+%--- Introduction ---
+\section{Introduction}
+% 3-5 pages. Punchline in first paragraph. Embed literature review.
+% Structure: What/Why/How/Results/Literature/Roadmap
+
+
+%--- Institutional Background (optional) ---
+\section{Institutional Background}
+% Regulatory context, market structure, policy changes relevant to study
+
+
+%--- Data ---
+\section{Data}
+
+\subsection{Data Sources}
+% Name exact data sources, identifiers, and coverage periods
+
+\subsection{Sample Construction}
+% Document all filters and their impact on sample size
+
+\subsection{Variable Definitions}
+% Table of variable names, definitions, and sources
+
+\subsection{Summary Statistics}
+
+% Example summary statistics table
+\begin{table}[htbp]
+\centering
+\begin{threeparttable}
+\caption{Summary Statistics}
+\label{tab:sumstats}
+\begin{tabular}{lccccccc}
+\toprule
+Variable & N & Mean & SD & p25 & Median & p75 \\
+\midrule
+Assets (\$B)      & 100,000 & 2.45  & 5.12  & 0.15  & 0.52  & 1.85  \\
+Equity/Assets (\%) & 100,000 & 10.23 & 3.45  & 8.12  & 9.87  & 11.54 \\
+ROA (\%)           & 100,000 & 1.05  & 0.62  & 0.72  & 1.02  & 1.35  \\
+ETR (\%)           & 85,000  & 25.4  & 8.7   & 20.1  & 26.3  & 31.2  \\
+\bottomrule
+\end{tabular}
+\begin{tablenotes}[flushleft]
+\small
+\item \textit{Notes:} This table reports summary statistics for the main
+analysis sample. The sample covers [period]. All continuous variables are
+winsorized at the 1st and 99th percentiles.
+\end{tablenotes}
+\end{threeparttable}
+\end{table}
+
+
+%--- Empirical Strategy ---
+\section{Empirical Strategy}
+
+\subsection{Identification}
+% The most scrutinized section. Clearly articulate:
+% (1) What variation identifies the effect
+% (2) Why this variation is plausibly exogenous
+% (3) Threats to identification
+
+\subsection{Specification}
+% Formal model specification:
+% y_{i,t} = \beta X_{i,t} + \gamma Controls_{i,t} + \alpha_i + \delta_t + \varepsilon_{i,t}
+
+
+%--- Results ---
+\section{Results}
+
+\subsection{Main Results}
+
+% Example regression table
+\begin{table}[htbp]
+\centering
+\begin{threeparttable}
+\caption{Main Results: Effect of X on Y}
+\label{tab:main}
+\begin{tabular}{ld{3}d{3}d{3}}
+\toprule
+ & \multicolumn{1}{c}{(1)} & \multicolumn{1}{c}{(2)} & \multicolumn{1}{c}{(3)} \\
+ & \multicolumn{1}{c}{OLS} & \multicolumn{1}{c}{FE} & \multicolumn{1}{c}{FE} \\
+\midrule
+Key Variable     & 0.045\sym{***} & 0.032\sym{**}  & 0.028\sym{**}  \\
+                 & \se{0.012}     & \se{0.014}     & \se{0.013}     \\[0.5em]
+Control 1        & 0.123\sym{***} & 0.098\sym{**}  & 0.087\sym{**}  \\
+                 & \se{0.034}     & \se{0.041}     & \se{0.039}     \\
+\midrule
+Controls         & \multicolumn{1}{c}{No}  & \multicolumn{1}{c}{Yes} & \multicolumn{1}{c}{Yes} \\
+Firm FE          & \multicolumn{1}{c}{No}  & \multicolumn{1}{c}{Yes} & \multicolumn{1}{c}{Yes} \\
+Year FE          & \multicolumn{1}{c}{No}  & \multicolumn{1}{c}{No}  & \multicolumn{1}{c}{Yes} \\
+\midrule
+Observations     & \multicolumn{1}{c}{100,000} & \multicolumn{1}{c}{100,000} & \multicolumn{1}{c}{100,000} \\
+Within $R^2$     & \multicolumn{1}{c}{0.05}    & \multicolumn{1}{c}{0.12}    & \multicolumn{1}{c}{0.15}    \\
+\bottomrule
+\end{tabular}
+\begin{tablenotes}[flushleft]
+\small
+\item \textit{Notes:} This table reports OLS and fixed-effects estimates of
+the effect of [Key Variable] on [Dependent Variable]. The sample covers
+[period]. All continuous variables are winsorized at the 1st and 99th
+percentiles. Standard errors clustered at the firm level are reported in
+parentheses. \sym{*}~$p<0.10$, \sym{**}~$p<0.05$, \sym{***}~$p<0.01$.
+\end{tablenotes}
+\end{threeparttable}
+\end{table}
+
+\subsection{Robustness}
+% Alternative specifications, samples, variable definitions
+% Address specific threats to identification
+
+\subsection{Heterogeneity}
+% Who is most affected? By size, time period, type
+
+
+%--- Conclusion ---
+\section{Conclusion}
+% 1-2 pages. Do not overstate. Acknowledge limitations.
+
+
+%--- References ---
+\bibliographystyle{plainnat}
+\bibliography{references}
+
+%--- Appendix ---
+\newpage
+\appendix
+
+\section{Variable Definitions}
+\label{app:variables}
+% Comprehensive table: Variable, Definition, Source
+
+\section{Additional Tables and Figures}
+\label{app:additional}
+% Robustness tables, supplementary figures
+
+\end{document}

--- a/templates/paper_styles/finance/style_config.yaml
+++ b/templates/paper_styles/finance/style_config.yaml
@@ -1,0 +1,5 @@
+# Finance paper style configuration (generic, JF-compatible)
+# Uses standard article class with finance-appropriate formatting
+package_name: finance_paper
+package_options: ""
+bib_style: plainnat


### PR DESCRIPTION
## Summary
- Add full finance domain support (templates, paper style, agent overrides) comparable to mathematics domain
- Move paper style defaults from hardcoded dict in `runner.py` to `config/domains.yaml` so Docker container picks up mappings via mounted config volume
- Includes Stata detection and hybrid Python/Stata execution in session instructions

## New files
- `templates/domains/finance/core.txt` — domain template (~680 lines)
- `templates/paper_styles/finance/` — style_config.yaml + example_paper.tex
- `templates/agents/domains/finance/` — paper_writer, resource_finder, session_instructions overrides

## Modified files
- `config/domains.yaml` — added finance entry with `paper_style: finance`, added `paper_style: ams` to mathematics
- `src/core/config_loader.py` — added `get_domain_paper_style()` method
- `src/core/runner.py` — reads style from config instead of hardcoded `_DOMAIN_STYLE_DEFAULTS` dict

## Why the runner.py change matters
The old hardcoded dict was baked into the Docker image at build time. Since `config/` is volume-mounted but `src/` is not, adding new domain-style mappings required rebuilding the image. Now style defaults live in `domains.yaml` (mounted as `/app/config:ro`), so future domains just need a config change.

## Test plan
- [ ] Rebuild Docker image
- [ ] Verify `./neurico run` with finance domain idea selects finance paper style
- [ ] Verify mathematics domain still selects AMS style
- [ ] Verify other domains still default to neurips
- [ ] Verify `example_paper.tex` compiles with pdflatex

🤖 Generated with [Claude Code](https://claude.com/claude-code)