### PR TITLE
fix: Charmap Encoding Error on Windows

### DIFF
--- a/src/agents/comment_handler.py
+++ b/src/agents/comment_handler.py
@@ -276,7 +276,8 @@ def run_comment_handler(
     start_time = time.time()
 
     try:
-        with open(log_file, 'w') as log_f, open(transcript_file, 'w') as transcript_f:
+        with open(log_file, 'w', encoding='utf-8') as log_f, \
+             open(transcript_file, 'w', encoding='utf-8') as transcript_f:
             process = subprocess.Popen(
                 shlex.split(cmd),
                 stdin=subprocess.PIPE,
@@ -284,6 +285,7 @@ def run_comment_handler(
                 stderr=subprocess.STDOUT,
                 env=env,
                 text=True,
+                encoding='utf-8',
                 bufsize=1,
                 cwd=str(work_dir)
             )

--- a/src/agents/paper_writer.py
+++ b/src/agents/paper_writer.py
@@ -265,7 +265,7 @@ def run_paper_writer(
     log_file = logs_dir / f"paper_writer_{provider}.log"
 
     try:
-        with open(log_file, 'w') as log_f:
+        with open(log_file, 'w', encoding='utf-8') as log_f:
             process = subprocess.Popen(
                 shlex.split(cmd),
                 stdin=subprocess.PIPE,
@@ -273,6 +273,8 @@ def run_paper_writer(
                 stderr=subprocess.STDOUT,
                 env=env,
                 text=True,
+                encoding='utf-8',
+                errors='replace',
                 cwd=str(work_dir)
             )
 

--- a/src/agents/paper_writer.py
+++ b/src/agents/paper_writer.py
@@ -11,6 +11,13 @@ from typing import Dict, Any
 import subprocess
 import shlex
 import os
+import sys
+
+# Force UTF-8 stdout on Windows so print() can handle Unicode from the Claude CLI.
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
+    sys.stderr.reconfigure(encoding='utf-8', errors='replace')
 
 CLI_COMMANDS = {
     'claude': 'claude -p',
@@ -42,7 +49,7 @@ def _load_style_config(style: str) -> Dict[str, Any]:
     }
 
     if config_path.exists():
-        with open(config_path, 'r') as f:
+        with open(config_path, 'r', encoding='utf-8') as f:
             config = yaml.safe_load(f)
             return {**default_config, **config}
     else:
@@ -238,7 +245,7 @@ def run_paper_writer(
     # Save prompt for debugging
     logs_dir = work_dir / "logs"
     logs_dir.mkdir(exist_ok=True)
-    (logs_dir / "paper_writer_prompt.txt").write_text(prompt)
+    (logs_dir / "paper_writer_prompt.txt").write_text(prompt, encoding='utf-8')
 
     # Build command
     cmd = CLI_COMMANDS.get(provider, 'claude -p')
@@ -274,7 +281,6 @@ def run_paper_writer(
                 env=env,
                 text=True,
                 encoding='utf-8',
-                errors='replace',
                 cwd=str(work_dir)
             )
 

--- a/src/agents/resource_finder.py
+++ b/src/agents/resource_finder.py
@@ -168,7 +168,8 @@ def run_resource_finder(
     start_time = time.time()
 
     try:
-        with open(log_file, 'w') as log_f, open(transcript_file, 'w') as transcript_f:
+        with open(log_file, 'w', encoding='utf-8') as log_f, \
+             open(transcript_file, 'w', encoding='utf-8') as transcript_f:
             # Start process in workspace directory
             process = subprocess.Popen(
                 shlex.split(cmd),
@@ -177,6 +178,8 @@ def run_resource_finder(
                 stderr=subprocess.STDOUT,
                 env=env,
                 text=True,
+                encoding='utf-8',
+                errors='replace',
                 bufsize=1,
                 cwd=str(work_dir)
             )

--- a/src/agents/resource_finder.py
+++ b/src/agents/resource_finder.py
@@ -179,7 +179,6 @@ def run_resource_finder(
                 env=env,
                 text=True,
                 encoding='utf-8',
-                errors='replace',
                 bufsize=1,
                 cwd=str(work_dir)
             )

--- a/src/cli/fetch_from_ideahub.py
+++ b/src/cli/fetch_from_ideahub.py
@@ -270,12 +270,12 @@ def convert_to_yaml(ideahub_content: dict) -> dict:
 
     # Read schema for reference
     schema_path = Path(__file__).parent.parent.parent / "ideas" / "schema.yaml"
-    with open(schema_path, 'r') as f:
+    with open(schema_path, 'r', encoding='utf-8') as f:
         schema_content = f.read()
 
     # Read example for reference
     example_path = Path(__file__).parent.parent.parent / "ideas" / "examples" / "ai_chain_of_thought_evaluation.yaml"
-    with open(example_path, 'r') as f:
+    with open(example_path, 'r', encoding='utf-8') as f:
         example_content = f.read()
 
     # Create prompt for GPT - minimal formatting only
@@ -635,7 +635,7 @@ def main():
 
                 # Save updated metadata
                 idea_path = manager.ideas_dir / "submitted" / f"{idea_id}.yaml"
-                with open(idea_path, 'w') as f:
+                with open(idea_path, 'w', encoding='utf-8') as f:
                     yaml.dump(idea, f, default_flow_style=False, sort_keys=False)
 
                 print(f"✅ Repository created: {github_repo_url}")

--- a/src/cli/submit.py
+++ b/src/cli/submit.py
@@ -162,7 +162,7 @@ def main():
 
                     # Save updated metadata
                     idea_path = manager.ideas_dir / "submitted" / f"{idea_id}.yaml"
-                    with open(idea_path, 'w') as f:
+                    with open(idea_path, 'w', encoding='utf-8') as f:
                         yaml.dump(idea, f, default_flow_style=False, sort_keys=False)
 
                     print(f"✅ Repository created: {github_repo_url}")

--- a/src/core/github_manager.py
+++ b/src/core/github_manager.py
@@ -620,7 +620,7 @@ Output ONLY the repository name, nothing else."""
         metadata_dir.mkdir(exist_ok=True)
 
         # Save full idea spec
-        with open(metadata_dir / "idea.yaml", 'w') as f:
+        with open(metadata_dir / "idea.yaml", 'w', encoding='utf-8') as f:
             yaml.dump(idea_spec, f, default_flow_style=False, sort_keys=False)
 
         print("✓ Added idea metadata to .neurico/idea.yaml")
@@ -654,7 +654,7 @@ def main():
 
     # Add test file
     test_file = Path(repo.working_dir) / "test.txt"
-    test_file.write_text("Hello from NeuriCo!")
+    test_file.write_text("Hello from NeuriCo!", encoding='utf-8')
 
     # Test commit and push
     manager.commit_and_push(

--- a/src/core/idea_manager.py
+++ b/src/core/idea_manager.py
@@ -53,6 +53,14 @@ class IdeaManager:
                          self.completed_dir]:
             dir_path.mkdir(parents=True, exist_ok=True)
 
+    def get_idea_path(self, idea_id: str) -> Path:
+        """Return the current file path for an idea, searching all status directories."""
+        for directory in [self.submitted_dir, self.in_progress_dir, self.completed_dir]:
+            idea_path = directory / f"{idea_id}.yaml"
+            if idea_path.exists():
+                return idea_path
+        raise FileNotFoundError(f"Idea file not found for: {idea_id}")
+
     def submit_idea(self, idea_spec: Dict[str, Any],
                    validate: bool = True) -> str:
         """

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -411,7 +411,8 @@ class ResearchPipelineOrchestrator:
             success = False
             start_time = time.time()
 
-            with open(log_file, 'w') as log_f, open(transcript_file, 'w') as transcript_f:
+            with open(log_file, 'w', encoding='utf-8') as log_f, \
+                 open(transcript_file, 'w', encoding='utf-8') as transcript_f:
                 process = subprocess.Popen(
                     shlex.split(cmd),
                     stdin=subprocess.PIPE,
@@ -419,6 +420,8 @@ class ResearchPipelineOrchestrator:
                     stderr=subprocess.STDOUT,
                     env=env,
                     text=True,
+                    encoding='utf-8',
+                    errors='replace',
                     bufsize=1,
                     cwd=str(self.work_dir)
                 )

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -30,7 +30,7 @@ class PipelineState:
 
         # Initialize or load state
         if self.state_file.exists():
-            with open(self.state_file, 'r') as f:
+            with open(self.state_file, 'r', encoding='utf-8') as f:
                 self.state = json.load(f)
         else:
             self.state = {
@@ -43,7 +43,7 @@ class PipelineState:
 
     def _save(self):
         """Save state to disk."""
-        with open(self.state_file, 'w') as f:
+        with open(self.state_file, 'w', encoding='utf-8') as f:
             json.dump(self.state, f, indent=2)
 
     def start_stage(self, stage_name: str):
@@ -227,7 +227,7 @@ class ResearchPipelineOrchestrator:
         finally:
             # Save final results
             results_file = self.work_dir / ".neurico" / "pipeline_results.json"
-            with open(results_file, 'w') as f:
+            with open(results_file, 'w', encoding='utf-8') as f:
                 json.dump(results, f, indent=2)
 
             print()
@@ -421,7 +421,6 @@ class ResearchPipelineOrchestrator:
                     env=env,
                     text=True,
                     encoding='utf-8',
-                    errors='replace',
                     bufsize=1,
                     cwd=str(self.work_dir)
                 )

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -345,10 +345,7 @@ class ResearchRunner:
                         print(f"\n⚠️  Paper generation failed (research still succeeded)")
 
             except Exception as e:
-                import traceback
                 print(f"\n❌ Pipeline error: {e}")
-                with open(work_dir / "pipeline_error.log", 'w', encoding='utf-8') as _ef:
-                    traceback.print_exc(file=_ef)
                 success = False
                 # Don't raise - let finally block handle cleanup
             finally:

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -435,7 +435,7 @@ class ResearchRunner:
             print("=" * 80)
             print()
 
-            with open(log_file, 'w') as log_f:
+            with open(log_file, 'w', encoding='utf-8') as log_f:
                 # Start process in workspace directory
                 process = subprocess.Popen(
                     shlex.split(cmd),
@@ -444,6 +444,8 @@ class ResearchRunner:
                     stderr=subprocess.STDOUT,
                     env=env,
                     text=True,
+                    encoding='utf-8',
+                    errors='replace',
                     bufsize=1,
                     cwd=str(work_dir)
                 )

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Optional, List, Dict, Any
 import subprocess
 import shlex
-from datetime import datetime
 import sys
 import os
 import yaml
@@ -122,7 +121,8 @@ class ResearchRunner:
                     paper_style: str = None,
                     paper_timeout: int = 3600,
                     no_hash: bool = False,
-                    private: bool = False) -> Dict[str, Any]:
+                    private: bool = False,
+                    force_fresh: bool = False) -> Dict[str, Any]:
         """
         Execute research for a given idea.
 
@@ -142,6 +142,7 @@ class ResearchRunner:
             write_paper: Generate paper draft after experiments (default: False)
             paper_style: Paper template style (neurips, icml, acl, ams). None = auto-detect from domain
             paper_timeout: Timeout for paper writing in seconds
+            force_fresh: Ignore existing local workspace and start a new run from scratch
 
         Returns:
             Dictionary with:
@@ -197,6 +198,7 @@ class ResearchRunner:
                     print(f"   Continuing with local version...")
 
                 work_dir = existing_workspace
+                is_resuming = (work_dir / ".neurico" / "pipeline_state.json").exists()
 
                 # Get GitHub URL from remote
                 try:
@@ -260,6 +262,7 @@ class ResearchRunner:
                     )
 
                     work_dir = repo_info['local_path']
+                    is_resuming = False
                     print(f"\n✅ Working in GitHub repository")
                     print(f"   URL: {github_url}")
                     print(f"   Local: {work_dir}\n")
@@ -271,12 +274,24 @@ class ResearchRunner:
                     # Fall through to local setup below
 
         if not self.use_github:
-            # Local execution (original behavior)
-            timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-            run_id = f"{idea_id}_{provider}_{timestamp}"
-            work_dir = self.runs_dir / run_id
-            work_dir.mkdir(parents=True, exist_ok=True)
-            print(f"📁 Working directory: {work_dir}\n")
+            existing_workspace = idea.get('idea', {}).get('metadata', {}).get('local_workspace')
+
+            if not force_fresh and existing_workspace and Path(existing_workspace).exists():
+                work_dir = Path(existing_workspace)
+                is_resuming = (work_dir / ".neurico" / "pipeline_state.json").exists()
+                print(f"\n✅ Using existing workspace: {work_dir}\n")
+            else:
+                work_dir = self.runs_dir / idea_id
+                work_dir.mkdir(parents=True, exist_ok=True)
+                is_resuming = False
+
+                # Persist workspace path in idea metadata for future runs
+                idea.setdefault('idea', {}).setdefault('metadata', {})['local_workspace'] = str(work_dir)
+                idea_path = self.idea_manager.get_idea_path(idea_id)
+                with open(idea_path, 'w', encoding='utf-8') as f:
+                    yaml.dump(idea, f, default_flow_style=False, sort_keys=False)
+
+                print(f"📁 Working directory: {work_dir}\n")
 
         # Create subdirectories
         (work_dir / "logs").mkdir(parents=True, exist_ok=True)
@@ -304,6 +319,22 @@ class ResearchRunner:
                 work_dir=work_dir,
                 templates_dir=self.project_root / "templates"
             )
+
+            # If resuming into an existing workspace, check which stages already completed
+            # and skip them — read pipeline_state.json directly rather than relying on
+            # resume_pipeline() which is not wired up for production use.
+            if is_resuming and not skip_resource_finder:
+                state_file = work_dir / ".neurico" / "pipeline_state.json"
+                try:
+                    import json as _json
+                    with open(state_file, 'r', encoding='utf-8') as _f:
+                        _state = _json.load(_f)
+                    rf_stage = _state.get('stages', {}).get('resource_finder', {})
+                    if rf_stage.get('status') == 'completed' and rf_stage.get('success'):
+                        print("⏭️  Resource finder already completed — skipping.")
+                        skip_resource_finder = True
+                except Exception:
+                    pass  # Unreadable state file — run all stages normally
 
             try:
                 pipeline_result = orchestrator.run_pipeline(
@@ -927,6 +958,11 @@ def main():
         help="Timeout for paper writing in seconds (default: 3600 = 60 min)"
     )
     parser.add_argument(
+        "--force-fresh",
+        action="store_true",
+        help="Ignore existing local workspace and start a new run from scratch"
+    )
+    parser.add_argument(
         "--comment-mode",
         action="store_true",
         help="Run in comment mode: make targeted improvements based on comments in the idea file"
@@ -977,7 +1013,8 @@ def main():
             paper_style=args.paper_style,
             paper_timeout=args.paper_timeout,
             no_hash=args.no_hash,
-            private=args.private
+            private=args.private,
+            force_fresh=args.force_fresh
         )
 
         print()

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -18,6 +18,14 @@ import sys
 import os
 import yaml
 
+# Force UTF-8 stdout/stderr on Windows where the default is cp1252.
+# Claude CLI output contains Unicode characters that cp1252 cannot represent,
+# causing a UnicodeEncodeError when print() tries to write them to the terminal.
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
+    sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -230,7 +238,7 @@ class ResearchRunner:
 
                     # Save updated metadata
                     idea_path = self.idea_manager.ideas_dir / "submitted" / f"{idea_id}.yaml"
-                    with open(idea_path, 'w') as f:
+                    with open(idea_path, 'w', encoding='utf-8') as f:
                         yaml.dump(idea, f, default_flow_style=False, sort_keys=False)
 
                     # Clone repository
@@ -337,7 +345,10 @@ class ResearchRunner:
                         print(f"\n⚠️  Paper generation failed (research still succeeded)")
 
             except Exception as e:
+                import traceback
                 print(f"\n❌ Pipeline error: {e}")
+                with open(work_dir / "pipeline_error.log", 'w', encoding='utf-8') as _ef:
+                    traceback.print_exc(file=_ef)
                 success = False
                 # Don't raise - let finally block handle cleanup
             finally:
@@ -445,7 +456,6 @@ class ResearchRunner:
                     env=env,
                     text=True,
                     encoding='utf-8',
-                    errors='replace',
                     bufsize=1,
                     cwd=str(work_dir)
                 )

--- a/src/templates/prompt_generator.py
+++ b/src/templates/prompt_generator.py
@@ -459,17 +459,17 @@ Location: {run_dir}
         lit_review_path = work_dir / "literature_review.md"
 
         if report_path.exists():
-            report_content = report_path.read_text()
+            report_content = report_path.read_text(encoding='utf-8')
         else:
             report_content = "No REPORT.md found"
 
         if planning_path.exists():
-            planning_content = planning_path.read_text()
+            planning_content = planning_path.read_text(encoding='utf-8')
         else:
             planning_content = "No planning.md found"
 
         if lit_review_path.exists():
-            lit_review_content = lit_review_path.read_text()
+            lit_review_content = lit_review_path.read_text(encoding='utf-8')
         else:
             lit_review_content = "No literature_review.md found"
 
@@ -478,7 +478,7 @@ Location: {run_dir}
         idea_yaml_path = work_dir / ".neurico" / "idea.yaml"
         if idea_yaml_path.exists():
             try:
-                idea_meta = yaml.safe_load(idea_yaml_path.read_text())
+                idea_meta = yaml.safe_load(idea_yaml_path.read_text(encoding='utf-8'))
                 submitter = idea_meta.get('idea', {}).get('metadata', {}).get('author')
                 if submitter:
                     author_line = f"{submitter} and NeuriCo"


### PR DESCRIPTION
# fix: Windows encoding crash and local workspace reuse with stage-level resume

---

## Fix 1: Windows encoding crash

### Background

On Windows, Python defaults to cp1252 encoding for all file I/O and subprocess pipes.
cp1252 cannot represent many Unicode characters that appear in Claude's output stream,
causing the pipeline to crash with:

```
Pipeline error: 'charmap' codec can't encode characters in position 29-108: character maps to <undefined>
```

This is Windows-specific — Linux and macOS default to UTF-8 and are unaffected.

### Fix Summary

- Added `encoding='utf-8'` to all `open()`, `Path.write_text()`, `Path.read_text()`,
  and `subprocess.Popen()` calls across `runner.py`, `pipeline_orchestrator.py`,
  `paper_writer.py`, `resource_finder.py`, `comment_handler.py`, `github_manager.py`,
  `prompt_generator.py`, `submit.py`, and `fetch_from_ideahub.py`
- Added `sys.stdout.reconfigure(encoding='utf-8')` in `runner.py` and `paper_writer.py`
  to ensure terminal output also uses UTF-8

### Test

Run l2_regularization idea on Windows. No errors after the fix — experiment and paper
writer stages ran successfully and a research paper was produced.

---

## Fix 2: Local workspace reuse and stage-level resume

### Problem

When running without GitHub, every `runner.py` invocation created a new timestamped
workspace (`runs/{idea_id}_{provider}_{timestamp}/`). This meant:

- Retrying a failed run threw away all prior work and started from scratch
- `pipeline_state.json` was always empty — completed stages were never skipped


The GitHub path already solved this by storing `github_repo_name` in the idea YAML and
reusing the cloned workspace on subsequent runs. The local path had no equivalent.

### Changes

#### `src/core/idea_manager.py`
- Added `get_idea_path(idea_id)` helper that searches all status directories
  (`submitted/`, `in_progress/`, `completed/`) and returns the current path of an idea
  YAML. Used by runner to write back workspace metadata after first run.

#### `src/core/runner.py`
- **Workspace reuse (local path):** On first run, creates `runs/{idea_id}/` (stable name,
  no timestamp, no provider suffix) and writes the path into `idea.metadata.local_workspace`
  in the idea YAML. On subsequent runs, reads that field and reuses the same folder —
  mirroring how the GitHub path stores and looks up `github_repo_name`.
- **Stage-level resume:** When an existing workspace is detected and
  `pipeline_state.json` is present, reads it directly to check whether the resource
  finder stage already completed. If so, sets `skip_resource_finder=True` before calling
  `run_pipeline()`, avoiding a redundant 45-minute Stage 1 re-run on retry.
- **`--force-fresh` flag:** Opt-out for users who want a clean run despite an existing
  workspace. Skips the reuse check and creates a new `runs/{idea_id}/` folder.
- Removed unused `from datetime import datetime` import.

### Behavior

| Scenario | Before | After |
|----------|--------|-------|
| First run, no GitHub | New `{idea_id}_{provider}_{timestamp}/` | `runs/{idea_id}/`, path saved to idea YAML |
| Retry after failure | New folder, start from scratch | Same folder, Stage 1 skipped if already done |
| Provider switch (claude → gemini) | Different folder | Same folder, prior resources reused |
| Force clean run | N/A | `--force-fresh` flag |
| GitHub path | Unchanged | Stage 1 also skipped on retry if already completed |

### GitHub Impact

The stage-skip logic runs for both local and GitHub paths. When a GitHub workspace is
reused and `pipeline_state.json` exists, Stage 1 is now also skipped if it already
completed.

All other changes are local-only:
- Workspace reuse block is inside `if not self.use_github:`
- `get_idea_path()` is only called from the local path
- `--force-fresh` has no effect on GitHub runs

### Notes

- Stage-level resume reads `pipeline_state.json` directly in `runner.py` rather than
  using `resume_pipeline()` in `pipeline_orchestrator.py`, which is not wired up for
  production use.
- Only `resource_finder` stage completion is checked for now.
