### PR TITLE
feat: Track usage and enforce run budgets

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -684,6 +684,18 @@ cmd_run() {
 }
 
 # -----------------------------------------------------------------------------
+# Show cost and token usage history
+# -----------------------------------------------------------------------------
+cmd_usage() {
+    if command -v python3 &> /dev/null; then
+        (cd "$PROJECT_ROOT" && python3 src/cli/usage.py "$@")
+    else
+        echo -e "${RED}Error: python3 not found${NC}"
+        exit 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
 # Update CLI tools (Claude, Codex, Gemini) to latest versions
 # -----------------------------------------------------------------------------
 cmd_update_tools() {
@@ -1679,6 +1691,7 @@ cmd_help() {
     echo "  fetch <url> [--submit]    Fetch idea from IdeaHub"
     echo "  submit <idea.yaml>        Submit a research idea"
     echo "  run <id> [options]        Run research exploration"
+    echo "  usage [options]           Show token/cost usage history"
     echo "  update-tools              Update Claude/Codex/Gemini to latest versions"
     echo "  bump-version <version>    Bump version across all files (e.g., 0.3.0)"
     echo "  up                        Start container in background (compose)"
@@ -1706,7 +1719,7 @@ ACTION="${1:-help}"
 shift 2>/dev/null || true
 
 # Check Docker is available (skip for commands that don't need it)
-if [ "$ACTION" != "config" ] && [ "$ACTION" != "help" ] && [ "$ACTION" != "--help" ] && [ "$ACTION" != "-h" ]; then
+if [ "$ACTION" != "config" ] && [ "$ACTION" != "usage" ] && [ "$ACTION" != "help" ] && [ "$ACTION" != "--help" ] && [ "$ACTION" != "-h" ]; then
     check_docker
 fi
 
@@ -1737,6 +1750,9 @@ case "$ACTION" in
         ;;
     run)
         cmd_run "$@"
+        ;;
+    usage)
+        cmd_usage "$@"
         ;;
     update-tools)
         cmd_update_tools

--- a/docs/USAGE_TRACKING_TRANSCRIPTS.md
+++ b/docs/USAGE_TRACKING_TRANSCRIPTS.md
@@ -1,0 +1,164 @@
+# Usage Tracking Transcript Contracts
+
+This document records the provider transcript structures used by NeuriCo's
+token and cost tracker. The tracker reads the structured stdout transcripts
+that NeuriCo already captures for agent stages. It does not call provider APIs
+again, ask agents to self-report usage, or estimate token counts from text.
+
+## Stage Transcript Files
+
+NeuriCo tracks usage for these roadmap stages:
+
+| Stage | Transcript path |
+| --- | --- |
+| Resource finder | `logs/resource_finder_<provider>_transcript.jsonl` |
+| Experiment runner | `logs/execution_<provider>_transcript.jsonl` |
+| Paper writer | `logs/paper_writer_<provider>_transcript.jsonl` |
+
+Each parsed attempt is appended to `.neurico/usage.json`. Project-level history
+is appended to `logs/usage_history.jsonl`.
+
+## Provider Commands
+
+The tracker is tied to the provider commands already used by NeuriCo:
+
+| Provider | Command form | Cost handling |
+| --- | --- | --- |
+| Claude | `claude -p --verbose --output-format stream-json` | Provider-reported cost |
+| Codex | `codex exec --json` | Tokens only; cost unknown |
+| Gemini | `gemini --output-format stream-json` | Estimated cost when model pricing is known |
+
+## Claude
+
+Official references:
+
+- Claude CLI reference: <https://code.claude.com/docs/en/cli-reference>
+- Claude Code cost tracking: <https://code.claude.com/docs/en/agent-sdk/cost-tracking>
+
+NeuriCo parses Claude result events with `modelUsage`:
+
+```json
+{
+  "type": "result",
+  "modelUsage": {
+    "claude-sonnet-4-5": {
+      "inputTokens": 1000,
+      "outputTokens": 100,
+      "cacheReadInputTokens": 200,
+      "cacheCreationInputTokens": 50,
+      "costUSD": 0.004
+    }
+  },
+  "total_cost_usd": 0.004
+}
+```
+
+Parsed fields:
+
+- `inputTokens`
+- `outputTokens`
+- `cacheReadInputTokens`
+- `cacheCreationInputTokens`
+- `costUSD`
+- `total_cost_usd`
+
+Claude is the only supported provider where the transcript can directly report
+dollar cost. When `modelUsage` is present, NeuriCo uses the per-model provider
+costs. If only `total_cost_usd` is present, NeuriCo records cost and leaves
+tokens unknown.
+
+## Codex
+
+Official reference:
+
+- Codex non-interactive mode: <https://developers.openai.com/codex/noninteractive>
+
+NeuriCo runs Codex with `codex exec --json`, which emits JSONL events. Usage is
+parsed from `turn.completed` events:
+
+```json
+{
+  "type": "turn.completed",
+  "usage": {
+    "input_tokens": 1000,
+    "cached_input_tokens": 100,
+    "output_tokens": 250,
+    "reasoning_output_tokens": 50
+  }
+}
+```
+
+Parsed fields:
+
+- `usage.input_tokens`
+- `usage.cached_input_tokens`
+- `usage.output_tokens`
+- `usage.reasoning_output_tokens`
+
+Codex transcript events do not provide a model name or dollar cost in the
+documented JSONL usage event. NeuriCo therefore records token usage and keeps
+cost as unknown.
+
+## Gemini
+
+Official references:
+
+- Gemini CLI headless docs: <https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/headless.md>
+- Gemini CLI reference: <https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/cli-reference.md>
+- Gemini stream event types: <https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/core/src/output/types.ts>
+- Gemini stream JSON formatter: <https://raw.githubusercontent.com/google-gemini/gemini-cli/main/packages/core/src/output/stream-json-formatter.ts>
+
+NeuriCo uses Gemini's `--output-format stream-json` mode. The stream is JSONL
+and includes events such as `init`, `message`, `tool_use`, `tool_result`,
+`error`, and final `result`. NeuriCo parses usage from the final `result`
+event's `stats.models` fields:
+
+```json
+{
+  "type": "result",
+  "status": "success",
+  "stats": {
+    "total_tokens": 115,
+    "input_tokens": 100,
+    "output_tokens": 15,
+    "cached": 40,
+    "input": 60,
+    "duration_ms": 1200,
+    "tool_calls": 1,
+    "models": {
+      "gemini-2.5-flash": {
+        "total_tokens": 115,
+        "input_tokens": 100,
+        "output_tokens": 15,
+        "cached": 40,
+        "input": 60
+      }
+    }
+  }
+}
+```
+
+Parsed fields:
+
+- `stats.models[model].total_tokens`
+- `stats.models[model].input_tokens`
+- `stats.models[model].output_tokens`
+- `stats.models[model].cached`
+- `stats.models[model].input`
+
+Gemini transcripts provide token counts and model names, but not provider
+dollar cost. NeuriCo estimates cost only when the reported model matches the
+local pricing table. If the model is unknown, tokens are recorded and cost
+remains unknown.
+
+## Missing Or Unrecognized Usage
+
+If a transcript is missing, malformed, or contains no recognized usage fields,
+NeuriCo does not append an empty attempt. Existing usage records are preserved.
+
+If cost cannot be determined:
+
+- token totals are still recorded when available
+- provider and stage summaries show cost as `unknown`
+- budget enforcement does not guess spend from unknown-cost attempts
+

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -6,6 +6,11 @@ This guide explains the complete workflow for using NeuriCo, from idea submissio
 
 NeuriCo uses a **workspace-first** approach where GitHub repositories are created immediately upon idea submission, allowing you to add resources before the AI agent runs.
 
+Usage and budget tracking reads the structured transcripts emitted by the
+Claude, Codex, and Gemini CLI commands used during each agent stage. See
+[`USAGE_TRACKING_TRANSCRIPTS.md`](USAGE_TRACKING_TRANSCRIPTS.md) for the exact
+provider transcript fields parsed by NeuriCo.
+
 ## Complete Workflow
 
 ### Step 1: Setup (One-time)
@@ -50,7 +55,7 @@ idea:
 
   constraints:
     compute: cpu_only
-    budget: 50
+    budget: "$50"
     time_limit: 3600
 ```
 

--- a/src/agents/paper_writer.py
+++ b/src/agents/paper_writer.py
@@ -13,6 +13,10 @@ import shlex
 import os
 import sys
 
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.security import sanitize_text
+
 # Force UTF-8 stdout on Windows so print() can handle Unicode from the Claude CLI.
 if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
     sys.stdout.reconfigure(encoding='utf-8', errors='replace')
@@ -112,7 +116,7 @@ def _copy_style_files(draft_dir: Path, style: str):
         print(f"   Copied {style} style files to {draft_dir}")
     else:
         print(f"   Warning: Style directory {style_dir} not found")
-        print(f"   Agent will need to create paper without template style files")
+        print("   Agent will need to create paper without template style files")
 
 
 def _copy_paper_writing_resources(draft_dir: Path):
@@ -199,7 +203,8 @@ def run_paper_writer(
     style: str = "neurips",
     timeout: int = 3600,
     full_permissions: bool = True,
-    domain: str = "general"
+    domain: str = "general",
+    budget_context: str = ""
 ) -> Dict[str, Any]:
     """
     Run paper writing agent.
@@ -222,7 +227,7 @@ def run_paper_writer(
     Returns:
         Result dictionary with success status and paths
     """
-    print(f"📝 Starting Paper Writer Agent")
+    print("📝 Starting Paper Writer Agent")
     print(f"   Style: {style}")
     print(f"   Provider: {provider}")
     print(f"   Workspace: {work_dir}")
@@ -241,6 +246,8 @@ def run_paper_writer(
 
     # Generate prompt
     prompt = generate_paper_writer_prompt(work_dir, style, provider=provider, domain=domain)
+    if budget_context:
+        prompt = f"{budget_context}\n\n{'=' * 80}\n\n{prompt}"
 
     # Save prompt for debugging
     logs_dir = work_dir / "logs"
@@ -270,9 +277,11 @@ def run_paper_writer(
     env['PYTHONUNBUFFERED'] = '1'
 
     log_file = logs_dir / f"paper_writer_{provider}.log"
+    transcript_file = logs_dir / f"paper_writer_{provider}_transcript.jsonl"
 
     try:
-        with open(log_file, 'w', encoding='utf-8') as log_f:
+        with open(log_file, 'w', encoding='utf-8') as log_f, \
+             open(transcript_file, 'w', encoding='utf-8') as transcript_f:
             process = subprocess.Popen(
                 shlex.split(cmd),
                 stdin=subprocess.PIPE,
@@ -289,14 +298,16 @@ def run_paper_writer(
 
             for line in iter(process.stdout.readline, ''):
                 if line:
-                    print(line, end='')
-                    log_f.write(line)
+                    sanitized_line = sanitize_text(line)
+                    print(sanitized_line, end='')
+                    log_f.write(sanitized_line)
+                    transcript_f.write(sanitized_line)
 
             return_code = process.wait(timeout=timeout)
 
         success = return_code == 0
         if success:
-            print(f"\n✅ Paper writer agent completed!")
+            print("\n✅ Paper writer agent completed!")
             print(f"   Output directory: {draft_dir}")
         else:
             print(f"\n❌ Paper generation failed with code {return_code}")
@@ -305,6 +316,7 @@ def run_paper_writer(
             'success': success,
             'draft_dir': str(draft_dir),
             'log_file': str(log_file),
+            'transcript_file': str(transcript_file),
             'return_code': return_code
         }
 
@@ -315,6 +327,7 @@ def run_paper_writer(
             'success': False,
             'draft_dir': str(draft_dir),
             'log_file': str(log_file),
+            'transcript_file': str(transcript_file),
             'error': 'timeout'
         }
     except Exception as e:
@@ -323,6 +336,7 @@ def run_paper_writer(
             'success': False,
             'draft_dir': str(draft_dir),
             'log_file': str(log_file),
+            'transcript_file': str(transcript_file),
             'error': str(e)
         }
 

--- a/src/agents/resource_finder.py
+++ b/src/agents/resource_finder.py
@@ -16,12 +16,12 @@ import shlex
 import os
 import sys
 import time
-from datetime import datetime
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.security import sanitize_text
+from core.usage_tracker import budget_prompt_context
 
 
 # CLI commands for different providers
@@ -35,11 +35,11 @@ CLI_COMMANDS = {
 
 # CLI flags for verbose/structured transcript output
 # These enable capturing detailed conversation transcripts for logging
-# All providers now output streaming JSON for consistent transcript format
+# All providers output structured transcript data for consistent logging
 TRANSCRIPT_FLAGS = {
     'claude': '--verbose --output-format stream-json',  # Streaming JSON (requires -p and --verbose)
     'codex': '--json',  # Outputs newline-delimited JSON events (works with codex exec)
-    'gemini': '--output-format stream-json'  # Outputs JSONL stream
+    'gemini': '--output-format stream-json'  # Existing NeuriCo behavior
 }
 
 
@@ -101,7 +101,7 @@ def run_resource_finder(
     if templates_dir is None:
         templates_dir = Path(__file__).parent.parent.parent / "templates"
 
-    print(f"🔍 Starting Resource Finder Agent")
+    print("🔍 Starting Resource Finder Agent")
     print(f"   Provider: {provider}")
     print(f"   Work dir: {work_dir}")
     print(f"   Timeout: {timeout}s ({timeout//60} minutes)")
@@ -110,6 +110,9 @@ def run_resource_finder(
     # Generate prompt
     print("📝 Generating resource finder prompt...")
     prompt = generate_resource_finder_prompt(idea, templates_dir)
+    budget_context = budget_prompt_context(work_dir, idea)
+    if budget_context:
+        prompt = f"{budget_context}\n\n{'=' * 80}\n\n{prompt}"
 
     # Save prompt for reference
     logs_dir = work_dir / "logs"
@@ -187,9 +190,7 @@ def run_resource_finder(
             process.stdin.write(prompt)
             process.stdin.close()
 
-            # Stream output to both log file and transcript file (sanitized for security)
-            # For Claude/Codex with JSON flags, the output IS the transcript
-            # For Gemini, the output is regular text but sessions are saved separately
+            # Stream structured provider output to both log and transcript files.
             for line in iter(process.stdout.readline, ''):
                 if line:
                     sanitized_line = sanitize_text(line)
@@ -291,7 +292,7 @@ def wait_for_completion(
     completion_marker = work_dir / ".resource_finder_complete"
     start_time = time.time()
 
-    print(f"⏳ Waiting for resource finder completion...")
+    print("⏳ Waiting for resource finder completion...")
     print(f"   Checking for: {completion_marker}")
     print(f"   Timeout: {timeout}s ({timeout//60} minutes)")
 

--- a/src/cli/usage.py
+++ b/src/cli/usage.py
@@ -1,0 +1,158 @@
+"""
+Show NeuriCo token and cost usage history.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.usage_tracker import load_usage_history
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Show NeuriCo cost history")
+    parser.add_argument("--idea-id", help="Filter usage history to a single idea ID")
+    parser.add_argument("--json", action="store_true", help="Print raw JSON records")
+    parser.add_argument("--limit", type=_non_negative_int, default=20, help="Maximum records to show")
+    args = parser.parse_args()
+
+    project_root = Path(__file__).parent.parent.parent
+    records = load_usage_history(project_root)
+
+    if args.idea_id:
+        records = [record for record in records if record.get("idea_id") == args.idea_id]
+
+    records = _dedupe_latest(records)
+    records = records[-args.limit :] if args.limit else []
+
+    if args.json:
+        print(json.dumps(records, indent=2))
+        return
+
+    if not records:
+        print("No usage history recorded yet.")
+        return
+
+    print("NeuriCo usage history")
+    for index, record in enumerate(records):
+        if index:
+            print()
+        print(_format_record(record))
+
+
+def _dedupe_latest(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Keep only the latest record per workspace, preserving final order."""
+    latest_by_workspace: Dict[str, Dict[str, Any]] = {}
+    order: List[str] = []
+    for record in records:
+        key = record.get("workspace") or record.get("idea_id") or str(len(order))
+        if key not in latest_by_workspace:
+            order.append(key)
+        latest_by_workspace[key] = record
+    return [latest_by_workspace[key] for key in order]
+
+
+def _non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be greater than or equal to 0")
+    return parsed
+
+
+def _format_record(record: Dict[str, Any]) -> str:
+    lines = [
+        f"Idea: {record.get('idea_id') or 'unknown'}",
+    ]
+    if record.get("title"):
+        lines.append(f"  title: {record['title']}")
+    if record.get("workspace"):
+        lines.append(f"  workspace: {record['workspace']}")
+    lines.extend(
+        [
+            f"  budget: {_fmt_money(record.get('budget_usd'))}",
+            f"  status: {record.get('budget_status') or 'unknown'}",
+            f"  total_tokens: {_fmt_int(record.get('total_tokens'))}",
+            f"  total_cost: {_fmt_money(record.get('total_cost_usd'))}",
+        ]
+    )
+
+    providers = record.get("providers")
+    if isinstance(providers, dict) and providers:
+        lines.append("  providers:")
+        for provider_name in sorted(providers):
+            provider = providers[provider_name]
+            if not isinstance(provider, dict):
+                continue
+            lines.append(
+                "    "
+                f"- {provider_name}: "
+                f"attempts={provider.get('attempt_count', 'unknown')}, "
+                f"tokens={_fmt_int(provider.get('total_tokens'))}, "
+                f"cost={_fmt_money(provider.get('total_cost_usd'))}"
+            )
+
+    stages = record.get("stages")
+    if isinstance(stages, dict) and stages:
+        lines.append("  stages:")
+        for stage_name in _ordered_stage_names(stages):
+            stage = stages[stage_name]
+            if not isinstance(stage, dict):
+                continue
+            lines.append(
+                "    "
+                f"- {stage_name}: "
+                f"attempts={stage.get('attempt_count', _attempt_count_for_stage(stage))}, "
+                f"tokens={_fmt_int(stage.get('total_tokens'))}, "
+                f"cost={_fmt_money(stage.get('total_cost_usd'))}"
+            )
+            attempts = stage.get("attempts")
+            if isinstance(attempts, list) and attempts:
+                for index, attempt in enumerate(attempts, start=1):
+                    if not isinstance(attempt, dict):
+                        continue
+                    lines.append(
+                        "        "
+                        f"attempt {index}: "
+                        f"provider={attempt.get('provider') or 'unknown'}, "
+                        f"model={attempt.get('model') or 'unknown'}, "
+                        f"tokens={_fmt_int(attempt.get('total_tokens'))}, "
+                        f"cost={_fmt_money(attempt.get('estimated_cost_usd'))}"
+                    )
+    return "\n".join(lines)
+
+
+def _attempt_count_for_stage(stage: Dict[str, Any]) -> Any:
+    attempts = stage.get("attempts")
+    if isinstance(attempts, list):
+        return len(attempts)
+    return "unknown"
+
+
+def _ordered_stage_names(stages: Dict[str, Any]) -> List[str]:
+    preferred_order = ["resource_finder", "experiment_runner", "paper_writer"]
+    known = [stage for stage in preferred_order if stage in stages]
+    extra = sorted(str(stage) for stage in stages if stage not in preferred_order)
+    return known + extra
+
+
+def _fmt_int(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    return f"{int(value):,}"
+
+
+def _fmt_money(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    return f"${float(value):.4f}"
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -15,9 +15,20 @@ from typing import Optional, Dict, Any
 import json
 from datetime import datetime
 import time
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from agents.resource_finder import run_resource_finder
 from templates.research_agent_instructions import generate_instructions
+from core.usage_tracker import (
+    budget_prompt_context,
+    check_budget_before_stage,
+    format_usage_summary,
+    load_workspace_usage,
+    parse_transcript_usage,
+    update_workspace_usage,
+)
 
 
 class PipelineState:
@@ -171,6 +182,12 @@ class ResearchPipelineOrchestrator:
         try:
             # STAGE 1: Resource Finder
             if not skip_resource_finder:
+                guard = check_budget_before_stage(self.work_dir, idea, "resource_finder")
+                if not guard["allowed"]:
+                    print(f"🛑 {guard['reason']}")
+                    results["budget_status"] = "exceeded"
+                    return results
+
                 results['stages']['resource_finder'] = self._run_resource_finder(
                     idea=idea,
                     provider=provider,
@@ -185,6 +202,12 @@ class ResearchPipelineOrchestrator:
                     print("   1. Review logs and fix issues")
                     print("   2. Re-run with --skip-resource-finder if resources are already gathered")
                     print("   3. Manually add resources to workspace and continue")
+                    return results
+
+                usage = load_workspace_usage(self.work_dir)
+                if usage.get("budget_status") == "exceeded":
+                    print("🛑 Budget exceeded after resource finder; stopping before experiment runner.")
+                    results["budget_status"] = "exceeded"
                     return results
             else:
                 print("⏭️  Skipping resource finder stage (resources assumed to be ready)")
@@ -201,6 +224,12 @@ class ResearchPipelineOrchestrator:
                     return results
 
             # STAGE 3: Experiment Runner
+            guard = check_budget_before_stage(self.work_dir, idea, "experiment_runner")
+            if not guard["allowed"]:
+                print(f"🛑 {guard['reason']}")
+                results["budget_status"] = "exceeded"
+                return results
+
             results['stages']['experiment_runner'] = self._run_experiment_runner(
                 idea=idea,
                 provider=provider,
@@ -261,7 +290,24 @@ class ResearchPipelineOrchestrator:
                 full_permissions=full_permissions
             )
 
-            self.state.complete_stage('resource_finder', result['success'], result.get('outputs'))
+            transcript_file = result.get('transcript_file')
+            if transcript_file:
+                usage = parse_transcript_usage(
+                    Path(transcript_file),
+                    stage="resource_finder",
+                    provider=provider,
+                )
+                usage_data = update_workspace_usage(
+                    self.work_dir,
+                    idea,
+                    provider,
+                    usage,
+                    project_root=self.templates_dir.parent,
+                )
+                result["usage"] = usage.to_dict()
+                print(format_usage_summary(usage_data))
+
+            self.state.complete_stage('resource_finder', result['success'], result)
 
             return result
 
@@ -338,6 +384,9 @@ class ResearchPipelineOrchestrator:
 
             prompt_generator = PromptGenerator(self.templates_dir)
             prompt = prompt_generator.generate_research_prompt(idea, root_dir=self.work_dir)
+            budget_context = budget_prompt_context(self.work_dir, idea)
+            if budget_context:
+                prompt = f"{budget_context}\n\n{'=' * 80}\n\n{prompt}"
 
             # Save prompt
             prompt_file = self.work_dir / "logs" / "research_prompt.txt"
@@ -379,7 +428,7 @@ class ResearchPipelineOrchestrator:
                     cmd += " --yolo --skip-trust"
 
             # Add streaming JSON output flags for detailed logging
-            # All providers now output streaming JSON for consistent transcript format
+            # Preserve the provider invocation behavior used by the original pipeline.
             if provider == "claude":
                 cmd += " --verbose --output-format stream-json"  # Streaming JSON (requires -p and --verbose)
             elif provider == "codex":
@@ -429,9 +478,7 @@ class ResearchPipelineOrchestrator:
                 process.stdin.write(session_instructions)
                 process.stdin.close()
 
-                # Stream output to both log file and transcript file (sanitized for security)
-                # For Claude/Codex with JSON flags, the output IS the transcript
-                # For Gemini, the output is regular text but sessions are saved separately
+                # Stream structured provider output to both log and transcript files.
                 for line in iter(process.stdout.readline, ''):
                     if line:
                         sanitized_line = sanitize_text(line)
@@ -463,6 +510,21 @@ class ResearchPipelineOrchestrator:
                 'transcript_file': str(transcript_file)
             }
 
+            usage = parse_transcript_usage(
+                transcript_file,
+                stage="experiment_runner",
+                provider=provider,
+            )
+            usage_data = update_workspace_usage(
+                self.work_dir,
+                idea,
+                provider,
+                usage,
+                project_root=self.templates_dir.parent,
+            )
+            result["usage"] = usage.to_dict()
+            print(format_usage_summary(usage_data))
+
             self.state.complete_stage('experiment_runner', success, result)
 
             return result
@@ -471,12 +533,44 @@ class ResearchPipelineOrchestrator:
             print(f"\n⏱️  Experiment runner timed out after {timeout} seconds")
             process.kill()
             result = {'success': False, 'error': 'timeout'}
+            if 'transcript_file' in locals():
+                result['transcript_file'] = str(transcript_file)
+                usage = parse_transcript_usage(
+                    transcript_file,
+                    stage="experiment_runner",
+                    provider=provider,
+                )
+                usage_data = update_workspace_usage(
+                    self.work_dir,
+                    idea,
+                    provider,
+                    usage,
+                    project_root=self.templates_dir.parent,
+                )
+                result["usage"] = usage.to_dict()
+                print(format_usage_summary(usage_data))
             self.state.complete_stage('experiment_runner', False, result)
             return result
 
         except Exception as e:
             print(f"❌ Experiment runner stage failed: {e}")
             result = {'success': False, 'error': str(e)}
+            if 'transcript_file' in locals():
+                result['transcript_file'] = str(transcript_file)
+                usage = parse_transcript_usage(
+                    transcript_file,
+                    stage="experiment_runner",
+                    provider=provider,
+                )
+                usage_data = update_workspace_usage(
+                    self.work_dir,
+                    idea,
+                    provider,
+                    usage,
+                    project_root=self.templates_dir.parent,
+                )
+                result["usage"] = usage.to_dict()
+                print(format_usage_summary(usage_data))
             self.state.complete_stage('experiment_runner', False, result)
             raise
 

--- a/src/core/pricing.py
+++ b/src/core/pricing.py
@@ -1,0 +1,164 @@
+"""Provider/model pricing helpers for NeuriCo usage tracking.
+
+Values are USD per one million tokens. They are estimates based on public
+provider pricing and can be overridden per provider family with environment
+variables such as ``NEURICO_PRICE_GEMINI_INPUT_PER_M``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class TokenPrice:
+    """USD price per one million tokens for one model/provider family."""
+
+    input_per_million: float
+    output_per_million: float
+    cached_input_per_million: Optional[float] = None
+    cache_write_per_million: Optional[float] = None
+    source: str = "model"
+
+
+MODEL_PRICES: Tuple[Tuple[str, Tuple[str, ...], TokenPrice], ...] = (
+    (
+        "gemini",
+        ("gemini-2.5-pro",),
+        TokenPrice(1.25, 10.00, 0.125, 1.25, "model"),
+    ),
+    (
+        "gemini",
+        ("gemini-2.5-flash-lite",),
+        TokenPrice(0.10, 0.40, 0.01, 0.10, "model"),
+    ),
+    (
+        "gemini",
+        ("gemini-2.5-flash",),
+        TokenPrice(0.30, 2.50, 0.03, 0.30, "model"),
+    ),
+    (
+        "gemini",
+        ("gemini-2.0-flash",),
+        TokenPrice(0.10, 0.40, 0.025, 0.10, "model"),
+    ),
+)
+
+
+def get_price(
+    provider: str,
+    model: Optional[str] = None,
+    input_tokens: Optional[int] = None,
+) -> Optional[TokenPrice]:
+    """Return pricing for a known model, including environment overrides."""
+    normalized = provider.lower()
+    default = _match_model_price(normalized, model, input_tokens)
+    if default is None:
+        return None
+
+    prefix = f"NEURICO_PRICE_{normalized.upper()}"
+    input_price = _float_env(f"{prefix}_INPUT_PER_M", default.input_per_million)
+    output_price = _float_env(f"{prefix}_OUTPUT_PER_M", default.output_per_million)
+    cached_input_price = _optional_float_env(
+        f"{prefix}_CACHED_INPUT_PER_M",
+        default.cached_input_per_million,
+    )
+    cache_write_price = _optional_float_env(
+        f"{prefix}_CACHE_WRITE_PER_M",
+        default.cache_write_per_million,
+    )
+    return TokenPrice(
+        input_per_million=input_price,
+        output_per_million=output_price,
+        cached_input_per_million=cached_input_price,
+        cache_write_per_million=cache_write_price,
+        source=default.source,
+    )
+
+
+def estimate_cost_usd(
+    provider: str,
+    input_tokens: Optional[int],
+    output_tokens: Optional[int],
+    cached_input_tokens: Optional[int] = None,
+    cache_creation_input_tokens: Optional[int] = None,
+    model: Optional[str] = None,
+) -> Optional[float]:
+    """Estimate cost in USD from input/output/cache token counts."""
+    if (
+        input_tokens is None
+        and output_tokens is None
+        and cached_input_tokens is None
+        and cache_creation_input_tokens is None
+    ):
+        return None
+
+    price = get_price(provider, model=model, input_tokens=input_tokens)
+    if price is None:
+        return None
+
+    input_count = input_tokens or 0
+    output_count = output_tokens or 0
+    cached_count = cached_input_tokens or 0
+    cache_creation_count = cache_creation_input_tokens or 0
+    regular_input_count = max(input_count - cached_count - cache_creation_count, 0)
+
+    cached_price = price.cached_input_per_million
+    if cached_price is None:
+        cached_price = price.input_per_million
+
+    cache_write_price = price.cache_write_per_million
+    if cache_write_price is None:
+        cache_write_price = price.input_per_million
+
+    cost = (
+        regular_input_count / 1_000_000 * price.input_per_million
+        + cached_count / 1_000_000 * cached_price
+        + cache_creation_count / 1_000_000 * cache_write_price
+        + output_count / 1_000_000 * price.output_per_million
+    )
+    return round(cost, 6)
+
+
+def _match_model_price(
+    provider: str,
+    model: Optional[str],
+    input_tokens: Optional[int],
+) -> Optional[TokenPrice]:
+    if not model:
+        return None
+    normalized_model = _normalize_model_name(model)
+    for price_provider, patterns, price in MODEL_PRICES:
+        if price_provider != provider:
+            continue
+        if any(pattern in normalized_model for pattern in patterns):
+            if provider == "gemini" and "gemini-2.5-pro" in patterns and (input_tokens or 0) > 200_000:
+                return TokenPrice(2.50, 15.00, 0.25, 2.50, "model")
+            return price
+    return None
+
+
+def _normalize_model_name(model: str) -> str:
+    return model.lower().replace("_", "-")
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _optional_float_env(name: str, default: Optional[float]) -> Optional[float]:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -10,7 +10,7 @@ This module orchestrates the execution of research by:
 """
 
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Optional, Dict, Any
 import subprocess
 import shlex
 import sys
@@ -31,6 +31,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from core.idea_manager import IdeaManager
 from core.config_loader import ConfigLoader
 from core.security import sanitize_text
+from core.usage_tracker import (
+    budget_prompt_context,
+    check_budget_before_stage,
+    format_usage_summary,
+    load_workspace_usage,
+    parse_transcript_usage,
+    update_workspace_usage,
+)
 from templates.prompt_generator import PromptGenerator
 from templates.research_agent_instructions import generate_instructions
 
@@ -177,7 +185,6 @@ class ResearchRunner:
 
         # Setup working directory (GitHub repo or local runs/)
         github_url = None
-        github_repo = None
 
         if self.use_github and self.github_manager:
             # Check if workspace already exists from submission
@@ -186,7 +193,7 @@ class ResearchRunner:
             existing_workspace = self.github_manager.get_workspace_path(idea_id, repo_name)
 
             if existing_workspace:
-                print(f"\n✅ Using existing workspace from submission")
+                print("\n✅ Using existing workspace from submission")
                 print(f"   Local: {existing_workspace}")
 
                 # Pull latest changes (in case user added resources)
@@ -194,7 +201,7 @@ class ResearchRunner:
                     self.github_manager.pull_latest(existing_workspace)
                 except Exception as e:
                     print(f"   ⚠️  Could not pull latest changes: {e}")
-                    print(f"   Continuing with local version...")
+                    print("   Continuing with local version...")
 
                 work_dir = existing_workspace
                 is_resuming = (work_dir / ".neurico" / "pipeline_state.json").exists()
@@ -214,8 +221,8 @@ class ResearchRunner:
 
             else:
                 # Create new GitHub repository (backward compatibility)
-                print(f"\n⚠️  No existing workspace found. Creating new GitHub repository...")
-                print(f"   (Tip: Use submit.py to create workspace before running)\n")
+                print("\n⚠️  No existing workspace found. Creating new GitHub repository...")
+                print("   (Tip: Use submit.py to create workspace before running)\n")
 
                 try:
                     domain = idea_spec.get('domain', 'research')
@@ -230,8 +237,6 @@ class ResearchRunner:
                     )
 
                     github_url = repo_info['repo_url']
-                    github_repo = repo_info['repo_object']
-
                     # Store repo_name in idea metadata
                     idea['idea']['metadata'] = idea['idea'].get('metadata', {})
                     idea['idea']['metadata']['github_repo_name'] = repo_info['repo_name']
@@ -262,7 +267,7 @@ class ResearchRunner:
 
                     work_dir = repo_info['local_path']
                     is_resuming = False
-                    print(f"\n✅ Working in GitHub repository")
+                    print("\n✅ Working in GitHub repository")
                     print(f"   URL: {github_url}")
                     print(f"   Local: {work_dir}\n")
 
@@ -351,6 +356,17 @@ class ResearchRunner:
 
                 # Paper writing stage (optional)
                 if write_paper and success:
+                    guard = check_budget_before_stage(work_dir, idea, "paper_writer")
+                    if not guard["allowed"]:
+                        print(f"🛑 {guard['reason']}")
+                        success = False
+                        return {
+                            'work_dir': work_dir,
+                            'github_url': github_url,
+                            'success': success,
+                            'budget_status': 'exceeded'
+                        }
+
                     print()
                     print("=" * 80)
                     print("📝 STAGE 3: Paper Writing")
@@ -366,13 +382,31 @@ class ResearchRunner:
                         style=paper_style,
                         timeout=paper_timeout,
                         full_permissions=full_permissions,
-                        domain=domain
+                        domain=domain,
+                        budget_context=budget_prompt_context(work_dir, idea)
                     )
+
+                    transcript_file = paper_result.get('transcript_file')
+                    if transcript_file:
+                        usage = parse_transcript_usage(
+                            Path(transcript_file),
+                            stage="paper_writer",
+                            provider=provider,
+                        )
+                        usage_data = update_workspace_usage(
+                            work_dir,
+                            idea,
+                            provider,
+                            usage,
+                            project_root=self.project_root,
+                        )
+                        paper_result["usage"] = usage.to_dict()
+                        print(format_usage_summary(usage_data))
 
                     if paper_result.get('success'):
                         print(f"\n✅ Paper generated: {paper_result['draft_dir']}/main.tex")
                     else:
-                        print(f"\n⚠️  Paper generation failed (research still succeeded)")
+                        print("\n⚠️  Paper generation failed (research still succeeded)")
 
             except Exception as e:
                 print(f"\n❌ Pipeline error: {e}")
@@ -457,7 +491,8 @@ class ResearchRunner:
                 elif provider == "gemini":
                     cmd += " --yolo --skip-trust"
 
-            # Add streaming JSON output flags for detailed logging
+            # Add streaming JSON output flags for detailed logging.
+            # Preserve the provider invocation behavior used by the original runner.
             if provider == "claude":
                 cmd += " --verbose --output-format stream-json"  # Streaming JSON (requires -p and --verbose)
             elif provider == "codex":
@@ -546,7 +581,7 @@ https://github.com/ChicagoHAI/neurico
                         commit_msg
                     )
 
-                    print(f"\n🎉 Results published to GitHub!")
+                    print("\n🎉 Results published to GitHub!")
                     print(f"   {github_url}")
 
                 except Exception as e:
@@ -557,7 +592,7 @@ https://github.com/ChicagoHAI/neurico
             self.idea_manager.update_status(idea_id, 'completed')
 
             print()
-            print(f"✅ Research completed!")
+            print("✅ Research completed!")
             print(f"   Location: {work_dir}")
             if github_url:
                 print(f"   GitHub: {github_url}")
@@ -679,7 +714,7 @@ Generated by NeuriCo (comment mode)
 https://github.com/ChicagoHAI/neurico
 """
                 self.github_manager.commit_and_push(work_dir, commit_msg)
-                print(f"Changes published to GitHub!")
+                print("Changes published to GitHub!")
                 if github_url:
                     print(f"   {github_url}")
 
@@ -716,7 +751,7 @@ https://github.com/ChicagoHAI/neurico
                     if dst_skill_dir.exists():
                         shutil.rmtree(dst_skill_dir)
                     shutil.copytree(skill_dir, dst_skill_dir)
-            print(f"   Copied Claude Code skills to .claude/skills/")
+            print("   Copied Claude Code skills to .claude/skills/")
 
         # Copy skills to .gemini/skills/ for Gemini support
         gemini_skills_dst = work_dir / ".gemini" / "skills"
@@ -728,7 +763,7 @@ https://github.com/ChicagoHAI/neurico
                     if dst_skill_dir.exists():
                         shutil.rmtree(dst_skill_dir)
                     shutil.copytree(skill_dir, dst_skill_dir)
-            print(f"   Copied skills to .gemini/skills/")
+            print("   Copied skills to .gemini/skills/")
 
         # Copy skills to .codex/skills/ for Codex support
         codex_skills_dst = work_dir / ".codex" / "skills"
@@ -740,7 +775,7 @@ https://github.com/ChicagoHAI/neurico
                     if dst_skill_dir.exists():
                         shutil.rmtree(dst_skill_dir)
                     shutil.copytree(skill_dir, dst_skill_dir)
-            print(f"   Copied skills to .codex/skills/")
+            print("   Copied skills to .codex/skills/")
 
         # Add/merge .gitignore for research workspace
         self._setup_workspace_gitignore(work_dir)
@@ -784,12 +819,12 @@ https://github.com/ChicagoHAI/neurico
 
             merged_content = existing_content.rstrip('\n') + '\n\n' + '\n'.join(new_lines) + '\n'
             workspace_gitignore.write_text(merged_content, encoding='utf-8')
-            print(f"   Merged research .gitignore patterns into workspace")
+            print("   Merged research .gitignore patterns into workspace")
         else:
             # No existing .gitignore (e.g. local-only mode), copy template directly
             import shutil
             shutil.copy2(template_gitignore, workspace_gitignore)
-            print(f"   Copied .gitignore template to workspace")
+            print("   Copied .gitignore template to workspace")
 
     def _finalize_research(self, idea_id: str, work_dir: Path, github_url: Optional[str],
                           title: str, provider: str, success: bool):
@@ -828,7 +863,7 @@ https://github.com/ChicagoHAI/neurico
                     commit_msg
                 )
 
-                print(f"\n🎉 Results published to GitHub!")
+                print("\n🎉 Results published to GitHub!")
                 if github_url:
                     print(f"   {github_url}")
 
@@ -840,10 +875,15 @@ https://github.com/ChicagoHAI/neurico
         self.idea_manager.update_status(idea_id, 'completed')
 
         print()
-        print(f"✅ Research completed!")
+        print("✅ Research completed!")
         print(f"   Location: {work_dir}")
         if github_url:
             print(f"   GitHub: {github_url}")
+
+        usage_data = load_workspace_usage(work_dir)
+        if usage_data:
+            print()
+            print(format_usage_summary(usage_data))
 
 
 def main():

--- a/src/core/usage_tracker.py
+++ b/src/core/usage_tracker.py
@@ -1,0 +1,805 @@
+"""
+Usage and budget tracking for NeuriCo agent runs.
+
+The tracker reads provider JSONL transcripts when possible, estimates cost from
+known token counts, persists per-workspace usage, and appends project-level
+history for the ``usage`` command.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from uuid import uuid4
+from typing import Any, Dict, Iterable, List, Optional
+
+from core.pricing import estimate_cost_usd
+
+
+USAGE_FILENAME = "usage.json"
+HISTORY_FILENAME = "usage_history.jsonl"
+
+
+@dataclass
+class StageUsage:
+    """Normalized token/cost usage for one agent stage."""
+
+    stage: str
+    provider: str
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    reasoning_output_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    cached_input_tokens: Optional[int] = None
+    cache_creation_input_tokens: Optional[int] = None
+    estimated_cost_usd: Optional[float] = None
+    transcript_file: Optional[str] = None
+    token_source: str = "unknown"
+    model: Optional[str] = None
+    model_usage: Optional[Dict[str, Any]] = None
+    pricing_source: str = "unknown_model"
+    run_id: str = ""
+    updated_at: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        if not self.run_id:
+            self.run_id = uuid4().hex
+        if not self.updated_at:
+            self.updated_at = datetime.now().isoformat()
+        return asdict(self)
+
+    def has_usage_data(self) -> bool:
+        """Return True when this attempt contains parsed usage or cost data."""
+        return any(
+            value is not None
+            for value in (
+                self.input_tokens,
+                self.output_tokens,
+                self.reasoning_output_tokens,
+                self.total_tokens,
+                self.cached_input_tokens,
+                self.cache_creation_input_tokens,
+                self.estimated_cost_usd,
+                self.model_usage,
+            )
+        )
+
+
+def get_budget_usd(idea: Dict[str, Any]) -> Optional[float]:
+    """Return required ``idea.constraints.budget`` as a float."""
+    raw_budget = idea.get("idea", {}).get("constraints", {}).get("budget")
+    if raw_budget in (None, ""):
+        raise ValueError("Missing required constraints.budget value")
+    budget = _coerce_float(raw_budget)
+    if budget is None:
+        raise ValueError(f"Invalid constraints.budget value: {raw_budget!r}")
+    if budget < 0:
+        raise ValueError(f"constraints.budget must be non-negative, got {raw_budget!r}")
+    return budget
+
+
+def parse_transcript_usage(
+    transcript_file: Path,
+    stage: str,
+    provider: str,
+) -> StageUsage:
+    """Parse token usage from a transcript JSONL file.
+
+    Existing transcript files may contain warning text or HTML in addition to
+    JSON events. Non-JSON lines are ignored.
+    """
+    transcript_file = Path(transcript_file)
+    usage = StageUsage(
+        stage=stage,
+        provider=provider,
+        transcript_file=str(transcript_file),
+        updated_at=datetime.now().isoformat(),
+    )
+
+    if not transcript_file.exists():
+        return usage
+
+    events = _iter_json_lines(transcript_file)
+    if provider == "claude":
+        return _parse_claude_usage(events, usage)
+    if provider == "gemini":
+        return _parse_gemini_usage(events, usage)
+    if provider == "codex":
+        return _parse_codex_usage(events, usage)
+    return usage
+
+
+def update_workspace_usage(
+    work_dir: Path,
+    idea: Dict[str, Any],
+    provider: str,
+    stage_usage: StageUsage,
+    project_root: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Persist a stage usage record to ``.neurico/usage.json`` and history."""
+    work_dir = Path(work_dir)
+    usage_dir = work_dir / ".neurico"
+    usage_dir.mkdir(parents=True, exist_ok=True)
+    usage_file = usage_dir / USAGE_FILENAME
+
+    idea_spec = idea.get("idea", {})
+    metadata = idea_spec.get("metadata", {})
+    idea_id = metadata.get("idea_id")
+    budget_usd = get_budget_usd(idea)
+    if not stage_usage.has_usage_data():
+        return load_workspace_usage(work_dir)
+
+    data: Dict[str, Any]
+    if usage_file.exists():
+        try:
+            data = json.loads(usage_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            data = {}
+    else:
+        data = {}
+
+    data.setdefault("idea_id", idea_id)
+    data.setdefault("title", idea_spec.get("title"))
+    data["provider"] = provider
+    data["budget_usd"] = budget_usd
+    data.setdefault("workspace", str(work_dir))
+    data.setdefault("stages", {})
+    stage_record = _normalize_stage_record(data["stages"].get(stage_usage.stage))
+    stage_record.setdefault("attempts", [])
+    stage_record["attempts"].append(stage_usage.to_dict())
+    stage_record.update(summarize_stage(stage_record["attempts"]))
+    data["stages"][stage_usage.stage] = stage_record
+    data["updated_at"] = datetime.now().isoformat()
+
+    totals = summarize_usage(data)
+    data.update(totals)
+    usage_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    append_usage_history(data, project_root=project_root)
+    return data
+
+
+def summarize_usage(usage_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Calculate aggregate token/cost fields for a workspace usage dict."""
+    stages = usage_data.get("stages", {})
+    input_tokens = 0
+    output_tokens = 0
+    total_tokens = 0
+    reasoning_output_tokens = 0
+    cached_input_tokens = 0
+    cache_creation_input_tokens = 0
+    total_cost = 0.0
+    known_cost = False
+    known_tokens = False
+
+    for raw_stage in stages.values():
+        stage = _normalize_stage_record(raw_stage)
+        if stage.get("total_input_tokens") is not None:
+            input_tokens += int(stage["total_input_tokens"])
+            known_tokens = True
+        if stage.get("total_output_tokens") is not None:
+            output_tokens += int(stage["total_output_tokens"])
+            known_tokens = True
+        if stage.get("total_tokens") is not None:
+            total_tokens += int(stage["total_tokens"])
+            known_tokens = True
+        if stage.get("total_reasoning_output_tokens") is not None:
+            reasoning_output_tokens += int(stage["total_reasoning_output_tokens"])
+        if stage.get("total_cached_input_tokens") is not None:
+            cached_input_tokens += int(stage["total_cached_input_tokens"])
+        if stage.get("total_cache_creation_input_tokens") is not None:
+            cache_creation_input_tokens += int(stage["total_cache_creation_input_tokens"])
+        if stage.get("total_cost_usd") is not None:
+            total_cost += float(stage["total_cost_usd"])
+            known_cost = True
+
+    budget = usage_data.get("budget_usd")
+    budget_status = "unknown"
+    if budget is not None and known_cost:
+        budget_status = "exceeded" if total_cost >= float(budget) else "within_budget"
+    elif budget is not None:
+        budget_status = "unknown_cost"
+
+    return {
+        "total_input_tokens": input_tokens if known_tokens else None,
+        "total_output_tokens": output_tokens if known_tokens else None,
+        "total_reasoning_output_tokens": reasoning_output_tokens if reasoning_output_tokens else None,
+        "total_tokens": total_tokens if known_tokens else None,
+        "total_cached_input_tokens": cached_input_tokens if cached_input_tokens else None,
+        "total_cache_creation_input_tokens": cache_creation_input_tokens if cache_creation_input_tokens else None,
+        "total_cost_usd": round(total_cost, 6) if known_cost else None,
+        "budget_status": budget_status,
+        "providers": summarize_providers(usage_data),
+    }
+
+
+def summarize_stage(attempts: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Calculate aggregate usage for all attempts of one stage."""
+    input_tokens = 0
+    output_tokens = 0
+    total_tokens = 0
+    reasoning_output_tokens = 0
+    cached_input_tokens = 0
+    cache_creation_input_tokens = 0
+    total_cost = 0.0
+    known_tokens = False
+    known_cost = False
+
+    for attempt in attempts:
+        if attempt.get("input_tokens") is not None:
+            input_tokens += int(attempt["input_tokens"])
+            known_tokens = True
+        if attempt.get("output_tokens") is not None:
+            output_tokens += int(attempt["output_tokens"])
+            known_tokens = True
+        if attempt.get("total_tokens") is not None:
+            total_tokens += int(attempt["total_tokens"])
+            known_tokens = True
+        if attempt.get("reasoning_output_tokens") is not None:
+            reasoning_output_tokens += int(attempt["reasoning_output_tokens"])
+        if attempt.get("cached_input_tokens") is not None:
+            cached_input_tokens += int(attempt["cached_input_tokens"])
+        if attempt.get("cache_creation_input_tokens") is not None:
+            cache_creation_input_tokens += int(attempt["cache_creation_input_tokens"])
+        if attempt.get("estimated_cost_usd") is not None:
+            total_cost += float(attempt["estimated_cost_usd"])
+            known_cost = True
+
+    return {
+        "attempt_count": len(attempts),
+        "total_input_tokens": input_tokens if known_tokens else None,
+        "total_output_tokens": output_tokens if known_tokens else None,
+        "total_reasoning_output_tokens": reasoning_output_tokens if reasoning_output_tokens else None,
+        "total_tokens": total_tokens if known_tokens else None,
+        "total_cached_input_tokens": cached_input_tokens if cached_input_tokens else None,
+        "total_cache_creation_input_tokens": cache_creation_input_tokens if cache_creation_input_tokens else None,
+        "total_cost_usd": round(total_cost, 6) if known_cost else None,
+    }
+
+
+def summarize_providers(usage_data: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Calculate token/cost totals grouped by provider across stage attempts."""
+    providers: Dict[str, Dict[str, Any]] = {}
+    for raw_stage in usage_data.get("stages", {}).values():
+        stage = _normalize_stage_record(raw_stage)
+        for attempt in stage.get("attempts", []):
+            provider = attempt.get("provider")
+            if not provider:
+                continue
+            provider_record = providers.setdefault(
+                provider,
+                {
+                    "attempt_count": 0,
+                    "total_tokens": 0,
+                    "total_cost_usd": 0.0,
+                    "_known_tokens": False,
+                    "_known_cost": False,
+                },
+            )
+            provider_record["attempt_count"] += 1
+            if attempt.get("total_tokens") is not None:
+                provider_record["total_tokens"] += int(attempt["total_tokens"])
+                provider_record["_known_tokens"] = True
+            if attempt.get("estimated_cost_usd") is not None:
+                provider_record["total_cost_usd"] += float(attempt["estimated_cost_usd"])
+                provider_record["_known_cost"] = True
+
+    for provider_record in providers.values():
+        provider_record["total_tokens"] = (
+            provider_record["total_tokens"] if provider_record.pop("_known_tokens") else None
+        )
+        provider_record["total_cost_usd"] = (
+            round(provider_record["total_cost_usd"], 6)
+            if provider_record.pop("_known_cost")
+            else None
+        )
+    return providers
+
+
+def load_workspace_usage(work_dir: Path) -> Dict[str, Any]:
+    """Load ``.neurico/usage.json`` for a workspace, or return an empty dict."""
+    usage_file = Path(work_dir) / ".neurico" / USAGE_FILENAME
+    if not usage_file.exists():
+        return {}
+    try:
+        return json.loads(usage_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+
+def append_usage_history(
+    usage_data: Dict[str, Any],
+    project_root: Optional[Path] = None,
+) -> None:
+    """Append the latest workspace usage summary to ``logs/usage_history.jsonl``."""
+    if project_root is None:
+        project_root = Path(__file__).parent.parent.parent
+    history_dir = Path(project_root) / "logs"
+    history_dir.mkdir(parents=True, exist_ok=True)
+    history_file = history_dir / HISTORY_FILENAME
+
+    record = {
+        "recorded_at": datetime.now().isoformat(),
+        "idea_id": usage_data.get("idea_id"),
+        "title": usage_data.get("title"),
+        "provider": usage_data.get("provider"),
+        "workspace": usage_data.get("workspace"),
+        "budget_usd": usage_data.get("budget_usd"),
+        "total_tokens": usage_data.get("total_tokens"),
+        "total_cost_usd": usage_data.get("total_cost_usd"),
+        "budget_status": usage_data.get("budget_status"),
+        "providers": usage_data.get("providers", {}),
+        "stages": usage_data.get("stages", {}),
+    }
+    with open(history_file, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")
+
+
+def load_usage_history(project_root: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Load compact project-level usage history records."""
+    if project_root is None:
+        project_root = Path(__file__).parent.parent.parent
+    history_file = Path(project_root) / "logs" / HISTORY_FILENAME
+    if not history_file.exists():
+        return []
+    return list(_iter_json_lines(history_file))
+
+
+def check_budget_before_stage(
+    work_dir: Path,
+    idea: Dict[str, Any],
+    stage: str,
+) -> Dict[str, Any]:
+    """Return a budget guard decision before launching a stage."""
+    try:
+        budget = get_budget_usd(idea)
+    except ValueError as exc:
+        return {
+            "allowed": False,
+            "reason": f"Budget check failed before {stage}: {exc}.",
+            "budget_usd": None,
+            "spent_usd": None,
+            "remaining_usd": None,
+        }
+
+    usage = load_workspace_usage(work_dir)
+    spent = usage.get("total_cost_usd")
+    allowed = True
+    reason = ""
+
+    if budget is not None:
+        if budget <= 0:
+            allowed = False
+            reason = f"Budget exhausted before {stage}: budget is ${budget:.4f}."
+        elif spent is not None and float(spent) >= float(budget):
+            allowed = False
+            reason = (
+                f"Budget exhausted before {stage}: spent ${spent:.4f} "
+                f"of ${budget:.4f}."
+            )
+
+    return {
+        "allowed": allowed,
+        "reason": reason,
+        "budget_usd": budget,
+        "spent_usd": spent,
+        "remaining_usd": None if budget is None or spent is None else budget - spent,
+    }
+
+
+def budget_prompt_context(work_dir: Path, idea: Dict[str, Any]) -> str:
+    """Return a compact budget notice for agent prompts."""
+    budget = get_budget_usd(idea)
+    usage = load_workspace_usage(work_dir)
+    spent = usage.get("total_cost_usd")
+    remaining = None if spent is None else budget - float(spent)
+
+    lines = [
+        "BUDGET NOTICE:",
+        f"- Total run budget: ${budget:.4f}",
+    ]
+    if spent is None:
+        lines.append("- Spend so far: unknown because prior token usage was unavailable.")
+    else:
+        lines.append(f"- Estimated spend so far: ${spent:.4f}")
+        lines.append(f"- Estimated remaining budget: ${remaining:.4f}")
+        if remaining is not None and remaining <= 0:
+            lines.extend(
+                [
+                    "- The known budget is exhausted.",
+                    "- Avoid further model calls unless necessary to finish safely.",
+                    "- If tradeoffs are needed, document what was simplified because of budget.",
+                ]
+            )
+        elif remaining is not None and remaining <= (budget * 0.25) + 1e-9:
+            lines.extend(
+                [
+                    "- You are approaching the budget limit.",
+                    "- Prefer the simplest rigorous plan that can test the hypothesis.",
+                    "- Reduce unnecessary model calls, broad searches, huge samples, and long context.",
+                    "- If tradeoffs are needed, document what was simplified because of budget.",
+                ]
+            )
+    return "\n".join(lines)
+
+
+def format_budget_usd(value: Any) -> Optional[str]:
+    """Return a normalized USD budget string, or None when unavailable."""
+    budget = _coerce_float(value)
+    if budget is None:
+        return None
+    return f"${budget:.2f}"
+
+
+def format_usage_summary(usage_data: Dict[str, Any]) -> str:
+    """Format a human-readable usage summary."""
+    if not usage_data:
+        return "Cost summary unavailable: no usage data recorded."
+
+    lines = ["Cost summary"]
+    stages = usage_data.get("stages", {})
+    for stage_name in ("resource_finder", "experiment_runner", "paper_writer"):
+        stage = _normalize_stage_record(stages.get(stage_name))
+        if not stage:
+            continue
+        tokens = _fmt_int(stage.get("total_tokens"))
+        cost = _fmt_money(stage.get("total_cost_usd"))
+        attempts = stage.get("attempt_count", 0)
+        lines.append(f"  {stage_name:18s} {tokens:>12s} tokens  {cost:>12s}  ({attempts} attempts)")
+
+    providers = usage_data.get("providers") or summarize_providers(usage_data)
+    if providers:
+        lines.append("  by provider")
+        for provider_name in sorted(providers):
+            provider_record = providers[provider_name]
+            tokens = _fmt_int(provider_record.get("total_tokens"))
+            cost = _fmt_money(provider_record.get("total_cost_usd"))
+            attempts = provider_record.get("attempt_count", 0)
+            lines.append(f"    {provider_name:16s} {tokens:>12s} tokens  {cost:>12s}  ({attempts} attempts)")
+
+    total_tokens = _fmt_int(usage_data.get("total_tokens"))
+    total_cost = _fmt_money(usage_data.get("total_cost_usd"))
+    budget = usage_data.get("budget_usd")
+    if budget is None:
+        budget_text = "no budget set"
+    else:
+        budget_text = f"budget {_fmt_money(budget)}"
+    lines.append(f"  {'total':18s} {total_tokens:>12s} tokens  {total_cost:>12s}  ({budget_text})")
+    lines.append(f"  status: {usage_data.get('budget_status', 'unknown')}")
+    return "\n".join(lines)
+
+
+def _iter_json_lines(path: Path) -> Iterable[Dict[str, Any]]:
+    content = path.read_text(encoding="utf-8", errors="replace")
+    stripped_content = content.strip()
+    if stripped_content:
+        try:
+            parsed = json.loads(stripped_content)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            yield parsed
+            return
+        if isinstance(parsed, list):
+            for item in parsed:
+                if isinstance(item, dict):
+                    yield item
+            return
+
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or not stripped.startswith("{"):
+            continue
+        try:
+            event = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            yield event
+
+
+def _normalize_stage_record(raw_stage: Any) -> Dict[str, Any]:
+    """Return a stage record in the current attempts-based shape.
+
+    Older usage files stored a single StageUsage dict at ``stages.<stage>``.
+    This keeps those files readable and allows the next update to migrate them.
+    """
+    if not isinstance(raw_stage, dict):
+        return {}
+    if "attempts" in raw_stage and isinstance(raw_stage.get("attempts"), list):
+        normalized = dict(raw_stage)
+        normalized.update(summarize_stage(normalized["attempts"]))
+        return normalized
+
+    if {"stage", "provider"} <= set(raw_stage):
+        attempts = [raw_stage]
+        normalized = {"attempts": attempts}
+        normalized.update(summarize_stage(attempts))
+        return normalized
+
+    return raw_stage
+
+
+def _parse_claude_usage(events: Iterable[Dict[str, Any]], usage: StageUsage) -> StageUsage:
+    """Parse Claude Code official cost-tracking result fields."""
+    for event in events:
+        model_usage = event.get("modelUsage")
+        if isinstance(model_usage, dict) and model_usage:
+            usage.model_usage = {}
+            input_tokens = 0
+            output_tokens = 0
+            cached_input_tokens = 0
+            cache_creation_input_tokens = 0
+            total_cost = 0.0
+            known_cost = False
+
+            for model_name, model_record in model_usage.items():
+                if not isinstance(model_name, str) or not isinstance(model_record, dict):
+                    continue
+
+                model_input = _first_int(model_record, "inputTokens") or 0
+                model_output = _first_int(model_record, "outputTokens") or 0
+                model_cache_read = _first_int(model_record, "cacheReadInputTokens") or 0
+                model_cache_creation = _first_int(model_record, "cacheCreationInputTokens") or 0
+                model_cost = _first_float(model_record, "costUSD")
+
+                input_tokens += model_input
+                output_tokens += model_output
+                cached_input_tokens += model_cache_read
+                cache_creation_input_tokens += model_cache_creation
+                if model_cost is not None:
+                    total_cost += model_cost
+                    known_cost = True
+
+                usage.model_usage[model_name] = {
+                    "input_tokens": model_input or None,
+                    "output_tokens": model_output or None,
+                    "cached_input_tokens": model_cache_read or None,
+                    "cache_creation_input_tokens": model_cache_creation or None,
+                    "estimated_cost_usd": round(model_cost, 6) if model_cost is not None else None,
+                    "pricing_source": "provider_model_usage",
+                }
+
+            if usage.model_usage:
+                usage.input_tokens = input_tokens or None
+                usage.output_tokens = output_tokens or None
+                usage.cached_input_tokens = cached_input_tokens or None
+                usage.cache_creation_input_tokens = cache_creation_input_tokens or None
+                usage.total_tokens = (
+                    input_tokens
+                    + output_tokens
+                    + cached_input_tokens
+                    + cache_creation_input_tokens
+                ) or None
+                usage.estimated_cost_usd = round(total_cost, 6) if known_cost else None
+                usage.token_source = "claude_model_usage"
+                usage.pricing_source = "provider_model_usage" if known_cost else "unknown_cost"
+                if len(usage.model_usage) == 1:
+                    usage.model = next(iter(usage.model_usage))
+                return usage
+
+        total_cost = _first_float(event, "total_cost_usd")
+        if total_cost is not None:
+            usage.estimated_cost_usd = round(total_cost, 6)
+            usage.token_source = "provider_total_cost"
+            usage.pricing_source = "provider_total_cost"
+            return usage
+
+    return usage
+
+
+def _parse_gemini_usage(events: Iterable[Dict[str, Any]], usage: StageUsage) -> StageUsage:
+    """Parse Gemini CLI headless JSON and stream-json stats fields."""
+    for event in events:
+        stats = event.get("stats")
+        if not isinstance(stats, dict):
+            continue
+        models = stats.get("models")
+        if not isinstance(models, dict) or not models:
+            continue
+
+        usage.model_usage = {}
+        input_tokens = 0
+        output_tokens = 0
+        total_tokens = 0
+        cached_input_tokens = 0
+        total_cost = 0.0
+        known_cost = False
+
+        for model_name, model_record in models.items():
+            if not isinstance(model_name, str) or not isinstance(model_record, dict):
+                continue
+            tokens = model_record.get("tokens")
+            if isinstance(tokens, dict):
+                prompt_tokens_raw = _first_int(tokens, "prompt")
+                candidate_tokens_raw = _first_int(tokens, "candidates")
+                thought_tokens_raw = _first_int(tokens, "thoughts")
+                model_cached_tokens_raw = _first_int(tokens, "cached")
+                model_total_tokens = _first_int(tokens, "total")
+                model_output_tokens_raw = None
+                token_source = "gemini_stats_models"
+            else:
+                # Gemini stream-json result stats use flattened per-model fields:
+                # stats.models[model].{total_tokens,input_tokens,output_tokens,cached,input}
+                prompt_tokens_raw = _first_int(model_record, "input_tokens")
+                model_output_tokens_raw = _first_int(model_record, "output_tokens")
+                candidate_tokens_raw = None
+                thought_tokens_raw = None
+                model_cached_tokens_raw = _first_int(model_record, "cached")
+                model_total_tokens = _first_int(model_record, "total_tokens")
+                token_source = "gemini_stream_json_stats"
+
+            if (
+                prompt_tokens_raw is None
+                and candidate_tokens_raw is None
+                and thought_tokens_raw is None
+                and model_output_tokens_raw is None
+                and model_cached_tokens_raw is None
+                and model_total_tokens is None
+            ):
+                continue
+
+            prompt_tokens = prompt_tokens_raw or 0
+            candidate_tokens = candidate_tokens_raw or 0
+            thought_tokens = thought_tokens_raw or 0
+            model_cached_tokens = model_cached_tokens_raw or 0
+            model_output_tokens = model_output_tokens_raw or (candidate_tokens + thought_tokens)
+
+            model_cost = estimate_cost_usd(
+                "gemini",
+                prompt_tokens,
+                model_output_tokens,
+                cached_input_tokens=model_cached_tokens,
+                model=model_name,
+            )
+
+            input_tokens += prompt_tokens
+            output_tokens += model_output_tokens
+            cached_input_tokens += model_cached_tokens
+            total_tokens += model_total_tokens or (prompt_tokens + model_output_tokens)
+            if model_cost is not None:
+                total_cost += model_cost
+                known_cost = True
+
+            usage.model_usage[model_name] = {
+                "input_tokens": prompt_tokens or None,
+                "output_tokens": model_output_tokens or None,
+                "total_tokens": model_total_tokens,
+                "cached_input_tokens": model_cached_tokens or None,
+                "estimated_cost_usd": model_cost,
+                "pricing_source": (
+                    "estimated_from_gemini_stats_model"
+                    if model_cost is not None
+                    else "unknown_model"
+                ),
+                "token_source": token_source,
+            }
+
+        if usage.model_usage:
+            usage.input_tokens = input_tokens or None
+            usage.output_tokens = output_tokens or None
+            usage.cached_input_tokens = cached_input_tokens or None
+            usage.total_tokens = total_tokens or None
+            usage.estimated_cost_usd = round(total_cost, 6) if known_cost else None
+            sources = {
+                record.get("token_source")
+                for record in usage.model_usage.values()
+                if isinstance(record, dict)
+            }
+            usage.token_source = sources.pop() if len(sources) == 1 else "gemini_stats_models"
+            usage.pricing_source = "estimated_from_gemini_stats_models" if known_cost else "unknown_model"
+            if len(usage.model_usage) == 1:
+                usage.model = next(iter(usage.model_usage))
+            return usage
+
+    return usage
+
+
+def _parse_codex_usage(events: Iterable[Dict[str, Any]], usage: StageUsage) -> StageUsage:
+    """Parse Codex exec turn.completed usage fields; cost remains unknown."""
+    input_tokens = 0
+    output_tokens = 0
+    reasoning_output_tokens = 0
+    cached_input_tokens = 0
+    saw_any = False
+
+    for event in events:
+        if event.get("type") != "turn.completed":
+            continue
+        event_usage = event.get("usage")
+        if not isinstance(event_usage, dict):
+            continue
+        in_tokens = _first_int(event_usage, "input_tokens")
+        cached_tokens = _first_int(event_usage, "cached_input_tokens")
+        out_tokens = _first_int(event_usage, "output_tokens")
+        reasoning_tokens = _first_int(event_usage, "reasoning_output_tokens")
+        if (
+            in_tokens is None
+            and cached_tokens is None
+            and out_tokens is None
+            and reasoning_tokens is None
+        ):
+            continue
+
+        saw_any = True
+        input_tokens += in_tokens or 0
+        cached_input_tokens += cached_tokens or 0
+        output_tokens += out_tokens or 0
+        reasoning_output_tokens += reasoning_tokens or 0
+
+    if saw_any:
+        usage.input_tokens = input_tokens or None
+        usage.output_tokens = output_tokens or None
+        usage.reasoning_output_tokens = reasoning_output_tokens or None
+        usage.cached_input_tokens = cached_input_tokens or None
+        usage.total_tokens = (input_tokens + output_tokens) or None
+        usage.estimated_cost_usd = None
+        usage.token_source = "codex_turn_completed_usage"
+        usage.pricing_source = "unknown_model"
+
+    return usage
+
+
+def _first_int(data: Dict[str, Any], *keys: str) -> Optional[int]:
+    for key in keys:
+        raw = data.get(key)
+        if isinstance(raw, bool):
+            continue
+        if isinstance(raw, int):
+            return raw
+        if isinstance(raw, float):
+            return int(raw)
+        if isinstance(raw, str):
+            try:
+                return int(raw)
+            except ValueError:
+                continue
+    return None
+
+
+def _first_float(data: Dict[str, Any], *keys: str) -> Optional[float]:
+    for key in keys:
+        raw = data.get(key)
+        if isinstance(raw, bool):
+            continue
+        if isinstance(raw, (int, float)):
+            return float(raw)
+        if isinstance(raw, str):
+            try:
+                return float(raw)
+            except ValueError:
+                continue
+    return None
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        normalized = value.strip()
+        if normalized.startswith("$"):
+            normalized = normalized[1:].strip()
+        normalized = normalized.replace(",", "")
+        if normalized.upper().endswith("USD"):
+            normalized = normalized[:-3].strip()
+        try:
+            return float(normalized)
+        except ValueError:
+            return None
+    return None
+
+
+def _fmt_int(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    return f"{int(value):,}"
+
+
+def _fmt_money(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    return f"${float(value):.4f}"

--- a/src/templates/prompt_generator.py
+++ b/src/templates/prompt_generator.py
@@ -10,12 +10,13 @@ This module generates complete prompts for research agents by:
 from pathlib import Path
 from typing import Dict, Any, Optional
 import yaml
-from jinja2 import Environment, FileSystemLoader, Template
+from jinja2 import Environment, FileSystemLoader
 import sys
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from core.config_loader import ConfigLoader, normalize_domain
+from core.usage_tracker import format_budget_usd
 
 
 class PromptGenerator:
@@ -159,7 +160,7 @@ class PromptGenerator:
                 domain_template = self.load_template(default_template_path)
             except FileNotFoundError:
                 # Ultimate fallback: no domain-specific guidance
-                print(f"⚠️  No domain templates available, using base template only")
+                print("⚠️  No domain templates available, using base template only")
                 domain_template = ""
 
         # Prepare variables for template rendering
@@ -346,7 +347,7 @@ Location: {run_dir}
                         desc = repo.get('description', 'Code repository')
                         lines.append(f"- **{desc}**")
                         lines.append(f"  - URL: {repo_url}")
-                        lines.append(f"  - ACTION REQUIRED: Clone this repository and explore its capabilities")
+                        lines.append("  - ACTION REQUIRED: Clone this repository and explore its capabilities")
                     else:
                         lines.append(f"- {repo}")
                 lines.append("")
@@ -389,7 +390,8 @@ Location: {run_dir}
                 lines.append(f"- **Memory**: {constraints['memory']}")
 
             if 'budget' in constraints:
-                lines.append(f"- **Budget**: ${constraints['budget']:.2f}")
+                budget = format_budget_usd(constraints['budget'])
+                lines.append(f"- **Budget**: {budget or constraints['budget']}")
 
             if 'dependencies' in constraints and constraints['dependencies']:
                 lines.append(f"- **Dependencies**: {', '.join(constraints['dependencies'])}")
@@ -698,7 +700,7 @@ RESEARCH DOMAIN:
                         desc = repo.get('description', 'Code repository')
                         research_context += f"- {desc}\n"
                         research_context += f"  URL: {repo_url}\n"
-                        research_context += f"  → You MUST clone this repository to code/ directory\n"
+                        research_context += "  → You MUST clone this repository to code/ directory\n"
                     else:
                         research_context += f"- {repo}\n"
                 research_context += "\nThese are NOT optional - they are specified by the research author.\n"


### PR DESCRIPTION
**Summary**

This PR fixes ChicagoHAI/NeuriCo#47 by implementing budget control and cost tracking for NeuriCo runs.

**Track Token Usage Per Stage**

This PR tracks usage for the three roadmap stages:

- `resource_finder`
- `experiment_runner`
- `paper_writer`

Each stage already writes a provider transcript. NeuriCo now parses those existing structured JSON streams instead of asking the agent to self-report usage. Each parsed transcript is recorded as a stage attempt, and usage is aggregated by stage and provider for the idea run.

**Show Cost Summary After Each Run**

After tracked stages complete, NeuriCo prints a cost summary directly in the run output.

```text
Cost summary
  resource_finder           1,100 tokens       $0.0040  (1 attempts)
  experiment_runner         6,200 tokens       $0.0028  (2 attempts)
  paper_writer                120 tokens       unknown  (1 attempts)
  by provider
    claude                  1,100 tokens       $0.0040  (1 attempts)
    codex                   4,200 tokens       unknown  (1 attempts)
    gemini                  2,120 tokens       $0.0028  (2 attempts)
  total                     7,420 tokens       $0.0068  (budget $0.0100)
  status: within_budget
```

Cost is only recorded when the transcript provides enough information:

- **Claude:** uses provider-reported tokens and cost from `modelUsage` / `total_cost_usd`.
- **Codex:** records tokens from `turn.completed.usage`, but leaves cost unknown because the transcript does not report model or cost.
- **Gemini:** records tokens from `--output-format stream-json` result stats and estimates cost only when the reported model is known.

**Enforce `constraints.budget`**

This PR enforces `constraints.budget` at runtime before launching tracked stages.

Expected budget format:

```yaml
constraints:
  budget: "$50"
```

Numeric values such as `50` are also accepted for compatibility.

Missing, invalid, or exhausted budgets block stage execution before launching the agent. Existing idea YAML files are not modified by this PR. Budget enforcement applies per idea run across all recorded stages and attempts.

**Add Usage History Command**

The roadmap names this command as `./idea-explorer usage`, but this repo’s CLI entrypoint is `./neurico`.

This PR implements:

```bash
./neurico usage
```

Example output:

```text
NeuriCo usage history
Idea: idea-smoke
  title: Synthetic budget smoke
  workspace: /path/to/workspaces/idea_run
  budget: $0.0100
  status: within_budget
  total_tokens: 7,420
  total_cost: $0.0068
  providers:
    - claude: attempts=1, tokens=1,100, cost=$0.0040
    - codex: attempts=1, tokens=4,200, cost=unknown
    - gemini: attempts=2, tokens=2,120, cost=$0.0028
  stages:
    - resource_finder: attempts=1, tokens=1,100, cost=$0.0040
        attempt 1: provider=claude, model=claude-sonnet-4-5, tokens=1,100, cost=$0.0040
    - experiment_runner: attempts=2, tokens=6,200, cost=$0.0028
        attempt 1: provider=codex, model=unknown, tokens=4,200, cost=unknown
        attempt 2: provider=gemini, model=gemini-2.5-flash, tokens=2,000, cost=$0.0028
    - paper_writer: attempts=1, tokens=120, cost=unknown
        attempt 1: provider=gemini, model=gemini-future-model, tokens=120, cost=unknown
```

Useful command options:

```bash
./neurico usage --json
./neurico usage --idea-id <idea_id>
./neurico usage --limit 10
./neurico usage --idea-id <idea_id> --json
./neurico usage --idea-id <idea_id> --limit 5
```

`./neurico usage --json` prints raw structured usage-history records for debugging, scripting, or inspecting full stage, attempt, and provider details.

`./neurico usage --idea-id <idea_id>` filters usage history to records matching a specific idea ID.

`./neurico usage --limit 10` shows only the latest 10 recorded run summaries after filtering and deduplicating by working directory. The default limit is 20.

`./neurico usage` reads repo-level `logs/usage_history.jsonl`. Raw per-run usage state is stored in each idea run’s `.neurico/usage.json`.

**Add Budget-Aware Prompting**

When known spend approaches or exceeds the idea budget, NeuriCo injects a compact budget notice into later agent prompts.

The prompt tells the agent to simplify its plan by reducing unnecessary model calls, broad searches, huge samples, and long context, and to document any budget-driven tradeoffs.

**Documentation**

`docs/USAGE_TRACKING_TRANSCRIPTS.md` documents the provider transcript structures and official references used by the parser.

**What I Have Learned**

**Transcript formats are part of the system contract.**

Each provider exposes usage through a different transcript structure, so the tracker has to respect the provider-specific contract instead of using one generic parser.

Claude reports provider-computed cost, Codex reports token usage without model or cost, and Gemini reports token usage with model names. The safest design is to record what the transcript actually contains and leave cost unknown when the transcript does not provide enough information.

**Budget enforcement depends on recorded run state.**

`constraints.budget` is defined in the idea YAML, but spend accumulates across the whole idea run: resource finding, experiment execution, paper writing, and any repeated attempts. Enforcing the budget correctly means checking accumulated recorded usage before launching the next tracked stage.

This also means budget enforcement should not guess missing costs. Unknown-cost attempts remain visible in the usage record, while known costs are used for budget checks.

**Research Questions**

**How should NeuriCo estimate cost before running an idea?**

A useful cost estimate should combine static idea complexity with empirical usage from past runs.

Before enough run history exists, NeuriCo can score idea complexity using features such as resource difficulty, implementation difficulty, experiment size, debug risk, writing burden, and context burden. For example, an idea with an unclear dataset, many baselines, multiple seeds, and a large writing burden should be classified as higher risk than a small single-dataset baseline comparison.

After enough instrumented runs are collected, NeuriCo can replace simple heuristics with empirical estimates. A practical target is P80 or P90 stage cost rather than average cost, because agent runs often have long-tail failures from debugging loops, repeated tool calls, or large context growth.

**How should budget be split across stages?**

The split should adapt by idea type. Known-dataset benchmark ideas can spend more on experiments. Novel-domain ideas may need more resource-finding budget. Paper-heavy or theory-heavy ideas may need more writing budget. Very tight budgets should prioritize one minimal executable experiment over broad searches, many baselines, or polished writing.

**What should NeuriCo do when budget is tight?**

The downgrade order might be:

- **Simplify experiments first.** Reduce datasets, baselines, seeds, hyperparameter sweeps, epochs, and ablations while preserving one runnable core experiment.
- **Compress context carefully.** Use summaries, state files, and curated resources instead of blindly passing longer context.
- **Cut late-stage polish last.** Skip extended literature expansion, extra ablations, review loops, and paper polish before skipping the core research loop.

Realistically, downgrade order should also depend on idea type and historical run data. Further experimentation is needed to empirically compare different downgrade orders.