### PR TITLE
fix: wrap LaTeX {#N} placeholders in {% raw %} in finance paper_writer

### DIFF
--- a/templates/domains/finance/paper_writer.txt
+++ b/templates/domains/finance/paper_writer.txt
@@ -167,8 +167,8 @@ INSTRUCTIONS:
    \usepackage{float}
 
    % Custom commands
-   \newcommand{\sym}[1]{^{#1}}
-   \newcolumntype{d}[1]{D{.}{.}{#1}}
+   {% raw %}\newcommand{\sym}[1]{^{#1}}
+   \newcolumntype{d}[1]{D{.}{.}{#1}}{% endraw %}
 
    % Import command files
    \InputIfFileExists{commands/math}{}{}


### PR DESCRIPTION
## Summary
- The finance domain paper-writer template contains LaTeX argument placeholders (`\newcommand{\sym}[1]{^{#1}}`, `\newcolumntype{d}[1]{D{.}{.}{#1}}`) that Jinja2 reads as the start of a comment block (`{#`) and errors out with **Missing end of comment tag** during paper-writer prompt rendering.
- Fix wraps the two offending lines in `{% raw %} … {% endraw %}` so Jinja leaves the LaTeX alone.

## Why it only surfaced now
The override was previously at `templates/agents/domains/finance/paper_writer.txt`, where `_load_template_with_domain_override` doesn't look (it checks `templates/domains/<domain>/<filename>`). So the override was silently ignored and the generic base template was used — which has no `{#` tokens.

Commit 97f0f40 (\"fix: move finance agent templates to domains/finance so overrides are actually loaded\") moved the file to the correct location. That exposed the latent LaTeX/Jinja collision in the paper-writer stage the next time someone ran a finance-domain idea end-to-end — which is what triggered this fix.

## Reproduction
Any run with \`domain: finance\` and \`--write-paper\` on this codebase:

\`\`\`
❌ Pipeline error: Missing end of comment tag
\`\`\`

## Verification
\`\`\`python
from jinja2 import Environment
env = Environment()
env.from_string(open('templates/domains/finance/paper_writer.txt').read())
# before fix: TemplateSyntaxError: Missing end of comment tag
# after fix:  OK
\`\`\`

## Follow-up worth considering (not in this PR)
Any future \`domains/*/paper_writer.txt\` that embeds LaTeX examples will hit the same trap. Two options:
1. Convention: wrap all LaTeX preamble blocks in templates in `{% raw %} … {% endraw %}`.
2. Structural: change the Jinja `Environment` to use non-LaTeX-colliding delimiters (e.g. `block_start_string='<%'`, `comment_start_string='<#'`) in `src/templates/prompt_generator.py`.

## Test plan
- [x] Template parses with Jinja2 after the change
- [ ] End-to-end: submit a finance idea with `--write-paper`, confirm Stage 3 (Paper Writing) completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)