### PR TITLE
fix(docker): unbreak codex/gemini after CLI updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,10 @@ services:
       # CLI credentials (for cached logins)
       # Mounted to /tmp/ because entrypoint sets HOME=/tmp for non-root users
       - ~/.claude:/tmp/.claude:ro
-      - ~/.codex:/tmp/.codex:ro
+      # Codex: read-only mount at .codex-host; entrypoint copies auth.json
+      # into a container-private CODEX_HOME (~/.codex-container) to avoid
+      # UID-mismatch chmod errors with codex ≥0.122. Login flows use ./neurico login.
+      - ~/.codex:/home/neurico/.codex-host:ro
       - ~/.gemini:/tmp/.gemini:ro
       # Optional: SSH keys for private GitHub repos
       # - ~/.ssh:/home/researcher/.ssh:ro

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -172,11 +172,17 @@ USER neurico
 WORKDIR /app
 
 # Configure git and CLI dirs for neurico user
+# .codex-container is the container-private CODEX_HOME (see entrypoint.sh).
+# .codex-host is the read-only mount target for the host's ~/.codex (see docker/run.sh).
 RUN git config --global user.email "noreply@neurico.dev" \
     && git config --global user.name "NeuriCo" \
     && git config --global init.defaultBranch main \
-    && mkdir -p ~/.claude ~/.codex ~/.gemini ~/.cache/uv \
+    && mkdir -p ~/.claude ~/.codex ~/.codex-container ~/.codex-host ~/.gemini ~/.cache/uv \
     && echo 'PS1="neurico:\w\$ "' >> ~/.bashrc
+
+# Bypass Gemini CLI's trusted-folders check in headless container runs
+# (introduced ~April 2026; without this --yolo is forced back to "default").
+ENV GEMINI_CLI_TRUST_WORKSPACE=true
 
 # Set environment variable for workspace location
 ENV NEURICO_WORKSPACE=/workspaces

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -25,6 +25,35 @@ if [ ! -w "${HOME:-/}" ]; then
     export HOME=/tmp
 fi
 
+# -----------------------------------------------------------------------------
+# Codex isolation: redirect CODEX_HOME to a container-private dir.
+#
+# Codex (≥0.122, April 2026) chmods session files and config.toml to 0600 and
+# validates ownership. When ~/.codex is bind-mounted from the host, the
+# container's neurico (UID 1000) can't chown/chmod files owned by the host
+# user, and writes from the container clobber host file ownership.
+#
+# Solution: mount the host ~/.codex read-only at ~/.codex-host and copy
+# auth.json (+ config.toml if present) into a container-only ~/.codex-container.
+# Set CODEX_HOME so codex reads/writes there. Login flows skip this redirect
+# (NEURICO_LOGIN_ONLY=1) so they can write fresh credentials back to the host.
+# -----------------------------------------------------------------------------
+if [ "${NEURICO_LOGIN_ONLY:-0}" != "1" ]; then
+    if [ -d "$HOME/.codex-host" ]; then
+        mkdir -p "$HOME/.codex-container"
+        # Seed credentials from the host (read-only mount) into the
+        # container-private dir on every start so refreshed host tokens are
+        # picked up. Skip silently if files don't exist yet.
+        for f in auth.json config.toml; do
+            if [ -f "$HOME/.codex-host/$f" ]; then
+                cp "$HOME/.codex-host/$f" "$HOME/.codex-container/$f" 2>/dev/null || true
+                chmod 600 "$HOME/.codex-container/$f" 2>/dev/null || true
+            fi
+        done
+        export CODEX_HOME="$HOME/.codex-container"
+    fi
+fi
+
 # Color output for better visibility
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -230,12 +230,22 @@ get_cli_credential_mounts() {
     fi
 
     # Codex credentials (~/.codex/)
+    # Mount READ-ONLY at .codex-host so the entrypoint can copy auth.json into
+    # a container-private CODEX_HOME (~/.codex-container). This avoids two
+    # problems with the previous RW mount:
+    #   1. Codex (≥0.122) chmods config.toml/sessions to 0600 and validates
+    #      ownership; with a UID-mismatched bind-mount this fails (EPERM).
+    #   2. Container writes through a RW mount clobbered host file ownership,
+    #      breaking the user's host-side `codex` until a manual chown.
+    # Login flows (cmd_login / setup_login_provider) intentionally do NOT use
+    # this helper — they keep an RW mount on ~/.codex so fresh credentials
+    # written during OAuth land back on the host.
     if [ -d "$HOME/.codex" ]; then
-        mounts="$mounts -v \"$HOME/.codex:/home/neurico/.codex\""
+        mounts="$mounts -v \"$HOME/.codex:/home/neurico/.codex-host:ro\""
         if [ "$(ls -A "$HOME/.codex" 2>/dev/null)" ]; then
-            echo -e "  ${GREEN}[OK]${NC} Mounting Codex credentials" >&2
+            echo -e "  ${GREEN}[OK]${NC} Mounting Codex credentials (read-only)" >&2
         else
-            echo -e "  ${DIM}[--]${NC} Mounting ~/.codex (empty)" >&2
+            echo -e "  ${DIM}[--]${NC} Mounting ~/.codex (empty, read-only)" >&2
         fi
         found_any=true
     fi

--- a/src/agents/comment_handler.py
+++ b/src/agents/comment_handler.py
@@ -245,7 +245,7 @@ def run_comment_handler(
         elif provider == "claude":
             cmd += " --dangerously-skip-permissions"
         elif provider == "gemini":
-            cmd += " --yolo"
+            cmd += " --yolo --skip-trust"
 
     # Add transcript/JSON output flags
     transcript_flag = TRANSCRIPT_FLAGS.get(provider, '')

--- a/src/agents/paper_writer.py
+++ b/src/agents/paper_writer.py
@@ -255,7 +255,7 @@ def run_paper_writer(
         elif provider == "claude":
             cmd += " --dangerously-skip-permissions"
         elif provider == "gemini":
-            cmd += " --yolo"
+            cmd += " --yolo --skip-trust"
 
     # Add streaming JSON output flags for detailed logging
     if provider == "claude":

--- a/src/agents/resource_finder.py
+++ b/src/agents/resource_finder.py
@@ -133,7 +133,7 @@ def run_resource_finder(
         elif provider == "claude":
             cmd += " --dangerously-skip-permissions"
         elif provider == "gemini":
-            cmd += " --yolo"
+            cmd += " --yolo --skip-trust"
 
     # Add transcript/JSON output flags for structured logging
     transcript_flag = TRANSCRIPT_FLAGS.get(provider, '')

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -376,7 +376,7 @@ class ResearchPipelineOrchestrator:
                 elif provider == "claude":
                     cmd += " --dangerously-skip-permissions"
                 elif provider == "gemini":
-                    cmd += " --yolo"
+                    cmd += " --yolo --skip-trust"
 
             # Add streaming JSON output flags for detailed logging
             # All providers now output streaming JSON for consistent transcript format

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -455,7 +455,7 @@ class ResearchRunner:
                 elif provider == "claude":
                     cmd += " --dangerously-skip-permissions"
                 elif provider == "gemini":
-                    cmd += " --yolo"
+                    cmd += " --yolo --skip-trust"
 
             # Add streaming JSON output flags for detailed logging
             if provider == "claude":


### PR DESCRIPTION
## Summary
- **Codex (≥0.122):** new strict chmod-to-0600 + ownership validation on session files and `config.toml` was incompatible with the RW bind-mount of `~/.codex` from host into the container. Inside the container `codex` failed with `Failed to create session: Operation not permitted (os error 1)`, and writes from the container clobbered host file ownership (host-side `codex` then refused to start with `Permission denied`). Fix: mount `~/.codex` read-only at `/home/neurico/.codex-host`; entrypoint copies `auth.json` (+ optional `config.toml`) into a container-private `/home/neurico/.codex-container` and exports `CODEX_HOME` so codex reads/writes only there. Login flows (`NEURICO_LOGIN_ONLY=1`) skip the redirect, keeping the existing RW mount so OAuth credentials still land on the host.
- **Gemini:** new "trusted folders" feature forces `--yolo` back to `default` approval and exits in untrusted dirs. Fix: append `--skip-trust` to the gemini branch of all five `--full-permissions` call sites (`resource_finder.py`, `comment_handler.py`, `paper_writer.py`, `runner.py`, `pipeline_orchestrator.py`). Also set `GEMINI_CLI_TRUST_WORKSPACE=true` in the Dockerfile as a belt-and-suspenders default.
- `docker-compose.yml` codex mount path aligned with the new `~/.codex-host:ro` convention.

## Files
- `docker/Dockerfile` — pre-create `~/.codex-container` and `~/.codex-host`; set `GEMINI_CLI_TRUST_WORKSPACE=true`.
- `docker/entrypoint.sh` — codex isolation block: copy host creds → `CODEX_HOME=~/.codex-container` (skipped when `NEURICO_LOGIN_ONLY=1`).
- `docker/run.sh` — `get_cli_credential_mounts` now mounts `~/.codex` read-only at `~/.codex-host`. Login paths (`cmd_login`, `setup_login_provider`) intentionally untouched.
- `docker-compose.yml` — codex volume mount matches the new container-side path.
- `src/agents/{resource_finder,comment_handler,paper_writer}.py`, `src/core/{runner,pipeline_orchestrator}.py` — gemini `--yolo --skip-trust` under `--full-permissions`.

## Test plan
- [ ] `./neurico build` → confirm new image reports 0.4.0 and contains the new `~/.codex-container` / `~/.codex-host` dirs.
- [ ] On a host whose `~/.codex/auth.json` is owned by the host user, run `./neurico fetch <idea> --run --provider codex` and verify no `os error 1` and no host-file ownership change after the run.
- [ ] After in-container codex run, on the host: `ls -la ~/.codex/config.toml` should still be owned by the host user with the original mode (untouched).
- [ ] `./neurico fetch <idea> --run --provider gemini --full-permissions` no longer prints "Approval mode overridden to default" and does not exit with code 55.
- [ ] `./neurico login codex` still works end-to-end and writes a fresh `auth.json` back to the host.
- [ ] Verify `claude` provider unaffected.