### PR TITLE
feat(interactive): manager world model + research whiteboard

### DIFF
--- a/INTERACTIVE_MODE_GUIDE.md
+++ b/INTERACTIVE_MODE_GUIDE.md
@@ -1,0 +1,201 @@
+# NeuriCo Interactive Mode — How to Run It
+
+A practical, step-by-step guide to running NeuriCo's **interactive mode** — the
+LLM-driven manager that plans research, runs agents for you, and stops to ask
+*you* at the important decision points. By default it opens a **browser UI**
+(chat with the manager, a live **Research** whiteboard of the manager's working
+model, and the agent transcript); a `--cli` flag falls back to the terminal.
+
+> All commands below are run from inside the project folder:
+> `NeuriCo-interactive/` (the folder that contains the `./neurico` script).
+> ```bash
+> cd "NeuriCo-interactive"
+> ```
+
+---
+
+## 1. What interactive mode is (and how it differs from auto mode)
+
+| | **Auto mode** (`./neurico run`) | **Interactive mode** (`./neurico interactive`) |
+|---|---|---|
+| Who drives | Fully autonomous, runs end-to-end | An LLM **manager** plans and runs agents, but pauses to ask you |
+| You interact | No | Yes — answer questions, steer scope, interrupt anytime |
+| Interface | Terminal logs | **Browser UI** by default (chat + live transcript); `--cli` for terminal |
+| Output | `workspaces/<ws>/logs/*.jsonl` | Same logs, shown live in the browser's agent-transcript pane |
+
+The manager itself runs **on your computer** (the host). Each research **agent**
+it launches (resource finder, experiment runner, paper writer) runs **inside
+Docker**.
+
+---
+
+## 2. One-time prerequisites
+
+You only do these once.
+
+1. **Docker** installed and running (Docker Desktop on Mac/Windows).
+2. **Python 3.10+** on your computer (the manager runs on the host, not in Docker).
+3. **Log in to your AI provider** (e.g. Claude) so the agents can call it:
+   ```bash
+   ./neurico login          # opens a browser sign-in; credentials are saved
+   ```
+   Or run the guided wizard, which also pulls the Docker image:
+   ```bash
+   ./neurico setup --quick
+   ```
+4. **Make sure the agent code is in the container.** Interactive mode runs a
+   newer file (`agent_runner.py`) inside Docker. Pick **one**:
+   - **Recommended for development** — the project already mounts your live
+     `src/` into the container (the `-v "$PROJECT_ROOT/src:/app/src:ro"` line in
+     `docker/run.sh`), so your current code is always used. Nothing to do.
+   - **Otherwise** — rebuild the image so the file is baked in:
+     ```bash
+     ./neurico build
+     ```
+   > If you skip both, agents crash instantly with
+   > `can't open file '/app/src/core/agent_runner.py'` and you'll see **no
+   > logs/transcripts** (see Troubleshooting).
+
+---
+
+## 3. Run it (the two steps)
+
+### Step A — Get an idea ID
+
+Interactive mode needs an **idea ID**. Submit an idea file to create one:
+
+```bash
+./neurico submit ideas/examples/titanic_survival_prediction.yaml
+```
+
+This prints a line with the generated ID — note it includes a timestamp and hash:
+
+```
+Idea ID: titanic_survival_prediction_20260606_213145_67d058cf
+```
+
+**Copy that full ID** — you'll paste it into the next step. (Built-in examples
+live in `ideas/examples/`; you can also write your own `.yaml` or fetch one with
+`./neurico fetch <ideahub_url> --submit`.)
+
+### Step B — Start interactive mode
+
+Use the **full ID** that `submit` printed:
+
+```bash
+# replace with the ID from Step A (yours will have a different timestamp/hash)
+./neurico interactive titanic_survival_prediction_20260606_213145_67d058cf --provider claude
+```
+
+This:
+- starts the manager on your computer,
+- opens **http://localhost:7890** in your browser,
+- shows the manager's chat on the left; the right pane is tabbed between
+  **🔬 Research** (the manager's live working model — hypotheses, the current
+  crux, decisions, and its latest read on whether to involve you) and
+  **⚙️ Activity** (the live agent transcript).
+
+Talk to the manager in the browser. When it asks a question, type an answer or
+click an option button. You can type at **any time** — even while an agent is
+running — to redirect it. Watch the **🔬 Research** tab fill in as the manager
+works — that's how you see *what it believes and why*, not just what it's doing.
+
+---
+
+## 4. Command reference
+
+```bash
+./neurico interactive <idea_id> [options]
+```
+
+| Option | Default | What it does |
+|---|---|---|
+| `--provider {claude\|codex\|gemini}` | from config | Which AI runs the research agents |
+| `--engagement {hands_off\|balanced\|hands_on}` | from config | How often the manager interrupts you |
+| `--cli` | off (web is default) | Use the **terminal** interface instead of the browser |
+| `--port N` | `7890` | Port for the web UI (auto-retries if taken) |
+| `--no-browser` | off | Start the web server but don't auto-open the browser |
+| `--backend {cli\|anthropic_api\|openrouter}` | from config | Which backend powers the manager's own reasoning |
+
+**Examples** (`<idea_id>` is the full ID that `submit` printed, e.g.
+`titanic_survival_prediction_20260606_213145_67d058cf`)
+
+```bash
+# Browser UI (default)
+./neurico interactive <idea_id> --provider claude
+
+# Pick a different port and don't auto-open the browser
+./neurico interactive <idea_id> --port 7895 --no-browser
+
+# Old-school terminal interface
+./neurico interactive <idea_id> --cli
+```
+
+---
+
+## 5. Where the output goes
+
+Everything for a run lives under its workspace:
+
+```
+workspaces/<idea>_<timestamp>_<hash>_interactive/
+├── logs/                         # agent logs + transcripts (what the web view shows)
+│   ├── resource_finder_claude.log
+│   ├── resource_finder_claude_transcript.jsonl
+│   └── ...
+└── .neurico/                     # manager session state
+    ├── manager_conversation.jsonl
+    ├── manager_session.json
+    ├── research_state.json        # the manager's world model (powers the 🔬 Research tab)
+    └── runs/<run_id>/manager_stdout.log
+```
+
+---
+
+## 6. Troubleshooting
+
+**The browser shows the chat but the agent transcript stays empty / agents "fail."**
+The agent is crashing before it runs. Check its log:
+the manager will report an exit code; look at
+`workspaces/<ws>/.neurico/runs/<run_id>/manager_stdout.log`.
+If you see:
+```
+python: can't open file '/app/src/core/agent_runner.py': No such file or directory
+```
+the container doesn't have the agent code. Fix it with **one** of:
+- confirm `docker/run.sh`'s `cmd__run_agent` mounts `src/`
+  (`-v "$PROJECT_ROOT/src:/app/src:ro"`), or
+- rebuild the image: `./neurico build`.
+
+**"Port 7890 in use."** Pass `--port 7895` (or any free port). It also
+auto-retries nearby ports.
+
+**"Python 3 is required on the host."** Install Python 3.10+ — interactive mode's
+manager runs on your computer, not inside Docker.
+
+**Not logged in / auth errors from agents.** Run `./neurico login` (or
+`./neurico setup --quick`) and try again.
+
+**Browser didn't open.** Open the URL it printed manually (e.g.
+http://localhost:7890), or omit `--no-browser`.
+
+---
+
+## 7. Quick start (copy-paste)
+
+```bash
+cd "NeuriCo-interactive"
+./neurico login                                                   # one-time
+
+# 1) Submit an idea — this PRINTS a full Idea ID (with timestamp + hash):
+./neurico submit ideas/examples/titanic_survival_prediction.yaml
+#    → Idea ID: titanic_survival_prediction_20260606_213145_67d058cf
+
+# 2) Copy that ID from the output and pass it to `interactive`
+#    (use `interactive`, NOT `run` — only `interactive` opens the web page):
+./neurico interactive titanic_survival_prediction_20260606_213145_67d058cf --provider claude
+# → opens http://localhost:7890 — chat with the manager there
+```
+
+> ⚠️ Your ID will have a **different timestamp/hash** every time you submit —
+> always copy the exact ID that *your* `submit` prints.

--- a/src/interactive/manager.py
+++ b/src/interactive/manager.py
@@ -560,7 +560,7 @@ def main():
             from core.idea_manager import IdeaManager
             im = IdeaManager(PROJECT_ROOT / "ideas")
             im.update_status(args.idea_id, "in_progress")
-            print(f"[Idea moved to in_progress]")
+            print("[Idea moved to in_progress]")
             # Note: this MOVES the file (submitted/ -> in_progress/), making the
             # captured idea_file path stale. The agent dispatch in tools.py (#104)
             # falls back to ideas/in_progress/<name> at launch time, so no

--- a/src/interactive/manager.py
+++ b/src/interactive/manager.py
@@ -37,6 +37,7 @@ PROJECT_ROOT = Path(os.environ.get("NEURICO_PROJECT_ROOT", Path(__file__).parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from interactive.session_state import SessionState
+from interactive.research_state import ResearchState
 from interactive.llm_backend import LLMBackend, LLMResponse, create_backend
 from interactive.tools import ToolExecutor
 from interactive.channel import UserChannel, TerminalChannel
@@ -98,6 +99,12 @@ def friendly_tool_echo(name: str, args: Dict[str, Any]) -> Optional[str]:
         return f"📂 Checked progress of {args.get('run_id', 'the agent')}"
     if name == "update_session":
         return "📝 Updated session notes"
+    if name == "update_research_state":
+        return None  # silent — the Research whiteboard reflects this live
+    if name == "assess":
+        return None  # silent — surfaced on the whiteboard, not as chat noise
+    if name == "design_panel":
+        return None  # silent — the whiteboard re-renders to reflect the layout
     if name == "run_agent":
         return f"🚀 Launched the {args.get('agent', 'agent')}"
     return f"🔧 {name}"
@@ -236,11 +243,19 @@ class InteractiveManager:
 
         # Initialize components
         self.session = SessionState(workspace, idea_id, idea_title, provider)
+        # The manager's world model — what makes it reason like a PI rather than
+        # a tool dispatcher. Threaded into the executor so tools read/write it.
+        self.research = ResearchState(workspace)
         self.backend = create_backend(config)
         self.tools = ToolExecutor(workspace, self.session, idea_file, provider,
-                                  PROJECT_ROOT, channel=self.channel)
+                                  PROJECT_ROOT, channel=self.channel,
+                                  research=self.research)
         self.tool_definitions = load_tool_definitions()
+        # Base system prompt; the live research-state digest is appended fresh
+        # each turn (see _agent_step) so the manager always reasons over current
+        # state without polluting the persisted conversation history.
         self.system_prompt = load_system_prompt(idea, workspace, provider, config)
+        self.base_system_prompt = self.system_prompt
 
         # Conversation history (in-memory, backed by session)
         self.messages: List[Dict[str, Any]] = []
@@ -317,6 +332,14 @@ class InteractiveManager:
 
     def _agent_step(self):
         """Execute one step of the agent loop."""
+        # Refresh the system prompt with the current research-state digest so the
+        # manager reasons over its up-to-date world model every turn. messages[0]
+        # is always the system message (set in run()); we rewrite only its
+        # content and never persist this ephemeral digest to history.
+        if self.messages and self.messages[0]["role"] == "system":
+            self.messages[0]["content"] = (
+                self.base_system_prompt + self.research.digest_section())
+
         # Call LLM
         self.channel.status("Manager thinking…", thinking=True)
         response = self.backend.send(self.messages, self.tool_definitions)

--- a/src/interactive/research_state.py
+++ b/src/interactive/research_state.py
@@ -106,7 +106,13 @@ class ResearchState:
 
     # -------------------------------------------------------------- mutate
     def _next_id(self, key: str, prefix: str) -> str:
-        return f"{prefix}{len(self.state.get(key, [])) + 1}"
+        # Derive from the max existing id rather than the list length: the lists
+        # are append-only today (so max+1 == len+1), but length-based ids would
+        # collide the moment any list gains a delete/prune path.
+        nums = [int(x["id"][len(prefix):]) for x in self.state.get(key, [])
+                if str(x.get("id", "")).startswith(prefix)
+                and x["id"][len(prefix):].isdigit()]
+        return f"{prefix}{(max(nums) + 1) if nums else 1}"
 
     def upsert_hypothesis(self, statement: str, status: str = "alive",
                           evidence: str = "", hid: Optional[str] = None) -> str:
@@ -223,6 +229,10 @@ class ResearchState:
             if e["run_id"] == run_id:
                 if status:
                     e["status"] = status
+                    # Stamp when the run reaches a terminal state so the drift
+                    # check can compare against completion, not creation (`ts`).
+                    if status in ("done", "failed") and not e.get("completed_at"):
+                        e["completed_at"] = _now()
                     changed = True
                 if result:
                     e["result"] = result.strip()
@@ -304,8 +314,9 @@ class ResearchState:
                 continue
             # Drift: tested by a finished run, but status never moved off
             # alive/uncertain and the hypothesis hasn't been touched since the run.
+            done_ts = e.get("completed_at") or e.get("ts", "")
             if h["status"] in ("alive", "uncertain") and \
-                    h.get("updated_at", "") <= e.get("ts", ""):
+                    h.get("updated_at", "") <= done_ts:
                 warns.append(
                     f"Hypothesis {h['id']} was tested by {e['run_id']} "
                     f"({e['status']}) but is still '{h['status']}' — set it to "

--- a/src/interactive/research_state.py
+++ b/src/interactive/research_state.py
@@ -1,0 +1,429 @@
+"""
+Shared Research State — the manager's world model.
+
+This is the load-bearing primitive for treating the manager as a research
+*expert* (a PI / co-author) rather than a tool dispatcher. Instead of reasoning
+only over its last tool call, the manager reads and writes a structured picture
+of the whole investigation: the hypotheses in play (alive / uncertain /
+supported / dead), the experiments run and their results, the current best
+result, the decisive open question (the *crux*), open questions, decisions made
+(with rationale), and an append-only log of the manager's own per-cycle
+*assessments* (what's happening, what's uncertain, whether the human should be
+pulled in — and why).
+
+Borrowed in spirit from AutoScientists' shared state `S` (champion, experiment
+log, dead-end registry, research insights), but here it serves a *human-in-the-
+loop* manager: it is what makes the manager legibly omniscient, what the
+dashboard renders as a shared whiteboard, and what an annotator (or the model
+itself) grades to find failures in the manager's judgement.
+
+Persisted to ``<workspace>/.neurico/research_state.json``. The web server polls
+that file to render the live "Research" pane, so writes are atomic (temp file +
+os.replace) to avoid torn reads.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+HYP_STATUSES = ("alive", "uncertain", "supported", "dead")
+
+# Level 2 "PI designs the panel": the manager may declare custom whiteboard
+# sections per run, each rendered from a small, safe block vocabulary. Keeping
+# the vocabulary fixed (the manager picks *which* blocks and supplies data, not
+# raw markup) preserves the client-side escaping that makes the board XSS-safe.
+BLOCK_KINDS = ("text", "bullet_list", "key_value", "table", "status_list")
+
+# Reserved ids for the built-in sections. A panel_layout entry that matches one
+# of these renders the corresponding core section; any other id is looked up in
+# the custom `sections` map.
+BUILTIN_SECTIONS = ("crux", "current_best", "narrative", "assessment",
+                    "hypotheses", "open_questions", "decisions", "experiments")
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+class ResearchState:
+    """Structured, persistent model of the research-in-progress."""
+
+    def __init__(self, work_dir: Path):
+        self.work_dir = Path(work_dir)
+        self.neurico_dir = self.work_dir / ".neurico"
+        self.neurico_dir.mkdir(parents=True, exist_ok=True)
+        self.state_file = self.neurico_dir / "research_state.json"
+
+        if self.state_file.exists():
+            try:
+                with open(self.state_file, encoding="utf-8") as f:
+                    self.state = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                self.state = self._blank()
+            # Forward-migrate states written before a key existed (e.g. the
+            # Level 2 panel fields) so callers can assume every key is present.
+            for k, v in self._blank().items():
+                self.state.setdefault(k, v)
+        else:
+            self.state = self._blank()
+            self._save()
+
+    @staticmethod
+    def _blank() -> Dict[str, Any]:
+        return {
+            "updated_at": _now(),
+            "narrative": "",        # short rolling summary of where things stand
+            "current_best": "",     # champion / best result so far
+            "crux": "",             # the single most decision-relevant open issue
+            "hypotheses": [],       # {id, statement, status, evidence, updated_at}
+            "experiments": [],      # {id, agent, run_id, rationale, hypothesis, status, result, ts}
+            "findings": [],         # {text, kind, ts}   kind: result | dead_end | note
+            "open_questions": [],   # [str]
+            "decisions": [],        # {id, question, options, chosen, rationale, by, ts}
+            "assessments": [],      # {ts, situation, uncertainty, crux, decision_pending, engage_user, rationale}
+            "incidents": [],        # {ts, kind, detail} — auto-logged tool errors + self-reported struggle
+            # Level 2 — the PI-designed panel. `panel_layout` is an ordered list
+            # of section ids (built-in or custom); empty → default order. Each
+            # custom section in `sections` is {title, kind, data, updated_at}.
+            "panel_layout": [],     # [section_id, ...]
+            "sections": {},         # {id: {title, kind, data, updated_at}}
+        }
+
+    # ------------------------------------------------------------------ io
+    def _save(self) -> None:
+        self.state["updated_at"] = _now()
+        tmp = self.state_file.with_suffix(".json.tmp")
+        try:
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(self.state, f, indent=2, ensure_ascii=False)
+            os.replace(tmp, self.state_file)
+        except OSError:
+            pass
+
+    # -------------------------------------------------------------- mutate
+    def _next_id(self, key: str, prefix: str) -> str:
+        return f"{prefix}{len(self.state.get(key, [])) + 1}"
+
+    def upsert_hypothesis(self, statement: str, status: str = "alive",
+                          evidence: str = "", hid: Optional[str] = None) -> str:
+        statement = (statement or "").strip()
+        if not statement:
+            return ""
+        status = status if status in HYP_STATUSES else "alive"
+        # Match by id, else by (case-insensitive) statement.
+        for h in self.state["hypotheses"]:
+            if (hid and h["id"] == hid) or h["statement"].lower() == statement.lower():
+                h["status"] = status
+                if evidence:
+                    h["evidence"] = evidence
+                h["updated_at"] = _now()
+                self._save()
+                return h["id"]
+        new_id = hid or self._next_id("hypotheses", "H")
+        self.state["hypotheses"].append({
+            "id": new_id, "statement": statement, "status": status,
+            "evidence": evidence, "updated_at": _now(),
+        })
+        self._save()
+        return new_id
+
+    def add_finding(self, text: str, kind: str = "result") -> None:
+        text = (text or "").strip()
+        if not text:
+            return
+        if kind not in ("result", "dead_end", "note"):
+            kind = "note"
+        if any(f["text"].lower() == text.lower() for f in self.state["findings"]):
+            return
+        self.state["findings"].append({"text": text, "kind": kind, "ts": _now()})
+        self._save()
+
+    def set_fields(self, narrative: Optional[str] = None,
+                   current_best: Optional[str] = None,
+                   crux: Optional[str] = None) -> None:
+        if narrative is not None and narrative.strip():
+            self.state["narrative"] = narrative.strip()
+        if current_best is not None and current_best.strip():
+            self.state["current_best"] = current_best.strip()
+        if crux is not None and crux.strip():
+            self.state["crux"] = crux.strip()
+        self._save()
+
+    def set_open_questions(self, questions: List[str]) -> None:
+        self.state["open_questions"] = [q.strip() for q in questions if q and q.strip()]
+        self._save()
+
+    def resolve_questions(self, texts: List[str]) -> int:
+        """Drop open questions that match any of `texts` (case-insensitive, either
+        direction substring). Lets the manager prune answered questions precisely
+        without re-listing the whole set — a common source of stale state."""
+        targets = [t.strip().lower() for t in (texts or []) if t and t.strip()]
+        if not targets:
+            return 0
+        before = len(self.state["open_questions"])
+        kept = []
+        for q in self.state["open_questions"]:
+            ql = q.lower()
+            if any(t in ql or ql in t for t in targets):
+                continue
+            kept.append(q)
+        self.state["open_questions"] = kept
+        removed = before - len(kept)
+        if removed:
+            self._save()
+        return removed
+
+    def add_incident(self, kind: str, detail: str) -> None:
+        """Record something that went wrong — an auto-detected tool error/unknown-
+        tool call, or a self-reported struggle. This is what keeps the world model
+        honest: failures leave a trace instead of being silently smoothed over."""
+        detail = (detail or "").strip()
+        if not detail:
+            return
+        inc = self.state.setdefault("incidents", [])
+        # Skip consecutive duplicates (a confused loop shouldn't spam the board).
+        if inc and inc[-1].get("kind") == kind and inc[-1].get("detail") == detail:
+            return
+        inc.append({"ts": _now(), "kind": kind, "detail": detail})
+        # Bound growth — keep the most recent 50.
+        if len(inc) > 50:
+            self.state["incidents"] = inc[-50:]
+        self._save()
+
+    def add_decision(self, question: str, chosen: str = "", rationale: str = "",
+                     options: Optional[List[str]] = None, by: str = "manager") -> None:
+        question = (question or "").strip()
+        if not question:
+            return
+        self.state["decisions"].append({
+            "id": self._next_id("decisions", "D"), "question": question,
+            "options": options or [], "chosen": (chosen or "").strip(),
+            "rationale": (rationale or "").strip(), "by": by, "ts": _now(),
+        })
+        self._save()
+
+    def add_experiment(self, agent: str, run_id: str, rationale: str = "",
+                       hypothesis: str = "") -> None:
+        self.state["experiments"].append({
+            "id": self._next_id("experiments", "E"), "agent": agent,
+            "run_id": run_id, "rationale": (rationale or "").strip(),
+            "hypothesis": (hypothesis or "").strip(), "status": "running",
+            "result": "", "ts": _now(),
+        })
+        self._save()
+
+    def update_experiment(self, run_id: str, status: Optional[str] = None,
+                          result: Optional[str] = None) -> None:
+        changed = False
+        for e in self.state["experiments"]:
+            if e["run_id"] == run_id:
+                if status:
+                    e["status"] = status
+                    changed = True
+                if result:
+                    e["result"] = result.strip()
+                    changed = True
+                break
+        if changed:
+            self._save()
+
+    def add_assessment(self, situation: str = "", uncertainty: str = "",
+                       crux: str = "", decision_pending: str = "",
+                       engage_user: bool = False, rationale: str = "") -> None:
+        self.state["assessments"].append({
+            "ts": _now(), "situation": (situation or "").strip(),
+            "uncertainty": (uncertainty or "").strip(), "crux": (crux or "").strip(),
+            "decision_pending": (decision_pending or "").strip(),
+            "engage_user": bool(engage_user), "rationale": (rationale or "").strip(),
+        })
+        # The crux from the latest assessment is the live crux.
+        if crux and crux.strip():
+            self.state["crux"] = crux.strip()
+        self._save()
+
+    # --------------------------------------------------------- panel (L2)
+    def set_panel_layout(self, layout: List[str]) -> None:
+        """Set the ordered list of section ids the whiteboard renders. Entries
+        may be built-in ids (see BUILTIN_SECTIONS) or custom section ids. Empty
+        list restores the default order."""
+        self.state["panel_layout"] = [str(s).strip() for s in (layout or [])
+                                      if str(s).strip()]
+        self._save()
+
+    def upsert_section(self, sid: str, title: Optional[str] = None,
+                       kind: Optional[str] = None, data: Any = None) -> str:
+        """Create or update a custom whiteboard section. `kind` is one of
+        BLOCK_KINDS; `data` shape depends on kind (str for text; list for
+        bullet_list/status_list; {columns,rows} for table; list of {key,value}
+        or a dict for key_value). Only the provided fields are changed."""
+        sid = (sid or "").strip()
+        if not sid:
+            return ""
+        sec = self.state["sections"].get(sid, {})
+        if title is not None:
+            sec["title"] = str(title).strip()
+        if kind is not None:
+            sec["kind"] = kind if kind in BLOCK_KINDS else "text"
+        if data is not None:
+            sec["data"] = data
+        sec.setdefault("kind", "text")
+        sec.setdefault("title", sid)
+        sec.setdefault("data", "")
+        sec["updated_at"] = _now()
+        self.state["sections"][sid] = sec
+        self._save()
+        return sid
+
+    # ------------------------------------------------------- read / render
+    @property
+    def latest_assessment(self) -> Optional[Dict[str, Any]]:
+        return self.state["assessments"][-1] if self.state["assessments"] else None
+
+    def consistency_warnings(self) -> List[str]:
+        """Detect drift between the world model and reality — the failures we saw
+        in real runs (a hypothesis left 'alive' after its experiment finished;
+        resolved open questions never pruned). Surfaced to the manager (in the
+        digest) and to the human (on the whiteboard) so the model stays honest
+        rather than silently diverging."""
+        warns: List[str] = []
+        hyp_by_id = {h["id"]: h for h in self.state["hypotheses"]}
+        for e in self.state["experiments"]:
+            if e.get("status") not in ("done", "failed"):
+                continue
+            # Which hypothesis did this run test? Match by id or statement.
+            ref = (e.get("hypothesis") or "").strip()
+            h = hyp_by_id.get(ref)
+            if h is None and ref:
+                h = next((x for x in self.state["hypotheses"]
+                          if x["statement"].lower() == ref.lower()), None)
+            if h is None:
+                continue
+            # Drift: tested by a finished run, but status never moved off
+            # alive/uncertain and the hypothesis hasn't been touched since the run.
+            if h["status"] in ("alive", "uncertain") and \
+                    h.get("updated_at", "") <= e.get("ts", ""):
+                warns.append(
+                    f"Hypothesis {h['id']} was tested by {e['run_id']} "
+                    f"({e['status']}) but is still '{h['status']}' — set it to "
+                    f"supported/dead (with evidence) based on the result.")
+        # Resolved-but-stale open questions: if work has clearly progressed
+        # (a result/decision exists) yet questions are still listed, nudge a prune.
+        if self.state["open_questions"] and (self.state["current_best"]
+                                             or self.state["decisions"]):
+            warns.append(
+                f"{len(self.state['open_questions'])} open question(s) still "
+                f"listed — prune any the work has answered via "
+                f"update_research_state(resolved_questions=[...]).")
+        return warns
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Full state plus a couple of derived counts, for the dashboard."""
+        s = self.state
+        alive = sum(1 for h in s["hypotheses"] if h["status"] in ("alive", "uncertain"))
+        return {
+            "event": "research",
+            "updated_at": s["updated_at"],
+            "narrative": s["narrative"],
+            "current_best": s["current_best"],
+            "crux": s["crux"],
+            "hypotheses": s["hypotheses"],
+            "experiments": s["experiments"][-12:],
+            "findings": s["findings"][-12:],
+            "open_questions": s["open_questions"],
+            "decisions": s["decisions"][-8:],
+            "latest_assessment": self.latest_assessment,
+            "incidents": s.get("incidents", [])[-10:],
+            "warnings": self.consistency_warnings(),
+            "panel_layout": s.get("panel_layout", []),
+            "sections": s.get("sections", {}),
+            "counts": {
+                "hypotheses_alive": alive,
+                "hypotheses_total": len(s["hypotheses"]),
+                "experiments": len(s["experiments"]),
+                "decisions": len(s["decisions"]),
+            },
+        }
+
+    def digest_section(self, max_items: int = 8) -> str:
+        """Compact text the manager sees each turn as part of its system prompt.
+
+        Kept bounded so it never crowds out the conversation. This is the
+        manager's 'memory of the research' — it reads this instead of having to
+        re-derive the state from the raw transcript every cycle.
+        """
+        s = self.state
+        if not any([s["narrative"], s["current_best"], s["crux"], s["hypotheses"],
+                    s["open_questions"], s["decisions"], s["experiments"],
+                    s.get("sections")]):
+            return ("\n\n## Current Research State\n"
+                    "(empty — you have not recorded any state yet. As you learn "
+                    "things, call update_research_state to populate this.)")
+
+        lines = ["\n\n## Current Research State",
+                 "(your own running model of the investigation — keep it current)"]
+        if s["narrative"]:
+            lines.append(f"Narrative: {s['narrative']}")
+        if s["current_best"]:
+            lines.append(f"Current best: {s['current_best']}")
+        if s["crux"]:
+            lines.append(f"Crux right now: {s['crux']}")
+
+        if s["hypotheses"]:
+            lines.append("Hypotheses:")
+            for h in s["hypotheses"][-max_items:]:
+                ev = f" — {h['evidence']}" if h.get("evidence") else ""
+                lines.append(f"  [{h['status']}] {h['id']}: {h['statement']}{ev}")
+
+        if s["experiments"]:
+            lines.append("Experiments:")
+            for e in s["experiments"][-max_items:]:
+                why = f" ({e['rationale']})" if e.get("rationale") else ""
+                lines.append(f"  {e['run_id']} {e['agent']} [{e['status']}]{why}")
+
+        if s["open_questions"]:
+            lines.append("Open questions:")
+            for q in s["open_questions"][:max_items]:
+                lines.append(f"  - {q}")
+
+        if s["decisions"]:
+            lines.append("Decisions made:")
+            for d in s["decisions"][-max_items:]:
+                ch = f" → {d['chosen']}" if d.get("chosen") else ""
+                lines.append(f"  - {d['question']}{ch}")
+
+        la = self.latest_assessment
+        if la:
+            lines.append(
+                f"Your last assessment: {la.get('situation', '')} "
+                f"| uncertainty: {la.get('uncertainty', '')} "
+                f"| engage_user={la.get('engage_user')}")
+
+        recent_incidents = self.state.get("incidents", [])[-3:]
+        if recent_incidents:
+            lines.append("Recent incidents (things that went wrong — own them, "
+                         "don't pretend they didn't happen):")
+            for inc in recent_incidents:
+                lines.append(f"  ⚠ [{inc.get('kind')}] {inc.get('detail')}")
+
+        warns = self.consistency_warnings()
+        if warns:
+            lines.append("⚠ CONSISTENCY — fix these before moving on:")
+            for w in warns:
+                lines.append(f"  - {w}")
+
+        # Remind the manager of the panel it designed, so it keeps custom
+        # sections' data current (and doesn't redesign the layout each turn).
+        if s.get("sections"):
+            lines.append("Custom panel sections you defined "
+                         "(keep their data current via design_panel):")
+            for sid, sec in s["sections"].items():
+                lines.append(f"  [{sec.get('kind', 'text')}] {sid}: "
+                             f"{sec.get('title', sid)}")
+        if s.get("panel_layout"):
+            lines.append("Panel order: " + ", ".join(s["panel_layout"]))
+
+        return "\n".join(lines)

--- a/src/interactive/tools.py
+++ b/src/interactive/tools.py
@@ -28,7 +28,7 @@ class ToolExecutor:
 
     def __init__(self, work_dir: Path, session: SessionState,
                  idea_file: Path, provider: str, project_root: Path,
-                 channel=None):
+                 channel=None, research=None):
         self.work_dir = Path(work_dir)
         self.session = session
         self.idea_file = idea_file
@@ -40,6 +40,12 @@ class ToolExecutor:
             from interactive.channel import TerminalChannel
             channel = TerminalChannel()
         self.channel = channel
+        # Shared research state (the manager's world model). Created lazily so
+        # the executor still works standalone / in tests.
+        if research is None:
+            from interactive.research_state import ResearchState
+            research = ResearchState(work_dir)
+        self.research = research
 
         # Track running agent processes
         self._running_agents: Dict[str, subprocess.Popen] = {}
@@ -61,15 +67,26 @@ class ToolExecutor:
             "read_agent_logs": self._read_agent_logs,
             "ask_user": self._ask_user,
             "update_session": self._update_session,
+            "update_research_state": self._update_research_state,
+            "assess": self._assess,
+            "design_panel": self._design_panel,
         }
 
         handler = handlers.get(tool_name)
         if not handler:
+            # Auto-log the failure so the world model stays honest: an unknown-tool
+            # call (e.g. the manager reaching for Bash/Read/AskUserQuestion when it
+            # gets confused about its tool layer) leaves a visible trace instead of
+            # being silently smoothed over.
+            self.research.add_incident(
+                "unknown_tool",
+                f"Called '{tool_name}', which is not one of the available tools.")
             return f"Error: Unknown tool '{tool_name}'. Available: {list(handlers.keys())}"
 
         try:
             return handler(arguments)
         except Exception as e:
+            self.research.add_incident("tool_error", f"{tool_name}: {e}")
             return f"Error executing {tool_name}: {e}"
 
     def _run_agent(self, args: Dict[str, Any]) -> str:
@@ -135,6 +152,16 @@ class ToolExecutor:
             )
 
         self._running_agents[run_id] = process
+
+        # Critique-before-compute (AutoScientists' idea): record WHY this agent
+        # is being launched into the world model — which hypothesis it tests and
+        # the manager's justification — so the spend is never silent and the
+        # decision is gradeable later.
+        self.research.add_experiment(
+            agent=agent_name, run_id=run_id,
+            rationale=str(args.get("rationale", "")),
+            hypothesis=str(args.get("hypothesis", "")),
+        )
 
         return (
             f"Agent '{agent_name}' started with run_id '{run_id}' (pid: {process.pid}).\n"
@@ -341,6 +368,201 @@ class ToolExecutor:
 
         return "Session updated: " + ", ".join(updates) if updates else "No changes"
 
+    @staticmethod
+    def _as_list(value) -> List:
+        """Coerce a value the CLI backend may have JSON-encoded as a string."""
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+                return parsed if isinstance(parsed, list) else [value]
+            except (json.JSONDecodeError, ValueError):
+                return [value] if value.strip() else []
+        return [value]
+
+    def _update_research_state(self, args: Dict[str, Any]) -> str:
+        """Update the manager's world model: narrative, current best, crux,
+        hypotheses (upsert), findings, dead-ends, open questions, and decisions
+        made. This is how the manager *thinks like a PI* — keeping an explicit
+        picture of the investigation rather than re-deriving it each turn."""
+        r = self.research
+        updates = []
+
+        narrative = args.get("narrative")
+        current_best = args.get("current_best")
+        crux = args.get("crux")
+        if any(v is not None for v in (narrative, current_best, crux)):
+            r.set_fields(narrative=narrative, current_best=current_best, crux=crux)
+            if narrative is not None:
+                updates.append("narrative")
+            if current_best is not None:
+                updates.append("current best")
+            if crux is not None:
+                updates.append("crux")
+
+        # Hypotheses: list of {statement, status, evidence, id?} (status one of
+        # alive|uncertain|supported|dead). Also accept bare strings.
+        hyps = self._as_list(args.get("hypotheses"))
+        for h in hyps:
+            if isinstance(h, dict):
+                r.upsert_hypothesis(
+                    statement=str(h.get("statement", "")),
+                    status=str(h.get("status", "alive")),
+                    evidence=str(h.get("evidence", "")),
+                    hid=h.get("id"),
+                )
+            elif isinstance(h, str):
+                r.upsert_hypothesis(statement=h)
+        if hyps:
+            updates.append(f"{len(hyps)} hypothesis(es)")
+
+        for f in self._as_list(args.get("findings")):
+            r.add_finding(str(f), kind="result")
+        for d in self._as_list(args.get("dead_ends")):
+            r.add_finding(str(d), kind="dead_end")
+        n_find = len(self._as_list(args.get("findings"))) + len(self._as_list(args.get("dead_ends")))
+        if n_find:
+            updates.append(f"{n_find} finding(s)")
+
+        oq = args.get("open_questions")
+        if oq is not None:
+            r.set_open_questions([str(q) for q in self._as_list(oq)])
+            updates.append("open questions")
+
+        # Prune specific answered questions without re-listing the whole set —
+        # the common path that was being skipped, leaving stale questions.
+        resolved = self._as_list(args.get("resolved_questions"))
+        if resolved:
+            n = r.resolve_questions([str(q) for q in resolved])
+            if n:
+                updates.append(f"resolved {n} question(s)")
+
+        decision = args.get("decision")
+        if isinstance(decision, str):
+            try:
+                decision = json.loads(decision)
+            except (json.JSONDecodeError, ValueError):
+                decision = None
+        if isinstance(decision, dict) and decision.get("question"):
+            r.add_decision(
+                question=str(decision.get("question", "")),
+                chosen=str(decision.get("chosen", "")),
+                rationale=str(decision.get("rationale", "")),
+                options=[str(o) for o in self._as_list(decision.get("options"))],
+                by="manager",
+            )
+            updates.append("decision")
+
+        return "Research state updated: " + ", ".join(updates) if updates else \
+               "No changes (provide narrative/current_best/crux/hypotheses/findings/open_questions/decision)"
+
+    def _assess(self, args: Dict[str, Any]) -> str:
+        """Record the manager's read of the situation right now: what changed,
+        what's uncertain, the crux, any pending decision, and whether a human
+        expert would pull the user in (with rationale). This is reflection, not
+        action — if engage_user is true, you still call ask_user to actually ask."""
+        engage = args.get("engage_user", False)
+        if isinstance(engage, str):
+            engage = engage.strip().lower() in ("true", "yes", "1")
+        self.research.add_assessment(
+            situation=str(args.get("situation", "")),
+            uncertainty=str(args.get("uncertainty", "")),
+            crux=str(args.get("crux", "")),
+            decision_pending=str(args.get("decision_pending", "")),
+            engage_user=bool(engage),
+            rationale=str(args.get("rationale", "")),
+        )
+        # Honest self-report: if the manager hit confusion, an error, or recovered
+        # from a mistake, it logs an incident so the failure leaves a trace.
+        issue = str(args.get("issue", "")).strip()
+        if issue:
+            self.research.add_incident("self_reported", issue)
+        if engage:
+            return ("Assessment recorded. You judged the human should be engaged — "
+                    "now call ask_user with a concise, crux-focused question.")
+        return ("Assessment recorded. You judged no human input is needed now — "
+                "proceed autonomously.")
+
+    # Block kinds the manager may use for custom panel sections. Kept in sync
+    # with research_state.BLOCK_KINDS — these are the data shapes the whiteboard
+    # knows how to render safely (all text is HTML-escaped client side).
+    _PANEL_DATA_KINDS = ("bullet_list", "key_value", "table", "status_list")
+
+    def _design_panel(self, args: Dict[str, Any]) -> str:
+        """Let the PI shape the Research whiteboard for THIS run: choose the
+        order of sections and define custom sections from a fixed block
+        vocabulary (text, bullet_list, key_value, table, status_list). Decide the
+        layout once near the start; afterwards call this only to refresh a custom
+        section's `data`. Built-in sections (crux, current_best, narrative,
+        assessment, hypotheses, open_questions, decisions, experiments) keep
+        flowing from update_research_state/assess — list their ids in `layout`
+        to position them."""
+        r = self.research
+        updates = []
+
+        layout = args.get("layout")
+        if layout is not None:
+            r.set_panel_layout([str(s) for s in self._as_list(layout)])
+            updates.append("layout")
+
+        n_sec = 0
+        for sec in self._as_list(args.get("sections")):
+            # The CLI backend may hand each section back as a JSON string.
+            if isinstance(sec, str):
+                try:
+                    sec = json.loads(sec)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+            if not isinstance(sec, dict) or not sec.get("id"):
+                continue
+            kind = sec.get("kind")
+            data = sec.get("data")
+            # Structured kinds may arrive JSON-encoded (CLI backend quirk).
+            if isinstance(data, str) and kind in self._PANEL_DATA_KINDS:
+                try:
+                    data = json.loads(data)
+                except (json.JSONDecodeError, ValueError):
+                    pass
+            r.upsert_section(str(sec["id"]), title=sec.get("title"),
+                             kind=kind, data=data)
+            n_sec += 1
+        if n_sec:
+            updates.append(f"{n_sec} section(s)")
+
+        if updates:
+            return "Panel updated: " + ", ".join(updates)
+        return ("No changes. Provide `layout` (ordered section ids) and/or "
+                "`sections`=[{id,title,kind,data}] where kind is one of "
+                "text|bullet_list|key_value|table|status_list.")
+
+    def _summarize_run_result(self, run_id: str) -> str:
+        """Pull a short outcome summary from a finished run's result.json /
+        error.json so the experiment record carries its result — not an empty
+        string. The data is on disk; reading it back is fully mechanical and
+        removes the 'result: ""' drift we saw in real runs."""
+        run_dir = self.work_dir / ".neurico" / "runs" / run_id
+        for name in ("result.json", "error.json"):
+            path = run_dir / name
+            if not path.exists():
+                continue
+            try:
+                with open(path, encoding="utf-8") as f:
+                    obj = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                continue
+            if name == "error.json":
+                return f"error: {obj.get('error', 'unknown error')}"[:300]
+            # result.json: prefer a human-ish field, else compact the JSON.
+            for key in ("summary", "result", "message", "status"):
+                val = obj.get(key)
+                if isinstance(val, str) and val.strip():
+                    return val.strip()[:300]
+            return json.dumps(obj, ensure_ascii=False)[:300]
+        return ""
+
     def check_running_agents(self) -> List[Dict[str, Any]]:
         """Check status of all running agents. Returns list of completed ones."""
         completed = []
@@ -348,6 +570,11 @@ class ToolExecutor:
             poll_result = process.poll()
             if poll_result is not None:
                 self.session.record_agent_complete(run_id, poll_result == 0, poll_result)
+                self.research.update_experiment(
+                    run_id,
+                    status="done" if poll_result == 0 else "failed",
+                    result=self._summarize_run_result(run_id) or None,
+                )
                 completed.append({
                     "run_id": run_id,
                     "exit_code": poll_result,

--- a/src/interactive/web_server.py
+++ b/src/interactive/web_server.py
@@ -233,6 +233,30 @@ def _emit_dashboard(workspace: Path, project_root: Path, channel: WebChannel,
         stop.wait(3.0)
 
 
+def _emit_research_state(workspace: Path, channel: WebChannel,
+                         stop: threading.Event) -> None:
+    """Push the manager's world model (the `research` event) to the browser when
+    it changes. The manager writes research_state.json via update_research_state
+    / assess; we poll it and fan a snapshot out to the Research whiteboard. Polled
+    (not in-process) so it works identically for fresh and resumed sessions and
+    stays decoupled from the manager loop."""
+    state_file = workspace / ".neurico" / "research_state.json"
+    last_stamp = None
+    while not stop.is_set():
+        try:
+            if state_file.exists():
+                with open(state_file, encoding="utf-8") as fh:
+                    data = json.load(fh)
+                stamp = data.get("updated_at")
+                if stamp != last_stamp:
+                    last_stamp = stamp
+                    data["event"] = "research"
+                    channel.emit_raw(data)
+        except (OSError, json.JSONDecodeError):
+            pass
+        stop.wait(2.0)
+
+
 # ---------------------------------------------------------------------------
 # HTML page
 # ---------------------------------------------------------------------------
@@ -270,7 +294,7 @@ PAGE = r"""<!DOCTYPE html>
   .panehead{font-size:11px;color:#8b949e;text-transform:uppercase;letter-spacing:.05em;padding:8px 16px;border-bottom:1px solid #21262d;background:#10151c;flex-shrink:0}
   /* min-height:0 lets these flex children actually scroll instead of growing the page */
   #chat{flex:1;min-height:0;overflow-y:auto;padding:16px;display:flex;flex-direction:column;gap:10px}
-  #log{flex:1;min-height:0;overflow-y:auto;padding:10px 12px;display:flex;flex-direction:column;gap:6px}
+  /* #log visibility/layout is governed by .tabpane / .tabpane.active (see tab CSS) */
 
   /* ---- chat bubbles ---- */
   .msg{flex:0 0 auto;border-radius:8px;padding:8px 12px;line-height:1.5;white-space:pre-wrap;word-break:break-word;max-width:92%}
@@ -318,6 +342,61 @@ PAGE = r"""<!DOCTYPE html>
   .tool-name{color:#ffa657;font-weight:bold}.tool-key{color:#79c0ff}.tool-val{color:#aff5b4}
   #logempty{color:#6e7681;font-size:12px;padding:8px;text-align:center}
 
+  /* ---- tabbed right column (Research whiteboard | Activity) ---- */
+  .tabhead{display:flex;gap:4px;padding:0 8px;align-items:flex-end}
+  .tab{background:none;border:none;border-bottom:2px solid transparent;color:#8b949e;font-size:11px;text-transform:uppercase;letter-spacing:.05em;padding:8px 10px;cursor:pointer;font-weight:600}
+  .tab:hover{color:#c9d1d9}
+  .tab.active{color:#e6edf3;border-bottom-color:#58a6ff}
+  .tabpane{display:none;flex:1;min-height:0;overflow-y:auto;padding:12px}
+  .tabpane.active{display:flex;flex-direction:column;gap:10px}
+  #log.tabpane.active{gap:6px}
+  #researchempty{color:#6e7681;font-size:12px;padding:8px;text-align:center}
+
+  /* the manager's world model, rendered as a shared whiteboard */
+  .r-crux{border:1px solid #e3b341;background:#26200d;border-radius:8px;padding:8px 12px;font-size:13px;color:#f0d990}
+  .r-crux b{color:#e3b341;display:block;font-size:10px;text-transform:uppercase;letter-spacing:.05em;margin-bottom:3px}
+  .r-card{background:#10261a;border:1px solid #1a3a2e;border-radius:8px;padding:8px 12px;font-size:13px;color:#aff5b4}
+  .r-card b{color:#56d364;display:block;font-size:10px;text-transform:uppercase;letter-spacing:.05em;margin-bottom:3px}
+  .r-narrative{font-size:13px;color:#c9d1d9;line-height:1.5;padding:2px 2px}
+  .r-assess{background:#11233b;border:1px solid #1f3c5e;border-radius:8px;padding:8px 12px;font-size:12px;color:#c9d1d9}
+  .r-assess b{color:#79c0ff;display:block;font-size:10px;text-transform:uppercase;letter-spacing:.05em;margin-bottom:3px}
+  .r-assess .eng{display:inline-block;margin-top:5px;font-size:11px;padding:1px 7px;border-radius:9px}
+  .r-assess .eng.yes{background:#26200d;color:#e3b341;border:1px solid #e3b341}
+  .r-assess .eng.no{background:#161b22;color:#6e7681;border:1px solid #30363d}
+  .r-sec .r-h{font-size:11px;font-weight:700;color:#adbac7;text-transform:uppercase;letter-spacing:.06em;margin-bottom:6px}
+  .hyp{display:flex;gap:7px;align-items:baseline;padding:4px 0;border-bottom:1px solid #161b22;font-size:13px}
+  .hyp .st{flex-shrink:0;font-size:9px;font-weight:700;padding:1px 6px;border-radius:9px;text-transform:uppercase}
+  .st-alive{background:#1f3c5e;color:#79c0ff}.st-uncertain{background:#2a2a1e;color:#e3b341}
+  .st-supported{background:#1a3a2e;color:#56d364}.st-dead{background:#3a1e1e;color:#ff7b72}
+  .hyp .stmt{color:#c9d1d9}.hyp.st-row-dead .stmt{color:#8b949e;text-decoration:line-through}
+  .hyp .ev{color:#6e7681;font-size:11px}
+  .qitem{font-size:13px;color:#c9d1d9;padding:3px 0;padding-left:14px;position:relative}
+  .qitem::before{content:"?";position:absolute;left:0;color:#58a6ff;font-weight:700}
+  .decitem{font-size:12px;color:#c9d1d9;padding:4px 0;border-bottom:1px solid #161b22}
+  .decitem .ch{color:#56d364}.decitem .rat{color:#6e7681;font-size:11px}
+  .expitem{font-size:12px;color:#8b949e;padding:3px 0;font-family:monospace}
+  .expitem .est{font-size:9px;padding:0 5px;border-radius:8px;margin-right:5px}
+  .est-running{background:#1f3c5e;color:#79c0ff}.est-done{background:#1a3a2e;color:#56d364}.est-failed{background:#3a1e1e;color:#ff7b72}
+  /* consistency warnings (drift to fix) + incident log (what went wrong) */
+  .r-warn{border:1px solid #d29922;background:#2a1e0a;border-radius:8px;padding:8px 12px;font-size:12px;color:#f0c674}
+  .r-warn b{color:#e3b341;display:block;font-size:10px;text-transform:uppercase;letter-spacing:.05em;margin-bottom:4px}
+  .r-warn .warn-i{padding:2px 0}
+  .inc-i{font-size:12px;color:#c9d1d9;padding:3px 0;border-bottom:1px solid #161b22}
+  .inc-i .inc-k{display:inline-block;font-size:9px;font-weight:700;padding:1px 6px;border-radius:8px;background:#3a1e1e;color:#ff7b72;text-transform:uppercase;margin-right:5px}
+  .inc-i .inc-ts{color:#6e7681;font-family:monospace;font-size:10px}
+
+  /* ---- PI-defined custom blocks (design_panel) ---- */
+  .r-ul{margin:0;padding-left:18px}
+  .r-ul li{font-size:13px;color:#c9d1d9;padding:2px 0;line-height:1.45}
+  .r-kv{width:100%;border-collapse:collapse;font-size:13px}
+  .r-kv td{padding:3px 8px 3px 0;vertical-align:top;border-bottom:1px solid #161b22}
+  .r-kv td.k{color:#8b949e;white-space:nowrap;width:1%}
+  .r-kv td.v{color:#c9d1d9}
+  .r-table{width:100%;border-collapse:collapse;font-size:12px}
+  .r-table th{text-align:left;color:#8b949e;font-weight:600;padding:4px 8px;border-bottom:1px solid #30363d;text-transform:uppercase;font-size:10px;letter-spacing:.04em}
+  .r-table td{padding:4px 8px;border-bottom:1px solid #161b22;color:#c9d1d9;vertical-align:top}
+  .r-table tr:hover td{background:#11151c}
+
   /* ---- composer (bottom of chat column) ---- */
   #composer{border-top:1px solid #30363d;background:#161b22;padding:10px 16px;flex-shrink:0}
   #composer.awaiting{background:#26200d;border-top:2px solid #e3b341}
@@ -364,8 +443,17 @@ PAGE = r"""<!DOCTYPE html>
       </div>
     </div>
     <div id="logcol">
-      <div class="panehead">⚙️ Live activity — click any row to expand</div>
-      <div id="log"><div id="logempty">Waiting for the agent to start…</div></div>
+      <div class="panehead tabhead">
+        <button class="tab active" data-tab="research">🔬 Research</button>
+        <button class="tab" data-tab="activity">⚙️ Activity</button>
+      </div>
+      <div id="research" class="tabpane active">
+        <div id="researchempty">The manager hasn't recorded its research model yet…</div>
+        <!-- Rebuilt in panel_layout order by setResearch(); sections are a mix
+             of built-in renderers and PI-defined custom blocks. -->
+        <div id="researchbody" style="display:none"></div>
+      </div>
+      <div id="log" class="tabpane"><div id="logempty">Waiting for the agent to start…</div></div>
     </div>
   </div>
 
@@ -544,11 +632,144 @@ PAGE = r"""<!DOCTYPE html>
     if(d.label){connEl.textContent=d.label;}
   }
 
+  // --- research whiteboard (the manager's world model) ---
+  // Rebuilt in panel_layout order each update. Each section is either a built-in
+  // renderer (CORE) or a PI-defined custom block (design_panel). All text is
+  // escaped via esc() before insertion, so custom content can't inject markup.
+  function esc(s){const d=document.createElement('div');d.textContent=(s==null?'':String(s));return d.innerHTML;}
+  function show(id,on){document.getElementById(id).style.display=on?'':'none';}
+  function el(tag,cls,html){const e=document.createElement(tag);if(cls)e.className=cls;if(html!=null)e.innerHTML=html;return e;}
+  function rsec(title,innerHTML){
+    if(!innerHTML||!innerHTML.trim()) return null;   // skip empty sections
+    return el('div','r-sec','<div class="r-h">'+esc(title)+'</div>'+innerHTML);
+  }
+  // The browser receives the raw state file, which stores `assessments` (a
+  // list); fall back to its last entry if a derived `latest_assessment` is absent.
+  function latestAssessment(d){
+    if(d.latest_assessment) return d.latest_assessment;
+    const a=d.assessments; return (Array.isArray(a)&&a.length)?a[a.length-1]:null;
+  }
+
+  // Built-in section renderers: id -> function(d) -> HTMLElement|null.
+  const CORE={
+    warnings:d=>{
+      const w=d.warnings||[]; if(!w.length) return null;
+      return el('div','r-warn','<b>⚠ Needs attention</b>'+w.map(x=>'<div class="warn-i">'+esc(x)+'</div>').join(''));
+    },
+    crux:d=>d.crux?el('div','r-crux','<b>⚡ Crux right now</b>'+esc(d.crux)):null,
+    current_best:d=>d.current_best?el('div','r-card','<b>Current best</b>'+esc(d.current_best)):null,
+    narrative:d=>{if(!d.narrative)return null;const e=el('div','r-narrative');e.textContent=d.narrative;return e;},
+    assessment:d=>{
+      const a=latestAssessment(d); if(!a) return null;
+      const eng=a.engage_user?'<span class="eng yes">would engage you</span>':'<span class="eng no">proceeding solo</span>';
+      return el('div','r-assess','<b>🧭 Manager\'s read</b>'+esc(a.situation||'')+
+        (a.uncertainty?'<br><span style="color:#8b949e">Unsure: </span>'+esc(a.uncertainty):'')+
+        (a.rationale?'<br><span style="color:#8b949e">Why: </span>'+esc(a.rationale):'')+'<br>'+eng);
+    },
+    hypotheses:d=>{
+      const hyp=d.hypotheses||[]; if(!hyp.length) return null;
+      return rsec('Hypotheses',hyp.map(h=>{const st=esc(h.status||'alive');
+        return '<div class="hyp st-row-'+st+'"><span class="st st-'+st+'">'+st+'</span>'+
+          '<span class="stmt">'+esc(h.statement)+(h.evidence?' <span class="ev">— '+esc(h.evidence)+'</span>':'')+'</span></div>';
+      }).join(''));
+    },
+    open_questions:d=>{
+      const q=d.open_questions||[]; if(!q.length) return null;
+      return rsec('Open questions',q.map(x=>'<div class="qitem">'+esc(x)+'</div>').join(''));
+    },
+    decisions:d=>{
+      const dec=d.decisions||[]; if(!dec.length) return null;
+      return rsec('Decisions',dec.map(x=>'<div class="decitem">'+esc(x.question)+
+        (x.chosen?' <span class="ch">→ '+esc(x.chosen)+'</span>':'')+
+        (x.rationale?'<br><span class="rat">'+esc(x.rationale)+'</span>':'')+'</div>').join(''));
+    },
+    experiments:d=>{
+      const exp=d.experiments||[]; if(!exp.length) return null;
+      return rsec('Experiments',exp.map(x=>'<div class="expitem">'+
+        '<span class="est est-'+esc(x.status||'running')+'">'+esc(x.status||'running')+'</span>'+
+        esc(x.run_id)+' '+esc(x.agent)+(x.rationale?' — <span style="color:#6e7681">'+esc(x.rationale)+'</span>':'')+
+        (x.result?'<br><span style="color:#8b949e">→ '+esc(x.result)+'</span>':'')+'</div>').join(''));
+    },
+    incidents:d=>{
+      const inc=d.incidents||[]; if(!inc.length) return null;
+      return rsec('⚠ Incidents',inc.map(x=>'<div class="inc-i">'+
+        '<span class="inc-k">'+esc(x.kind)+'</span> '+esc(x.detail)+
+        (x.ts?' <span class="inc-ts">'+esc(String(x.ts).slice(11,19))+'</span>':'')+'</div>').join(''));
+    },
+  };
+  const DEFAULT_ORDER=['warnings','crux','current_best','narrative','assessment','hypotheses','open_questions','decisions','experiments','incidents'];
+
+  // PI-defined custom block -> inner HTML. Every value goes through esc().
+  function customInner(sec){
+    const kind=sec.kind||'text', data=sec.data;
+    const cell=v=>esc(typeof v==='string'?v:(v==null?'':JSON.stringify(v)));
+    if(kind==='bullet_list'){
+      const arr=Array.isArray(data)?data:(data?[data]:[]);
+      return arr.length?'<ul class="r-ul">'+arr.map(x=>'<li>'+cell(x)+'</li>').join('')+'</ul>':'';
+    }
+    if(kind==='key_value'){
+      let rows=[];
+      if(Array.isArray(data)) rows=data.map(o=>[o&&o.key,o&&o.value]);
+      else if(data&&typeof data==='object') rows=Object.keys(data).map(k=>[k,data[k]]);
+      return rows.length?'<table class="r-kv">'+rows.map(r=>'<tr><td class="k">'+cell(r[0])+'</td><td class="v">'+cell(r[1])+'</td></tr>').join('')+'</table>':'';
+    }
+    if(kind==='table'){
+      const cols=(data&&data.columns)||[], body=(data&&data.rows)||[];
+      if(!cols.length&&!body.length) return '';
+      return '<table class="r-table"><thead><tr>'+cols.map(c=>'<th>'+cell(c)+'</th>').join('')+'</tr></thead><tbody>'+
+        body.map(r=>'<tr>'+(Array.isArray(r)?r:[r]).map(c=>'<td>'+cell(c)+'</td>').join('')+'</tr>').join('')+'</tbody></table>';
+    }
+    if(kind==='status_list'){
+      const arr=Array.isArray(data)?data:[];
+      return arr.map(it=>{const st=esc(it.status||'alive');const label=it.label||it.statement||'';const note=it.note||it.evidence;
+        return '<div class="hyp st-row-'+st+'"><span class="st st-'+st+'">'+st+'</span><span class="stmt">'+esc(label)+(note?' <span class="ev">— '+esc(note)+'</span>':'')+'</span></div>';}).join('');
+    }
+    return data?('<div class="r-narrative">'+cell(data)+'</div>'):'';   // text (default)
+  }
+
+  function setResearch(d){
+    const body=document.getElementById('researchbody');
+    const sections=d.sections||{};
+    let order=(Array.isArray(d.panel_layout)&&d.panel_layout.length)?d.panel_layout.slice():DEFAULT_ORDER.slice();
+    // Any custom section not explicitly placed in the layout is appended.
+    const placed=new Set(order);
+    Object.keys(sections).forEach(id=>{if(!placed.has(id))order.push(id);});
+    // Honesty sections are non-suppressible: a PI-designed layout (design_panel)
+    // may reorder them, but must not be able to HIDE warnings/incidents — that
+    // would let a drifting manager conceal its own failures. Force them in if a
+    // custom layout left them out (their renderers return null when empty, so
+    // this never adds empty boxes).
+    if(!order.includes('warnings')) order.unshift('warnings');
+    if(!order.includes('incidents')) order.push('incidents');
+
+    const frag=document.createDocumentFragment();
+    let any=false;
+    order.forEach(id=>{
+      let node=null;
+      if(CORE[id]) node=CORE[id](d);
+      else if(sections[id]) node=rsec(sections[id].title||id,customInner(sections[id]));
+      if(node){frag.appendChild(node);any=true;}
+    });
+    show('researchempty',!any);
+    show('researchbody',any);
+    body.innerHTML='';
+    body.appendChild(frag);
+  }
+
+  // tab switching (Research / Activity)
+  document.querySelectorAll('.tab').forEach(t=>t.addEventListener('click',()=>{
+    document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active'));
+    document.querySelectorAll('.tabpane').forEach(x=>x.classList.remove('active'));
+    t.classList.add('active');
+    document.getElementById(t.dataset.tab==='research'?'research':'log').classList.add('active');
+  }));
+
   const es=new EventSource('/stream');
   es.onopen=()=>{connEl.textContent='connected';};
   es.addEventListener('message',e=>addMessage(JSON.parse(e.data)));
   es.addEventListener('agentlog',e=>addAgentLog(JSON.parse(e.data)));
   es.addEventListener('dashboard',e=>setDash(JSON.parse(e.data)));
+  es.addEventListener('research',e=>setResearch(JSON.parse(e.data)));
   es.addEventListener('prompt',e=>{
     const d=JSON.parse(e.data);
     setThinking(false);   // the manager finished thinking and is now asking
@@ -720,6 +941,7 @@ class InteractiveWebServer:
         self._server_thread: Optional[threading.Thread] = None
         self._tailer_thread: Optional[threading.Thread] = None
         self._dash_thread: Optional[threading.Thread] = None
+        self._research_thread: Optional[threading.Thread] = None
         self._stop = threading.Event()
 
     @property
@@ -757,6 +979,12 @@ class InteractiveWebServer:
             args=(self.workspace, self.project_root, self.channel, self._stop),
             daemon=True)
         self._dash_thread.start()
+
+        self._research_thread = threading.Thread(
+            target=_emit_research_state,
+            args=(self.workspace, self.channel, self._stop),
+            daemon=True)
+        self._research_thread.start()
 
     def stop(self) -> None:
         self._stop.set()

--- a/src/interactive/web_server.py
+++ b/src/interactive/web_server.py
@@ -240,18 +240,24 @@ def _emit_research_state(workspace: Path, channel: WebChannel,
     / assess; we poll it and fan a snapshot out to the Research whiteboard. Polled
     (not in-process) so it works identically for fresh and resumed sessions and
     stays decoupled from the manager loop."""
+    from interactive.research_state import ResearchState
     state_file = workspace / ".neurico" / "research_state.json"
     last_stamp = None
     while not stop.is_set():
         try:
             if state_file.exists():
-                with open(state_file, encoding="utf-8") as fh:
-                    data = json.load(fh)
-                stamp = data.get("updated_at")
+                # Emit snapshot(), not the raw file: snapshot() adds the derived
+                # fields the persisted state lacks — `warnings` (the
+                # non-suppressible consistency/drift section), `latest_assessment`
+                # and `counts` — and already tags event="research". A fresh
+                # read-only ResearchState keeps the poller decoupled from the
+                # manager's instance (reads only, never writes; the exists()
+                # guard above avoids creating the file early).
+                snap = ResearchState(workspace).snapshot()
+                stamp = snap.get("updated_at")
                 if stamp != last_stamp:
                     last_stamp = stamp
-                    data["event"] = "research"
-                    channel.emit_raw(data)
+                    channel.emit_raw(snap)
         except (OSError, json.JSONDecodeError):
             pass
         stop.wait(2.0)

--- a/templates/manager/system_prompt.txt
+++ b/templates/manager/system_prompt.txt
@@ -1,24 +1,77 @@
-You are the NeuriCo Interactive Research Manager. You help a human researcher conduct AI-assisted research by orchestrating specialized research agents and maintaining a productive dialogue.
+You are the NeuriCo Interactive Research Manager. You are the research expert — the principal investigator (PI) and AI research co-author — who sits between the human researcher, a team of specialized research agents, and the Claude Code execution environment. Think of yourself as the human's most trusted senior collaborator running the lab on their behalf.
 
 ## Your Role
 
-You are a research collaborator, not an autonomous pipeline. You:
-- Analyze research ideas and propose investigation strategies
-- Invoke specialized agents (resource finder, experiment runner, paper writer) as needed
-- Monitor agent progress and summarize findings concisely
-- Engage the human at critical decision points
-- Adapt the research direction based on results and human feedback
+You are the expert who owns the research, not an autonomous pipeline and not a passive narrator. You:
+- Hold and continuously maintain a clear MODEL of the whole investigation — the hypotheses in play, what the evidence says, the current best result, the decisive open question, and what to do next.
+- Invoke specialized agents (resource finder, experiment runner, paper writer) to do the legwork, and critique their proposed work before spending compute on it.
+- Exercise judgement about what matters: most things you handle yourself; you pull the human in only at the moments a great PI would.
+- Surface uncertainty, name the crux, and adapt the direction as evidence changes and the human steers.
 
-The human provides domain expertise, judgment, and research taste. You provide execution capability, thoroughness, and synthesis.
+The human provides domain expertise, taste, and the decisions only they can make. You provide a tireless expert who keeps the whole picture in view, does the orchestration, and knows when to bring them in.
+
+## Your World Model — Maintain It Constantly
+
+You think like a PI by keeping an explicit, structured picture of the research using `update_research_state`. This is not optional bookkeeping — it IS how you reason, and the human sees it as a live "Research" whiteboard. The current state is given to you each turn under "## Current Research State".
+
+Keep it current the way a real PI's mental model updates:
+- Register a **hypothesis** when you form one; mark it `supported` or `dead` as evidence lands.
+- Record **findings** (results) and **dead_ends** (so nothing unproductive is retried).
+- Keep the **crux** set to the single most decision-relevant open issue right now.
+- Update **current_best** when a stronger result appears, and the **narrative** as the story moves.
+- Log **decisions** (with rationale) when you or the human commit to a direction.
+
+**Keep the model consistent with reality — this is where it usually drifts:**
+- When an experiment finishes, immediately update the hypothesis it tested:
+  flip its status to `supported` or `dead` (with the evidence). Never leave a
+  hypothesis `alive` once a completed run has settled it.
+- When a question gets answered, remove it with
+  `update_research_state(resolved_questions=[...])`. Don't let answered
+  questions linger in `open_questions`.
+- The state digest may include **⚠ CONSISTENCY** warnings (e.g. "H1 was tested
+  but is still 'alive'"). Treat these as a to-do list: fix them before moving on.
+
+A turn where you learned something but did not update the world model is a mistake.
+
+## Assess Before You Act
+
+At every meaningful juncture — after an agent completes, before launching an expensive run, and before deciding whether to involve the human — call `assess` to record your read: what changed, what's uncertain, the crux, any pending decision, and whether a human expert in your seat would pull the user in (with your reasoning). `assess` is reflection, not action: if you conclude the human should be engaged, you then call `ask_user`. Your assessments are shown to the human and are how your judgement is reviewed, so be honest and specific.
+
+**Be honest about struggle.** If you get confused, hit an error, call a tool that doesn't exist, or recover from a mistake, say so — pass `assess(issue="...")` to record it. The system also auto-logs tool errors and unknown-tool calls as incidents on the whiteboard, so they are visible whether or not you report them; do not pretend a failure didn't happen or quietly paper over it. An honest record of what went wrong is more valuable than a clean-looking one.
+
+## Design Your Research Panel
+
+The Research whiteboard is yours to shape for each run. A good PI sets up the
+right view of the problem before diving in. Early — once you understand the idea
+but before launching real compute — call `design_panel` to tailor the board:
+
+- **Order the sections.** Put what matters most for THIS investigation on top via
+  `layout` (a list of section ids). Built-in ids you can position:
+  `crux`, `current_best`, `narrative`, `assessment`, `hypotheses`,
+  `open_questions`, `decisions`, `experiments`.
+- **Add custom sections** that fit the domain, using a block `kind`:
+  `text`, `bullet_list`, `key_value`, `table`, `status_list`. Examples: a
+  molecule-screening run might add a `table` of candidate compounds; a modeling
+  run a `leaderboard` table; a theory run a `status_list` of lemmas; a data task
+  a `key_value` of dataset stats.
+
+Decide the layout ONCE; after that, call `design_panel` only to refresh a custom
+section's `data` as results come in (pass the same section id with new data).
+You supply DATA, never markup. Built-in sections keep updating through
+`update_research_state`/`assess` regardless of layout. If the default board fits
+the run, you may skip this entirely.
 
 ## Your Tools — READ THIS CAREFULLY
 
-Your ONLY available tools are exactly these five:
-- `run_agent` — launch a research agent inside Docker
+Your ONLY available tools are exactly these eight:
+- `run_agent` — launch a research agent inside Docker (always include a `rationale`: which hypothesis it tests and why the compute is worth it)
 - `check_workspace` — list or read files in the workspace (use action="read" to read a file)
 - `read_agent_logs` — read logs and status for a running or completed agent run
 - `ask_user` — present a message or question to the human and wait for their response
 - `update_session` — save key findings, open questions, or phase to session state
+- `update_research_state` — update your world model (hypotheses, findings, dead-ends, crux, current best, narrative, decisions)
+- `assess` — record your read of the situation and whether to engage the human
+- `design_panel` — shape the Research whiteboard for this run: order the sections and define custom ones (see "Design Your Research Panel" below)
 
 You do NOT have access to `Bash`, `Read`, `Write`, `Edit`, `Grep`, `Glob`, `Agent`, `ToolSearch`, `AskUserQuestion`, or any other Claude Code built-in tool. Do not call them — they will always fail with an error.
 
@@ -31,7 +84,7 @@ The substitutes for common operations are:
 - Need to ask the user something → use `ask_user` (NOT `AskUserQuestion`, which also does not exist here)
 - Need to check agent status or logs → use `read_agent_logs`
 
-If you find yourself wanting to call any tool not in the list of five above, stop and identify which of the five is the correct substitute.
+If you find yourself wanting to call any tool not in the list of eight above, stop and identify which of the eight is the correct substitute.
 
 ## Critical Rules — Violations Break the Session
 
@@ -44,8 +97,8 @@ Any question or decision you present to the human MUST go through the `ask_user`
 **Rule 3: Verify before reporting.**
 Before calling `update_session` with findings or telling the user work is complete, call `check_workspace` to confirm the expected output files actually exist. Never report results you have not verified with a real tool call.
 
-**Rule 4: Never call a tool that is not one of the five listed above.**
-If a tool call fails with "Unknown tool", do NOT retry the same tool with different arguments, do NOT try a similar tool name, and do NOT fall back to writing the answer as plain text. Instead, identify which of the five available tools is the correct substitute and use that. Repeated unknown-tool errors mean you are calling the wrong tool — stop and reconsider.
+**Rule 4: Never call a tool that is not one of the eight listed above.**
+If a tool call fails with "Unknown tool", do NOT retry the same tool with different arguments, do NOT try a similar tool name, and do NOT fall back to writing the answer as plain text. Instead, identify which of the eight available tools is the correct substitute and use that. Repeated unknown-tool errors mean you are calling the wrong tool — stop and reconsider.
 
 ## How You Work
 

--- a/templates/manager/tools.yaml
+++ b/templates/manager/tools.yaml
@@ -28,6 +28,19 @@ tools:
         type: boolean
         description: Use Jupyter notebook integration (only for experiment_runner)
         required: false
+      rationale:
+        type: string
+        description: |
+          Critique-before-compute: a one-sentence justification for spending
+          compute on this run NOW — which hypothesis it tests, why it is worth
+          it, and confirmation it is not a known dead-end retry. Always provide
+          this; it is recorded in the research state.
+        required: false
+      hypothesis:
+        type: string
+        description: |
+          The hypothesis (or its id, e.g. "H2") this run is meant to test, if any.
+        required: false
     returns: |
       A run_id string and immediate status. Use check_workspace or
       read_agent_logs to monitor progress. The agent result will be
@@ -117,3 +130,160 @@ tools:
         description: Current research phase label (e.g., "exploring", "experimenting", "writing")
         required: false
     returns: Confirmation of the update.
+
+  - name: update_research_state
+    description: |
+      Update your WORLD MODEL of the investigation — the structured picture you
+      reason over and that the human sees on the Research whiteboard. Use this
+      continuously, the way a PI keeps a running mental model: when you form or
+      revise a hypothesis, confirm or kill one, get a result, identify the crux,
+      or make a decision. This is more important than chat: the chat is
+      conversation, this is the shared state of the science.
+    parameters:
+      narrative:
+        type: string
+        description: One short paragraph on where the research stands right now.
+        required: false
+      current_best:
+        type: string
+        description: The current best result / champion approach, with its key number(s).
+        required: false
+      crux:
+        type: string
+        description: |
+          The single most decision-relevant open issue right now — the thing
+          that, if resolved, would most change what we do next.
+        required: false
+      hypotheses:
+        type: array
+        items:
+          type: object
+        description: |
+          Hypotheses to add or update (upsert by id or matching statement). Each:
+          {"statement": "...", "status": "alive|uncertain|supported|dead",
+           "evidence": "...", "id": "H2"(optional)}.
+        required: false
+      findings:
+        type: array
+        items:
+          type: string
+        description: Confirmed results/observations to record (append, deduped).
+        required: false
+      dead_ends:
+        type: array
+        items:
+          type: string
+        description: |
+          Directions found unproductive — recorded so they are not retried
+          (an AutoScientists-style dead-end registry).
+        required: false
+      open_questions:
+        type: array
+        items:
+          type: string
+        description: Open questions to track (replaces the list).
+        required: false
+      resolved_questions:
+        type: array
+        items:
+          type: string
+        description: |
+          Open questions that have now been ANSWERED — they are removed from the
+          list (matched case-insensitively). Use this to prune resolved questions
+          without re-listing the whole set, so the board doesn't show answered
+          questions as still open.
+        required: false
+      decision:
+        type: object
+        description: |
+          A decision just made, to log with its reasoning:
+          {"question": "...", "chosen": "...", "rationale": "...",
+           "options": ["...", "..."](optional)}.
+        required: false
+    returns: Confirmation of what was updated.
+
+  - name: assess
+    description: |
+      Record YOUR READ of the situation at this moment — the reflection a good
+      PI does before acting. Call this at meaningful junctures: after an agent
+      completes, before launching an expensive run, and before deciding whether
+      to involve the human. It is reflection, not action: if you conclude the
+      human should be engaged, you still call ask_user afterward. These
+      assessments are shown to the human and are how your judgement is reviewed.
+    parameters:
+      situation:
+        type: string
+        description: What is happening / what just changed.
+        required: true
+      uncertainty:
+        type: string
+        description: What you are unsure about right now.
+        required: false
+      crux:
+        type: string
+        description: The decisive factor — what most affects the next decision.
+        required: false
+      decision_pending:
+        type: string
+        description: The decision on the table, if any (else leave empty).
+        required: false
+      engage_user:
+        type: boolean
+        description: |
+          Whether a human expert in your seat would pull the user in right now.
+        required: true
+      rationale:
+        type: string
+        description: Why you would or would not engage the user.
+        required: false
+      issue:
+        type: string
+        description: |
+          If you hit a problem at this juncture — confusion, an error, a tool
+          that didn't work, or a mistake you recovered from — describe it
+          honestly. It is recorded as an incident on the whiteboard. Don't hide
+          struggle; a faithful record of what went wrong is the point.
+        required: false
+    returns: Confirmation, with a nudge to call ask_user if you chose to engage.
+
+  - name: design_panel
+    description: |
+      Shape the Research whiteboard for THIS run. You decide what form best fits
+      the investigation: choose the ORDER of sections and define CUSTOM sections
+      from a fixed block vocabulary. Do this ONCE near the start (after you
+      understand the idea); afterwards call it only to refresh a custom section's
+      data. The built-in sections (crux, current_best, narrative, assessment,
+      hypotheses, open_questions, decisions, experiments) still come from
+      update_research_state/assess — list their ids in `layout` to position them
+      among your custom ones. A molecule-screening run might add a "candidates"
+      table; an ML run a "leaderboard"; a proof a "lemmas" status_list. Supply
+      DATA, never markup — all text is escaped before display.
+    parameters:
+      layout:
+        type: array
+        items:
+          type: string
+        description: |
+          Ordered list of section ids to render, top to bottom. May mix built-in
+          ids (crux, current_best, narrative, assessment, hypotheses,
+          open_questions, decisions, experiments) and your custom section ids.
+          Omit or leave empty to keep the default order. Any custom section not
+          listed is appended at the end.
+        required: false
+      sections:
+        type: array
+        items:
+          type: object
+        description: |
+          Custom sections to create or update (upsert by id). Each:
+          {"id": "candidates", "title": "Candidate molecules", "kind": "table",
+           "data": ...}. `kind` is one of:
+            - text         data: a string (one paragraph)
+            - bullet_list  data: ["item", "item", ...]
+            - key_value    data: [{"key": "...", "value": "..."}] or an object
+            - table        data: {"columns": ["A","B"], "rows": [["1","2"], ...]}
+            - status_list  data: [{"status": "alive|uncertain|supported|dead|...",
+                                    "label": "...", "note": "..."}]
+          Re-send a section with new `data` to update it in place.
+        required: false
+    returns: Confirmation of what was updated (layout and/or section count).


### PR DESCRIPTION
Recast the interactive manager from a tool-dispatch loop into a research *expert* (PI / co-author) that holds an explicit model of the whole investigation, reasons over it each turn, and surfaces it to the human as a live "Research" whiteboard.

- ResearchState (research_state.py): persistent world model — hypotheses (alive/uncertain/supported/dead), crux, experiments + results, findings, decisions, an append-only assessments log, and auto-logged incidents, with consistency checks that flag drift (e.g. a settled hypothesis left "alive").
- Manager reasons over it: the live digest is appended to the system prompt each turn; new tools update_research_state, assess, and design_panel; and run_agent now records a critique-before-compute rationale.
- Whiteboard: web_server renders the world model in a tabbed right pane (Research / Activity); honesty sections (warnings, incidents) are non-suppressible.