### PR TITLE
Feature/interactive mode

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1674,6 +1674,8 @@ cmd__run_agent() {
     echo -e "${BLUE}Running agent: $1${NC}"
     echo -e "${BLUE}Workspace:${NC} $workspace_dir -> /workspaces"
 
+    local quoted_args
+    quoted_args=$(printf ' %q' "$@")
     eval "docker run --rm \
         $gpu_flags \
         $user_flags \
@@ -1687,7 +1689,7 @@ cmd__run_agent() {
         $credential_mounts \
         -w /app \
         \"$IMAGE_NAME\" \
-        python /app/src/core/agent_runner.py $@"
+        python /app/src/core/agent_runner.py$quoted_args"
 }
 
 # -----------------------------------------------------------------------------

--- a/src/core/agent_runner.py
+++ b/src/core/agent_runner.py
@@ -491,6 +491,11 @@ def main():
 
     work_dir = Path(args.workspace)
 
+    if not work_dir.exists():
+        print(f"Error: workspace path does not exist inside the container: {work_dir}")
+        print(f"Expected a path under /workspaces/, e.g. /workspaces/{work_dir.name}")
+        sys.exit(1)
+
     # Build kwargs based on agent type
     kwargs = {
         'full_permissions': args.full_permissions,

--- a/src/interactive/tools.py
+++ b/src/interactive/tools.py
@@ -318,6 +318,18 @@ class ToolExecutor:
         open_questions = args.get("open_questions")
         phase = args.get("phase")
 
+        # CLI backend LLM sometimes serializes arrays as JSON-encoded strings
+        if isinstance(key_findings, str):
+            try:
+                key_findings = json.loads(key_findings)
+            except (json.JSONDecodeError, ValueError):
+                key_findings = [key_findings]
+        if isinstance(open_questions, str):
+            try:
+                open_questions = json.loads(open_questions)
+            except (json.JSONDecodeError, ValueError):
+                open_questions = [open_questions]
+
         self.session.update_findings(
             key_findings=key_findings,
             open_questions=open_questions,

--- a/src/interactive/tools.py
+++ b/src/interactive/tools.py
@@ -78,14 +78,32 @@ class ToolExecutor:
         provider = args.get("provider", self.provider)
         run_id = self.session.generate_run_id(agent_name)
 
+        # Translate host paths to container paths before passing to Docker.
+        # The manager runs on the host where paths look like /mnt/d/.../workspaces/my_idea
+        # (WSL) or /Users/.../workspaces/my_idea (macOS). Inside Docker only /workspaces/
+        # and /app/ are mounted — the host prefix does not exist in the container.
+        workspace_base = Path(os.environ.get("NEURICO_WORKSPACE_DIR", str(self.work_dir.parent)))
+        work_rel = self.work_dir.relative_to(workspace_base)
+        container_work_dir = Path("/workspaces") / work_rel
+
+        # idea_file may have moved from ideas/submitted/ to ideas/in_progress/ after
+        # manager startup; resolve against project_root to get the current location.
+        idea_file = self.idea_file
+        if not idea_file.exists():
+            in_progress = self.project_root / "ideas" / "in_progress" / idea_file.name
+            if in_progress.exists():
+                idea_file = in_progress
+        idea_rel = idea_file.relative_to(self.project_root)
+        container_idea_file = Path("/app") / idea_rel
+
         # Build the Docker command via ./neurico _run-agent
         neurico_cmd = str(self.project_root / "neurico")
         cmd_parts = [
             neurico_cmd, "_run-agent", agent_name,
-            "--workspace", str(self.work_dir),
+            "--workspace", str(container_work_dir),
             "--provider", provider,
             "--run-id", run_id,
-            "--idea-file", str(self.idea_file),
+            "--idea-file", str(container_idea_file),
         ]
 
         # Agent-specific args

--- a/src/interactive/tools.py
+++ b/src/interactive/tools.py
@@ -254,6 +254,13 @@ class ToolExecutor:
         message = args.get("message", "")
         options = args.get("options", [])
 
+        # CLI backend LLM sometimes serializes arrays as JSON-encoded strings
+        if isinstance(options, str):
+            try:
+                options = json.loads(options)
+            except (json.JSONDecodeError, ValueError):
+                options = [options]
+
         print()
         print("=" * 70)
         print(message)

--- a/templates/manager/system_prompt.txt
+++ b/templates/manager/system_prompt.txt
@@ -20,7 +20,18 @@ Your ONLY available tools are exactly these five:
 - `ask_user` — present a message or question to the human and wait for their response
 - `update_session` — save key findings, open questions, or phase to session state
 
-You do NOT have access to `Bash`, `Read`, `Write`, `Edit`, `Grep`, `Glob`, `Agent`, `ToolSearch`, or any other Claude Code built-in tool. Do not call them — they will always fail with an error. If you need to read a file in the workspace, use `check_workspace` with action="read". If you need to run a command, use `run_agent` to delegate to an agent.
+You do NOT have access to `Bash`, `Read`, `Write`, `Edit`, `Grep`, `Glob`, `Agent`, `ToolSearch`, `AskUserQuestion`, or any other Claude Code built-in tool. Do not call them — they will always fail with an error.
+
+You may be aware that you are running inside a Claude Code environment which normally provides tools like `Bash`, `Read`, and `Glob`. Those tools are NOT available to you in this context. They have been intentionally disabled. Calling them will produce an error every single time — there is no workaround.
+
+The substitutes for common operations are:
+- Need to read a file → use `check_workspace` with `action="read"`
+- Need to list directory contents → use `check_workspace` with `action="list"`
+- Need to run a shell command or script → use `run_agent` to delegate to an agent inside Docker
+- Need to ask the user something → use `ask_user` (NOT `AskUserQuestion`, which also does not exist here)
+- Need to check agent status or logs → use `read_agent_logs`
+
+If you find yourself wanting to call any tool not in the list of five above, stop and identify which of the five is the correct substitute.
 
 ## Critical Rules — Violations Break the Session
 
@@ -32,6 +43,9 @@ Any question or decision you present to the human MUST go through the `ask_user`
 
 **Rule 3: Verify before reporting.**
 Before calling `update_session` with findings or telling the user work is complete, call `check_workspace` to confirm the expected output files actually exist. Never report results you have not verified with a real tool call.
+
+**Rule 4: Never call a tool that is not one of the five listed above.**
+If a tool call fails with "Unknown tool", do NOT retry the same tool with different arguments, do NOT try a similar tool name, and do NOT fall back to writing the answer as plain text. Instead, identify which of the five available tools is the correct substitute and use that. Repeated unknown-tool errors mean you are calling the wrong tool — stop and reconsider.
 
 ## How You Work
 

--- a/templates/manager/system_prompt.txt
+++ b/templates/manager/system_prompt.txt
@@ -11,6 +11,17 @@ You are a research collaborator, not an autonomous pipeline. You:
 
 The human provides domain expertise, judgment, and research taste. You provide execution capability, thoroughness, and synthesis.
 
+## Your Tools — READ THIS CAREFULLY
+
+Your ONLY available tools are exactly these five:
+- `run_agent` — launch a research agent inside Docker
+- `check_workspace` — list or read files in the workspace (use action="read" to read a file)
+- `read_agent_logs` — read logs and status for a running or completed agent run
+- `ask_user` — present a message or question to the human and wait for their response
+- `update_session` — save key findings, open questions, or phase to session state
+
+You do NOT have access to `Bash`, `Read`, `Write`, `Edit`, `Grep`, `Glob`, `Agent`, `ToolSearch`, or any other Claude Code built-in tool. Do not call them — they will always fail with an error. If you need to read a file in the workspace, use `check_workspace` with action="read". If you need to run a command, use `run_agent` to delegate to an agent.
+
 ## How You Work
 
 You have access to tools that let you run research agents inside a Docker container, inspect the workspace, and communicate with the human. The research agents do the heavy lifting (literature search, coding experiments, writing papers). Your job is to orchestrate them intelligently.

--- a/templates/manager/system_prompt.txt
+++ b/templates/manager/system_prompt.txt
@@ -22,6 +22,17 @@ Your ONLY available tools are exactly these five:
 
 You do NOT have access to `Bash`, `Read`, `Write`, `Edit`, `Grep`, `Glob`, `Agent`, `ToolSearch`, or any other Claude Code built-in tool. Do not call them — they will always fail with an error. If you need to read a file in the workspace, use `check_workspace` with action="read". If you need to run a command, use `run_agent` to delegate to an agent.
 
+## Critical Rules — Violations Break the Session
+
+**Rule 1: Never generate tool results yourself.**
+Tool results are provided to you by the system after you make a tool call. Never write `<tool_result>`, `<tool-result>`, or any similar block in your response text. If you generate fake tool results, they will be stored as real history and corrupt every subsequent turn. Only write `<tool_call>` blocks to invoke tools — never fabricate what the result will be.
+
+**Rule 2: Never ask the user questions in plain text.**
+Any question or decision you present to the human MUST go through the `ask_user` tool. Do not write questions like "Which would you prefer?" or "Shall I proceed?" directly in your response text — the human cannot respond to plain text in this interface. If you need a decision, call `ask_user`. If you have nothing to ask and no tool to call, say what you observed and wait.
+
+**Rule 3: Verify before reporting.**
+Before calling `update_session` with findings or telling the user work is complete, call `check_workspace` to confirm the expected output files actually exist. Never report results you have not verified with a real tool call.
+
 ## How You Work
 
 You have access to tools that let you run research agents inside a Docker container, inspect the workspace, and communicate with the human. The research agents do the heavy lifting (literature search, coding experiments, writing papers). Your job is to orchestrate them intelligently.
@@ -35,7 +46,7 @@ Do not follow a rigid pipeline. Adapt to what the research needs.
 
 ## When to Engage the Human
 
-Use the `ask_user` tool when:
+Always use the `ask_user` tool — never ask questions in plain text. Use it when:
 - An agent has completed and you need to decide whether to proceed, iterate, or pivot
 - You encounter an unexpected result or failure that could go multiple ways
 - The research direction would benefit from the human's domain expertise


### PR DESCRIPTION
Related to #102 
## Summary

- Fix silent data loss where experiment runner writes to Docker ephemeral layer instead of the bind-mounted workspace
- Fix array parameters (`key_findings`, `open_questions`, `options`) being stored as character arrays in `manager_session.json`
- Fix `agent_runner.py` argument parsing breaking on project paths that contain spaces
- Strengthen system prompt to reduce manager hallucination and incorrect tool usage