### PR TITLE
feat: Add retry mechanism

### DIFF
--- a/config/workspace.yaml.example
+++ b/config/workspace.yaml.example
@@ -18,3 +18,10 @@ workspace:
 
   # Default permissions for created workspace directories (octal)
   permissions: 0o755
+
+# Retry configuration for API calls and subprocess launches
+retry:
+  max_attempts: 3
+  backoff_factor: 2.0
+  initial_delay: 1.0
+  max_delay: 60.0

--- a/src/agents/resource_finder.py
+++ b/src/agents/resource_finder.py
@@ -22,6 +22,7 @@ from datetime import datetime
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.security import sanitize_text
+from core.retry import retry_call
 
 
 # CLI commands for different providers
@@ -167,18 +168,27 @@ def run_resource_finder(
     completion_marker = work_dir / ".resource_finder_complete"
     start_time = time.time()
 
+    def _launch_subprocess():
+        """Launch the CLI agent subprocess (retried on transient launch failures)."""
+        return subprocess.Popen(
+            shlex.split(cmd),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            text=True,
+            bufsize=1,
+            cwd=str(work_dir)
+        )
+
     try:
         with open(log_file, 'w') as log_f, open(transcript_file, 'w') as transcript_f:
-            # Start process in workspace directory
-            process = subprocess.Popen(
-                shlex.split(cmd),
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                env=env,
-                text=True,
-                bufsize=1,
-                cwd=str(work_dir)
+            # Start process in workspace directory (retry on launch failures like EAGAIN)
+            process = retry_call(
+                _launch_subprocess,
+                max_retries=3,
+                base_delay=1.0,
+                retryable_exceptions=(OSError,),
             )
 
             # Send prompt

--- a/src/cli/fetch_from_ideahub.py
+++ b/src/cli/fetch_from_ideahub.py
@@ -28,6 +28,8 @@ if env_local.exists():
 elif env_file.exists():
     load_dotenv(env_file)
 
+from core.retry import retry_call
+
 # Check if GitHub integration is available
 try:
     from core.github_manager import GitHubManager
@@ -50,12 +52,27 @@ def fetch_ideahub_content(url: str) -> dict:
     print(f"   URL: {url}")
 
     try:
-        # Fetch page
+        # Fetch page with retry on transient network errors
         headers = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
         }
-        response = requests.get(url, headers=headers, timeout=30)
-        response.raise_for_status()
+
+        def _fetch():
+            resp = requests.get(url, headers=headers, timeout=30)
+            resp.raise_for_status()
+            return resp
+
+        response = retry_call(
+            _fetch,
+            max_retries=3,
+            base_delay=2.0,
+            retryable_exceptions=(
+                requests.ConnectionError,
+                requests.Timeout,
+                ConnectionError,
+                TimeoutError,
+            ),
+        )
 
         # Parse HTML
         soup = BeautifulSoup(response.text, 'html.parser')
@@ -360,20 +377,27 @@ idea:
 
     try:
         print("   Calling GPT API...")
-        response = client.chat.completions.create(
-            model="gpt-4.1",
-            messages=[
-                {
-                    "role": "system",
-                    "content": "You are a research assistant that formats research ideas into minimal YAML. Only include information explicitly provided - do not invent datasets, methods, or metrics. Return valid YAML without markdown formatting."
-                },
-                {
-                    "role": "user",
-                    "content": prompt
-                }
-            ],
-            temperature=0.1,  # Lower temperature for more conservative output
-            max_tokens=2000  # Reduced since we want minimal output
+
+        def _call_openai():
+            return client.chat.completions.create(
+                model="gpt-4.1",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "You are a research assistant that formats research ideas into minimal YAML. Only include information explicitly provided - do not invent datasets, methods, or metrics. Return valid YAML without markdown formatting.",
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0.1,
+                max_tokens=2000,
+            )
+
+        response = retry_call(
+            _call_openai,
+            max_retries=3,
+            base_delay=2.0,
+            max_delay=30.0,
+            retryable_exceptions=(ConnectionError, TimeoutError, OSError),
         )
 
         yaml_content = response.choices[0].message.content.strip()

--- a/src/core/github_manager.py
+++ b/src/core/github_manager.py
@@ -16,6 +16,7 @@ import shlex
 from datetime import datetime
 
 from core.security import sanitize_logs_directory
+from core.retry import retry_call
 
 try:
     from github import Github, GithubException, Auth
@@ -163,15 +164,20 @@ class GitHubManager:
         print(f"   Visibility: {'Private' if private else 'Public'}")
 
         try:
-            # auto_init=True creates an initial commit with README, ensuring the
-            # 'main' branch exists. The agent will overwrite README.md later.
-            # gitignore_template="Python" adds a Python .gitignore in that initial commit.
-            repo = self.owner.create_repo(
-                name=repo_name,
-                description=description,
-                private=private,
-                auto_init=True,
-                gitignore_template="Python",
+            def _create_repo():
+                return self.owner.create_repo(
+                    name=repo_name,
+                    description=description,
+                    private=private,
+                    auto_init=True,
+                    gitignore_template="Python",
+                )
+
+            repo = retry_call(
+                _create_repo,
+                max_retries=3,
+                base_delay=2.0,
+                retryable_exceptions=(ConnectionError, TimeoutError, OSError),
             )
 
             print(f"✅ Repository created: {repo.html_url}")
@@ -312,7 +318,12 @@ class GitHubManager:
 
                 # Push using refspec HEAD:refs/heads/{branch} so it works even if
                 # the local branch name differs (e.g., "master" vs "main" on older git)
-                origin.push(f"HEAD:refs/heads/{branch}")
+                retry_call(
+                    lambda: origin.push(f"HEAD:refs/heads/{branch}"),
+                    max_retries=3,
+                    base_delay=2.0,
+                    retryable_exceptions=(ConnectionError, TimeoutError, OSError),
+                )
                 print(f"   ✓ Pushed to {branch}")
 
                 return True
@@ -388,12 +399,20 @@ class GitHubManager:
         try:
             repo = self.owner.get_repo(repo_name)
 
-            # Create PR
-            pr = repo.create_pull(
-                title=title,
-                body=body,
-                head=head_branch,
-                base=base_branch
+            # Create PR with retry on transient errors
+            def _create_pr():
+                return repo.create_pull(
+                    title=title,
+                    body=body,
+                    head=head_branch,
+                    base=base_branch,
+                )
+
+            pr = retry_call(
+                _create_pr,
+                max_retries=3,
+                base_delay=2.0,
+                retryable_exceptions=(ConnectionError, TimeoutError, OSError),
             )
 
             print(f"✅ Pull request created: {pr.html_url}")
@@ -529,11 +548,20 @@ Examples:
 
 Output ONLY the repository name, nothing else."""
 
-            response = client.chat.completions.create(
-                model="gpt-4o-mini",
-                messages=[{"role": "user", "content": prompt}],
-                temperature=0.3,
-                max_tokens=30
+            def _call_openai():
+                return client.chat.completions.create(
+                    model="gpt-4o-mini",
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=0.3,
+                    max_tokens=30,
+                )
+
+            response = retry_call(
+                _call_openai,
+                max_retries=3,
+                base_delay=2.0,
+                max_delay=30.0,
+                retryable_exceptions=(ConnectionError, TimeoutError, OSError),
             )
 
             slug = response.choices[0].message.content.strip()

--- a/src/core/retry.py
+++ b/src/core/retry.py
@@ -1,0 +1,130 @@
+"""
+Retry utilities for transient failures in API calls and subprocess launches.
+
+Provides a decorator and helper for retrying operations that may fail
+due to rate limits, network issues, or temporary server errors.
+"""
+
+import time
+import random
+import functools
+import logging
+from typing import Tuple, Type, Optional, Callable
+
+logger = logging.getLogger(__name__)
+
+# Default exceptions considered retryable (network / OS-level transient errors)
+RETRYABLE_EXCEPTIONS: Tuple[Type[BaseException], ...] = (
+    ConnectionError,
+    TimeoutError,
+    OSError,
+)
+
+
+def retry(
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    backoff_factor: float = 2.0,
+    retryable_exceptions: Tuple[Type[BaseException], ...] = RETRYABLE_EXCEPTIONS,
+    on_retry: Optional[Callable] = None,
+):
+    """
+    Decorator that retries a function with exponential backoff and jitter.
+
+    Jitter is applied as ``delay * uniform(0.5, 1.5)`` to avoid thundering-herd
+    problems when multiple processes retry concurrently.
+
+    Args:
+        max_retries: Maximum number of retry attempts (not counting the initial call).
+        base_delay: Initial delay in seconds before the first retry.
+        max_delay: Maximum delay in seconds between retries.
+        backoff_factor: Multiplier applied to the delay after each retry.
+        retryable_exceptions: Tuple of exception types that trigger a retry.
+        on_retry: Optional callback(attempt, max_retries, error, delay) called
+                  before each retry sleep. If None, uses default logger.info.
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            last_exception = None
+            delay = base_delay
+
+            for attempt in range(1, max_retries + 2):  # +2: 1 initial + max_retries
+                try:
+                    return func(*args, **kwargs)
+                except retryable_exceptions as e:
+                    last_exception = e
+                    if attempt == max_retries + 1:
+                        logger.warning(
+                            "All %d retries exhausted for %s: %s",
+                            max_retries, func.__name__, e,
+                        )
+                        raise
+
+                    # Apply jitter to avoid thundering herd
+                    jittered_delay = delay * (0.5 + random.random())
+
+                    if on_retry:
+                        on_retry(attempt, max_retries, e, jittered_delay)
+                    else:
+                        logger.info(
+                            "Retry %d/%d for %s after error: %s (waiting %.1fs)",
+                            attempt, max_retries, func.__name__, e, jittered_delay,
+                        )
+
+                    time.sleep(jittered_delay)
+                    delay = min(delay * backoff_factor, max_delay)
+
+            raise last_exception  # pragma: no cover
+
+        return wrapper
+    return decorator
+
+
+def retry_call(
+    func: Callable,
+    args: tuple = (),
+    kwargs: Optional[dict] = None,
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    backoff_factor: float = 2.0,
+    retryable_exceptions: Tuple[Type[BaseException], ...] = RETRYABLE_EXCEPTIONS,
+    on_retry: Optional[Callable] = None,
+):
+    """
+    Call a function with retry logic (non-decorator form).
+
+    Useful when you can't decorate the function (e.g., third-party code)
+    or want per-call retry configuration.
+
+    Args:
+        func: Callable to invoke.
+        args: Positional arguments for func.
+        kwargs: Keyword arguments for func.
+        max_retries: Maximum number of retry attempts.
+        base_delay: Initial delay in seconds.
+        max_delay: Maximum delay cap in seconds.
+        backoff_factor: Multiplier for delay between retries.
+        retryable_exceptions: Exception types that trigger a retry.
+        on_retry: Optional callback before each retry.
+
+    Returns:
+        The return value of func.
+    """
+    if kwargs is None:
+        kwargs = {}
+
+    @retry(
+        max_retries=max_retries,
+        base_delay=base_delay,
+        max_delay=max_delay,
+        backoff_factor=backoff_factor,
+        retryable_exceptions=retryable_exceptions,
+        on_retry=on_retry,
+    )
+    def _inner():
+        return func(*args, **kwargs)
+
+    return _inner()

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -26,6 +26,7 @@ from core.config_loader import ConfigLoader
 from core.security import sanitize_text
 from templates.prompt_generator import PromptGenerator
 from templates.research_agent_instructions import generate_instructions
+from core.retry import retry_call
 
 try:
     from core.github_manager import GitHubManager
@@ -434,9 +435,9 @@ class ResearchRunner:
             print("=" * 80)
             print()
 
-            with open(log_file, 'w') as log_f:
-                # Start process in workspace directory
-                process = subprocess.Popen(
+            def _launch_subprocess():
+                """Launch the CLI agent subprocess (retried on transient launch failures)."""
+                return subprocess.Popen(
                     shlex.split(cmd),
                     stdin=subprocess.PIPE,
                     stdout=subprocess.PIPE,
@@ -445,6 +446,15 @@ class ResearchRunner:
                     text=True,
                     bufsize=1,
                     cwd=str(work_dir)
+                )
+
+            with open(log_file, 'w') as log_f:
+                # Start process in workspace directory (retry on launch failures like EAGAIN)
+                process = retry_call(
+                    _launch_subprocess,
+                    max_retries=3,
+                    base_delay=1.0,
+                    retryable_exceptions=(OSError,),
                 )
 
                 # Send session instructions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,81 @@
+"""Shared fixtures for NeuriCo tests."""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Add src/ to path so core modules are importable
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+
+@pytest.fixture
+def tmp_config_dir(tmp_path):
+    """Create a temp directory with a valid domains.yaml config."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    # Minimal domains config matching the structure of config/domains.yaml
+    domains_config = {
+        "default_domain": "artificial_intelligence",
+        "domains": {
+            "artificial_intelligence": {
+                "name": "Artificial Intelligence",
+                "description": "AI research",
+                "has_template": True,
+            },
+            "machine_learning": {
+                "name": "Machine Learning",
+                "description": "ML research",
+                "has_template": True,
+            },
+            "data_science": {
+                "name": "Data Science",
+                "description": "Data analysis",
+                "has_template": False,
+            },
+        },
+        "validation": {"allow_unknown": True, "warn_missing_template": True},
+    }
+
+    with open(config_dir / "domains.yaml", "w") as f:
+        yaml.dump(domains_config, f)
+
+    return config_dir
+
+
+@pytest.fixture
+def tmp_ideas_dir(tmp_path):
+    """Create a temp directory structure for idea storage."""
+    ideas_dir = tmp_path / "ideas"
+    ideas_dir.mkdir()
+    return ideas_dir
+
+
+@pytest.fixture
+def sample_idea_spec():
+    """Return a valid idea specification dict with all optional fields populated."""
+    return {
+        "idea": {
+            "title": "Test ML Experiment",
+            "domain": "machine_learning",
+            "hypothesis": "Fine-tuning with curriculum learning improves convergence speed",
+            "expected_outputs": [
+                {"type": "metrics", "format": "json", "fields": ["accuracy", "loss"]}
+            ],
+            "evaluation_criteria": ["Convergence speed improvement > 10%"],
+        }
+    }
+
+
+@pytest.fixture
+def minimal_idea_spec():
+    """Return a minimal valid idea specification (only required fields)."""
+    return {
+        "idea": {
+            "title": "Minimal Test Idea",
+            "domain": "artificial_intelligence",
+            "hypothesis": "This is a sufficiently long hypothesis for testing purposes",
+        }
+    }

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,189 @@
+"""Tests for the retry module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.retry import retry, retry_call
+
+
+class TestRetryDecorator:
+    """Tests for the @retry decorator."""
+
+    def test_succeeds_first_try(self):
+        """Function that succeeds on first try is called once."""
+        call_count = 0
+
+        @retry(max_retries=3, base_delay=0.01)
+        def succeed():
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        assert succeed() == "ok"
+        assert call_count == 1
+
+    @patch("core.retry.time.sleep")
+    def test_retries_on_failure_then_succeeds(self, mock_sleep):
+        """Function that fails once then succeeds is retried."""
+        call_count = 0
+
+        @retry(max_retries=3, base_delay=1.0, retryable_exceptions=(ValueError,))
+        def fail_once():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("transient error")
+            return "ok"
+
+        assert fail_once() == "ok"
+        assert call_count == 2
+        assert mock_sleep.call_count == 1
+
+    @patch("core.retry.time.sleep")
+    def test_raises_after_max_retries(self, mock_sleep):
+        """Function that always fails raises after max_retries."""
+        call_count = 0
+
+        @retry(max_retries=2, base_delay=1.0, retryable_exceptions=(RuntimeError,))
+        def always_fail():
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("permanent error")
+
+        with pytest.raises(RuntimeError, match="permanent error"):
+            always_fail()
+
+        # 1 initial + 2 retries = 3 total attempts
+        assert call_count == 3
+        assert mock_sleep.call_count == 2
+
+    def test_only_retries_specified_exceptions(self):
+        """Non-retryable exceptions are raised immediately."""
+        call_count = 0
+
+        @retry(max_retries=3, base_delay=0.01, retryable_exceptions=(ValueError,))
+        def raise_type_error():
+            nonlocal call_count
+            call_count += 1
+            raise TypeError("not retryable")
+
+        with pytest.raises(TypeError, match="not retryable"):
+            raise_type_error()
+
+        assert call_count == 1  # No retry
+
+    @patch("core.retry.time.sleep")
+    def test_on_retry_callback_called(self, mock_sleep):
+        """on_retry callback is invoked with correct arguments."""
+        callback = MagicMock()
+        call_count = 0
+
+        @retry(max_retries=3, base_delay=1.0, on_retry=callback, retryable_exceptions=(ValueError,))
+        def fail_twice():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ValueError(f"fail {call_count}")
+            return "ok"
+
+        fail_twice()
+
+        assert callback.call_count == 2
+        # First retry: attempt=1, max_retries=3
+        args = callback.call_args_list[0][0]
+        assert args[0] == 1  # attempt
+        assert args[1] == 3  # max_retries
+
+    @patch("core.retry.time.sleep")
+    @patch("core.retry.random.random", return_value=0.5)
+    def test_exponential_backoff_with_jitter(self, mock_random, mock_sleep):
+        """Backoff delays increase exponentially with jitter applied."""
+
+        @retry(max_retries=3, base_delay=1.0, backoff_factor=2.0, retryable_exceptions=(ConnectionError,))
+        def always_fail():
+            raise ConnectionError("fail")
+
+        with pytest.raises(ConnectionError):
+            always_fail()
+
+        # With random()=0.5, jitter factor = 0.5 + 0.5 = 1.0
+        # So jittered delays = base * 1.0 = exact base values
+        assert mock_sleep.call_count == 3
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+        assert delays[0] == pytest.approx(1.0)   # 1.0 * 1.0
+        assert delays[1] == pytest.approx(2.0)   # 2.0 * 1.0
+        assert delays[2] == pytest.approx(4.0)   # 4.0 * 1.0
+
+    @patch("core.retry.time.sleep")
+    @patch("core.retry.random.random", return_value=0.5)
+    def test_max_delay_cap(self, mock_random, mock_sleep):
+        """Delay is capped at max_delay before jitter."""
+
+        @retry(max_retries=4, base_delay=10.0, backoff_factor=3.0, max_delay=25.0,
+               retryable_exceptions=(ConnectionError,))
+        def always_fail():
+            raise ConnectionError("fail")
+
+        with pytest.raises(ConnectionError):
+            always_fail()
+
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+        # base=10, 10*3=30->capped to 25, stays capped
+        # With jitter factor 1.0: delays are exact base values
+        assert delays[0] == pytest.approx(10.0)
+        assert delays[1] == pytest.approx(25.0)   # capped from 30
+        assert delays[2] == pytest.approx(25.0)   # stays capped
+
+    def test_preserves_function_metadata(self):
+        """Decorated function preserves original name and docstring."""
+
+        @retry(max_retries=2)
+        def my_function():
+            """My docstring."""
+            pass
+
+        assert my_function.__name__ == "my_function"
+        assert my_function.__doc__ == "My docstring."
+
+    @patch("core.retry.time.sleep")
+    def test_jitter_varies_sleep_duration(self, mock_sleep):
+        """Jitter ensures sleep duration varies (not pure exponential)."""
+
+        @retry(max_retries=2, base_delay=1.0, retryable_exceptions=(ValueError,))
+        def always_fail():
+            raise ValueError("fail")
+
+        with pytest.raises(ValueError):
+            always_fail()
+
+        # With real random, jittered delay should be in range [0.5*base, 1.5*base)
+        delay = mock_sleep.call_args_list[0].args[0]
+        assert 0.5 <= delay < 1.5  # base_delay * jitter range
+
+
+class TestRetryCall:
+    """Tests for retry_call (non-decorator form)."""
+
+    def test_succeeds_first_try(self):
+        func = MagicMock(return_value="ok")
+        result = retry_call(func, max_retries=3)
+        assert result == "ok"
+        assert func.call_count == 1
+
+    @patch("core.retry.time.sleep")
+    def test_retries_then_succeeds(self, mock_sleep):
+        func = MagicMock(side_effect=[ValueError("fail"), "ok"])
+        result = retry_call(func, max_retries=3, base_delay=1.0, retryable_exceptions=(ValueError,))
+        assert result == "ok"
+
+    def test_passes_args_and_kwargs(self):
+        func = MagicMock(return_value="ok")
+        retry_call(func, args=(1, 2), kwargs={"x": 3}, max_retries=1)
+        func.assert_called_once_with(1, 2, x=3)
+
+    @patch("core.retry.time.sleep")
+    def test_raises_after_max_retries(self, mock_sleep):
+        func = MagicMock(side_effect=RuntimeError("fail"))
+        with pytest.raises(RuntimeError, match="fail"):
+            retry_call(func, max_retries=2, base_delay=1.0, retryable_exceptions=(RuntimeError,))


### PR DESCRIPTION
  Closes #18      

  ## Summary                                                                                                            
   
  - Add `src/core/retry.py` with `@retry` decorator and `retry_call()` helper -- exponential backoff with jitter to      
  prevent thundering herd
  - Wrap GitHub API calls (repo creation, push, PR creation, repo name generation) with retry on transient errors       
  - Wrap HTTP requests and OpenAI API calls in `fetch_from_ideahub.py` with retry                                       
  - Wrap subprocess launches in `runner.py` and `resource_finder.py` with retry on OSError                              
  - Add retry config section to `config/workspace.yaml.example.`                                                         
  - 13 unit tests covering backoff timing, jitter, exception filtering, callback, and exhaustion                        
                                                                                                                        
  ## Design decisions
                                                                                                                        
  - **Jitter**: `delay * uniform(0.5, 1.5)` avoids synchronized retries across concurrent runs                          
  - **`max_retries` semantic**: counts retries after initial call (3 retries = 4 total attempts)
  - **Retryable exceptions**: defaults to `(ConnectionError, TimeoutError, OSError)` -- transient network/OS errors only 
  - **Subprocess retry**: only retries launch failures (OSError/EAGAIN), NOT timeouts (those are intentional)           
  - **Logging**: uses `logging.info`/`logging.warning` instead of print for library-appropriate output                  
                                                                                                                        
  ## Test plan                                                                                                          
                                                                                                                        
  - [ ] `python -m pytest tests/test_retry.py -v` -- all 13 tests pass
  - [ ] Verify jitter: retry delays vary between runs (not pure exponential)
  - [ ] Verify non-retryable exceptions propagate immediately without retry 