### PR TITLE
fix jinja2 rendering issue

### DIFF
--- a/src/templates/prompt_generator.py
+++ b/src/templates/prompt_generator.py
@@ -10,7 +10,7 @@ This module generates complete prompts for research agents by:
 from pathlib import Path
 from typing import Dict, Any, Optional
 import yaml
-from jinja2 import Environment, FileSystemLoader, Template, select_autoescape
+from jinja2 import Environment, FileSystemLoader, Template
 import sys
 
 # Add parent directory to path for imports
@@ -44,7 +44,7 @@ class PromptGenerator:
         # Set up Jinja2 environment
         self.env = Environment(
             loader=FileSystemLoader(str(self.template_dir)),
-            autoescape=select_autoescape(),
+            autoescape=False,
             trim_blocks=True,
             lstrip_blocks=True
         )


### PR DESCRIPTION
# Fix: Jinja2 Autoescape Corrupting Agent Prompts

## Problem

Prompts passed to research agents contained garbled text — single quotes `'` and double quotes `"` were replaced with HTML entities (`&#39;` and `&#34;`).

Example in agent workspace log folder's session_instruction.txt: (`'` is replaced by &#39)
```
- What&#39;s the potential impact?
```

**Root cause:** `src/templates/prompt_generator.py` initialized the Jinja2 environment with `select_autoescape()`:

`select_autoescape()` with no arguments enables HTML escaping by default. When templates are created via `env.from_string()` (no filename associated), Jinja2 has no extension to inspect, so it falls back to treating autoescape as **enabled**. Any variable containing quotes — research ideas, paper titles, instructions — was silently HTML-escaped before being sent to the agent.

## Fix

Set `autoescape=False` since these are plaintext AI prompts, not HTML:
Also removed the now-unused `select_autoescape` import.

## Files Changed

- `NeuriCo/src/templates/prompt_generator.py`
