### PR TITLE
feat(interactive): MCP tool backend for the manager

### DIFF
--- a/06-09-changes.md
+++ b/06-09-changes.md
@@ -1,0 +1,105 @@
+# 2026-06-09 — Manager "no permission to write code" deadlock fix
+
+## Symptom
+
+After a run finished, asking the interactive manager to make one more change
+(e.g. "add an Age-only baseline row") sent it into a confusion loop: it insisted
+it lacked permission to write code and kept telling the user to press
+`Shift+Tab` / switch to auto mode, while the user saw **no** approval prompt in
+VS Code. Nothing the user did cleared it.
+
+## Root cause (two stacked bugs)
+
+The manager is itself a headless `claude -p` subprocess (MCP backend, since the
+session provider is `claude`). When asked for a targeted change it hit:
+
+1. **Wrong dispatch path.** It first dispatched a `comment_handler` worker
+   (`ch_001`), which died in ~2s with `"No comments found in idea file"`.
+   `comment_handler` only reads its change request from the idea YAML's
+   `comments:` field — the **GitHub/async** flow. An interactive request arrives
+   over **chat**, so there was nothing for it to read.
+
+2. **Un-closed native-tool escape hatch.** After the worker failed, the manager
+   fell back to editing `src/experiment.py` itself with native `Edit`/`Bash`.
+   The MCP backend launches `claude -p` with `--allowedTools "mcp__neurico__*"`
+   but **no** `--dangerously-skip-permissions` and **no** `--disallowedTools`.
+   `--allowedTools` only *pre-approves* the NeuriCo tools — it does **not** make
+   them exclusive — so the native `Edit`/`Write`/`Bash` tools were still visible
+   and every write blocked on a permission prompt that, in headless print mode,
+   can **never** surface to the user. Reads (auto-approved) worked, which is why
+   the manager reported "reads work, writes are pending approval" → permanent
+   deadlock.
+
+(The CLI backend never had bug #2 — it hard-disables native tools with
+`--tools ""`. The MCP backend just never closed the same hole.)
+
+## Fixes
+
+### Fix 1 — give `comment_handler` a direct instructions channel
+
+A targeted change can now be passed straight to the agent instead of requiring a
+GitHub `comments:` field. New optional `instructions` parameter on `run_agent`;
+for `comment_handler` it is effectively required.
+
+- `src/core/agent_runner.py`
+  - `run_comment_handler(...)` gains `instructions: Optional[str]`. When present
+    it is injected as the comment source (precedence over `idea.comments`), so
+    the agent no longer dead-ends on "No comments found".
+  - `main()` adds a `--instructions` CLI flag and forwards it to
+    `comment_handler` via kwargs.
+- `src/interactive/tools.py` (`_run_agent`)
+  - Reads `instructions` (or `request`) from the tool args and appends
+    `--instructions <text>` to the `_run-agent` command for `comment_handler`.
+  - **Guard:** if `comment_handler` is dispatched with no `instructions`, return
+    an explicit error telling the manager to pass the request text and that it
+    has no file-writing tools of its own — instead of silently failing in-container.
+- `src/interactive/mcp_server.py` — added `instructions` to the `run_agent` MCP
+  input schema so the manager (MCP backend) can actually pass it.
+- `templates/manager/tools.yaml` — added the `instructions` parameter to the
+  `run_agent` tool definition (API/CLI backends).
+- `templates/manager/system_prompt.txt` — added explicit guidance: to change or
+  add code, delegate via `run_agent` (`comment_handler` for small targeted
+  changes with `instructions=...`, `experiment_runner` for larger re-runs), and
+  **never** attempt `Edit`/`Write`/`Bash` directly.
+
+### Fix 2 — close the native-tool escape hatch in the MCP backend
+
+- `src/interactive/llm_backend.py` (`_send_mcp`)
+  - Added `--disallowedTools "<native tools>"` to the `claude -p` command, via a
+    new `_NATIVE_TOOLS_DISALLOWED` constant
+    (`Bash, Edit, Write, MultiEdit, NotebookEdit, Read, Glob, Grep, LS,
+    WebFetch, WebSearch, Task, TodoWrite`).
+  - The manager now physically cannot attempt a native edit; its only path to
+    touching code is delegation via `run_agent`. This mirrors the CLI backend's
+    `--tools ""` and removes the deadlock at the source.
+
+These are complementary: Fix 1 makes the correct path *work*; Fix 2 makes the
+broken path *impossible to take*. Net manager tool count goes **down**, not up.
+
+## Why no rebuild is needed
+
+`docker/run.sh _run-agent` quotes passthrough args with `printf '%q'`, so
+`--instructions "text with spaces"` survives the `eval`. It mounts `src/` and
+`templates/` read-only into the container, so the agent-side changes are live;
+the manager runs on the host, so the backend/tool changes are live too.
+
+## Files changed
+
+- `src/core/agent_runner.py`
+- `src/interactive/tools.py`
+- `src/interactive/mcp_server.py`
+- `src/interactive/llm_backend.py`
+- `templates/manager/tools.yaml`
+- `templates/manager/system_prompt.txt`
+
+## Validation
+
+- `python -m py_compile` passes on all four edited Python files.
+- `templates/manager/tools.yaml` parses as valid YAML.
+
+## Follow-up not done here
+
+- The reproduction workspace
+  (`workspaces/titanic_survival_prediction_20260609_163448_67d058cf_interactive`)
+  still has the pending "Age-only rule" change unapplied; re-issuing it in a new
+  manager session will now route through `comment_handler` correctly.

--- a/config/manager.yaml
+++ b/config/manager.yaml
@@ -5,9 +5,17 @@
 
 manager:
   # LLM backend for manager reasoning
-  # Options: "cli" (uses claude -p, no extra keys), "anthropic_api", "openrouter"
-  # Can also be set via NEURICO_MANAGER_BACKEND env var
-  llm_backend: cli
+  # Default: auto-detected from default_provider — "mcp" when provider is "claude",
+  #          "cli" (XML tool definitions) otherwise (Codex, Gemini, …).
+  # Options:
+  #   "mcp"           — claude -p with MCP-registered tools (requires Claude Code CLI + pip install mcp)
+  #                     Recommended for Claude users: no hallucinated <tool_result> blocks.
+  #   "cli"           — claude -p with XML tool descriptions (requires Claude Code CLI)
+  #                     Older approach; prone to <tool_result> hallucination.
+  #   "anthropic_api" — Anthropic Python SDK with native tool schemas (requires ANTHROPIC_API_KEY)
+  #   "openrouter"    — OpenRouter API, supports Codex / Gemini / etc. (requires OPENROUTER_API_KEY)
+  # Override via NEURICO_MANAGER_BACKEND env var or uncomment below:
+  # llm_backend: mcp
 
   # Model to use for manager reasoning (null = default for backend)
   # For cli: uses whatever claude version is installed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "openai>=1.0.0",
     "nbformat>=5.10.4",
     "fastmcp>=2.0",
+    "mcp>=1.0",
     "httpx>=0.25.0",
 ]
 

--- a/src/core/agent_runner.py
+++ b/src/core/agent_runner.py
@@ -345,8 +345,18 @@ def run_paper_writer(idea: Dict[str, Any], work_dir: Path, provider: str,
 
 def run_comment_handler(idea: Dict[str, Any], work_dir: Path, provider: str,
                         tracker: RunTracker, full_permissions: bool = True,
-                        templates_dir: Optional[Path] = None) -> Dict[str, Any]:
-    """Run the comment handler agent for targeted improvements."""
+                        templates_dir: Optional[Path] = None,
+                        instructions: Optional[str] = None) -> Dict[str, Any]:
+    """Run the comment handler agent for targeted improvements.
+
+    The change request can come from two channels:
+    - `instructions`: a free-form request passed directly (used by the
+      interactive manager, whose requests arrive over chat — not GitHub).
+    - `idea.comments`: the GitHub/async flow, where a reviewer leaves a
+      `comments:` field on the idea YAML.
+    When `instructions` is provided it takes precedence and is injected as the
+    comment source, so the manager no longer dead-ends on "No comments found".
+    """
     from agents.comment_handler import generate_comment_prompt
 
     if templates_dir is None:
@@ -356,10 +366,24 @@ def run_comment_handler(idea: Dict[str, Any], work_dir: Path, provider: str,
     print(f"   Provider: {provider}")
     print(f"   Work dir: {work_dir}")
 
+    # Direct instructions (interactive manager) override the idea's comments
+    # field (GitHub flow). Inject into the nested spec so generate_comment_prompt
+    # — which reads idea_spec['comments'] — picks them up unchanged.
+    if instructions:
+        idea = dict(idea)
+        spec = dict(idea.get('idea', idea))
+        spec['comments'] = instructions
+        if 'idea' in idea:
+            idea['idea'] = spec
+        else:
+            idea = spec
+        print(f"   Source: direct instructions ({len(instructions)} chars)")
+
     # Generate prompt from comments in the idea file
     comments = idea.get('idea', {}).get('comments', [])
     if not comments:
-        return {'success': False, 'error': 'No comments found in idea file'}
+        return {'success': False, 'error': 'No comments found in idea file '
+                '(and no --instructions passed)'}
 
     prompt = generate_comment_prompt(idea, work_dir, templates_dir)
 
@@ -481,6 +505,12 @@ def main():
         action="store_true",
         help="Use scribe for notebook integration (for experiment_runner agent)"
     )
+    parser.add_argument(
+        "--instructions",
+        default=None,
+        help="Free-form change request for comment_handler (interactive manager "
+             "flow; replaces the idea's 'comments:' field)"
+    )
 
     args = parser.parse_args()
 
@@ -504,6 +534,8 @@ def main():
         kwargs['paper_style'] = args.paper_style
     if args.agent == 'experiment_runner':
         kwargs['use_scribe'] = args.use_scribe
+    if args.agent == 'comment_handler' and args.instructions:
+        kwargs['instructions'] = args.instructions
 
     # Run the agent
     result = run_agent(

--- a/src/interactive/llm_backend.py
+++ b/src/interactive/llm_backend.py
@@ -75,7 +75,7 @@ class LLMBackend:
         if self.backend == "cli":
             return self._send_cli(messages, tools)
         elif self.backend == "mcp":
-            return self._send_mcp(messages, self.mcp_config_path)
+            return self._send_mcp(messages, self.mcp_config_path, tools)
         elif self.backend == "anthropic_api":
             return self._send_anthropic_api(messages, tools)
         elif self.backend == "openrouter":
@@ -127,8 +127,17 @@ class LLMBackend:
 
         return self._parse_cli_response(stdout)
 
+    # Fallback allow-list if no tool definitions are passed (keeps behaviour if a
+    # caller invokes the mcp backend without tools). The live list is derived
+    # from the tool definitions below so adding a tool can't silently leave it
+    # uncallable.
+    _MCP_TOOL_FALLBACK = ("run_agent", "check_workspace", "read_agent_logs",
+                          "ask_user", "update_session", "update_research_state",
+                          "assess", "design_panel")
+
     def _send_mcp(self, messages: List[Dict[str, Any]],
-                  mcp_config_path: Optional[str] = None) -> LLMResponse:
+                  mcp_config_path: Optional[str] = None,
+                  tools: Optional[List[Dict[str, Any]]] = None) -> LLMResponse:
         """
         Send via claude -p with NeuriCo tools registered as an MCP server.
 
@@ -138,8 +147,12 @@ class LLMBackend:
         """
         prompt = self._messages_to_prompt(messages, tools=None)
 
+        names = [t.get("name") for t in tools if t.get("name")] if tools \
+            else list(self._MCP_TOOL_FALLBACK)
+        allowed = ",".join(f"mcp__neurico__{n}" for n in names)
+
         cmd = "claude -p --verbose --output-format stream-json"
-        cmd += ' --allowedTools "mcp__neurico__run_agent,mcp__neurico__check_workspace,mcp__neurico__read_agent_logs,mcp__neurico__ask_user,mcp__neurico__update_session,mcp__neurico__update_research_state,mcp__neurico__assess,mcp__neurico__design_panel"'
+        cmd += f' --allowedTools "{allowed}"'
         if mcp_config_path:
             cmd += f' --mcp-config "{mcp_config_path}"'
         if self.model:
@@ -167,10 +180,19 @@ class LLMBackend:
 
         # IPC watcher: intercepts ask_user calls from the MCP server subprocess
         # and routes them through the web channel instead of the terminal.
-        # Protocol: MCP server writes ask_user_request.json, we call channel.prompt(),
-        # write ask_user_response.json so the MCP server can return the answer.
+        # Protocol: MCP server writes ask_user_request.json with a unique "id",
+        # we call channel.prompt(), then write ask_user_response.json echoing that
+        # id. The id lets the server ignore a stale response from an earlier ask
+        # (e.g. one that timed out), so answers can't cross between questions.
+        # Writes are atomic (temp + os.replace) so the 0.3s poller never reads a
+        # half-written file.
         ask_user_exchanges: List[Dict[str, Any]] = []
         stop_ipc = threading.Event()
+
+        def _atomic_write_json(path: Path, obj: Any) -> None:
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_text(json.dumps(obj), encoding="utf-8")
+            os.replace(tmp, path)
 
         def _ipc_watcher():
             if not self.ipc_dir or not self.channel:
@@ -182,9 +204,11 @@ class LLMBackend:
                     answer = ""
                     question = ""
                     options = None
+                    req_id = ""
                     try:
                         data = json.loads(req_file.read_text(encoding="utf-8"))
                         req_file.unlink()
+                        req_id = data.get("id", "")
                         question = data.get("message", "")
                         options = data.get("options") or None
                         answer = self.channel.prompt(message=question, options=options)
@@ -199,9 +223,8 @@ class LLMBackend:
                         # Always write the response so the MCP server is never left
                         # polling forever — even if prompt() raised or channel closed.
                         try:
-                            resp_file.write_text(
-                                json.dumps({"response": answer}), encoding="utf-8"
-                            )
+                            _atomic_write_json(
+                                resp_file, {"id": req_id, "response": answer})
                         except Exception:
                             pass
                 time.sleep(0.3)
@@ -560,6 +583,24 @@ class LLMBackend:
         return LLMResponse(text=text, tool_calls=tool_calls, raw=data)
 
 
+def resolve_backend(config: Dict[str, Any]) -> str:
+    """Single source of truth for which manager backend runs.
+
+    Precedence: NEURICO_MANAGER_BACKEND env > config manager.llm_backend >
+    auto-detect from provider (claude → mcp for native tool calling via
+    claude -p; anything else → cli). Both manager.py (to decide whether to
+    provision .mcp.json / the IPC dir) and create_backend() call this, so the
+    two can never disagree about which backend is active.
+    """
+    configured = os.environ.get("NEURICO_MANAGER_BACKEND",
+                                config.get("manager", {}).get("llm_backend")) or None
+    if configured:
+        return configured
+    provider = os.environ.get("NEURICO_PROVIDER",
+                              config.get("manager", {}).get("default_provider", "claude"))
+    return "mcp" if provider == "claude" else "cli"
+
+
 def create_backend(config: Dict[str, Any],
                    mcp_config_path: Optional[str] = None,
                    channel=None,
@@ -576,28 +617,19 @@ def create_backend(config: Dict[str, Any],
     """
     import shutil
 
-    configured = os.environ.get("NEURICO_MANAGER_BACKEND",
-                                config.get("manager", {}).get("llm_backend")) or None
+    backend = resolve_backend(config)
     model = os.environ.get("NEURICO_MANAGER_MODEL",
                            config.get("manager", {}).get("llm_model")) or None
 
-    if configured:
-        backend = configured
-        if backend in ("mcp", "cli") and shutil.which("claude") is None:
-            raise RuntimeError(
-                f"llm_backend '{backend}' requires the Claude Code CLI ('claude' command) "
-                "but it was not found in PATH.\n"
-                "  • Install Claude Code: https://claude.ai/code\n"
-                "  • Or set a non-CLI backend in config/manager.yaml or NEURICO_MANAGER_BACKEND:\n"
-                "      anthropic_api   — requires ANTHROPIC_API_KEY\n"
-                "      openrouter      — requires OPENROUTER_API_KEY (supports Codex, Gemini, …)"
-            )
-    else:
-        # Auto-detect based on provider: Claude → mcp (native tool calling via claude -p),
-        # anything else (Codex, Gemini, …) → cli (XML tool definitions in prompt)
-        provider = os.environ.get("NEURICO_PROVIDER",
-                                  config.get("manager", {}).get("default_provider", "claude"))
-        backend = "mcp" if provider == "claude" else "cli"
+    if backend in ("mcp", "cli") and shutil.which("claude") is None:
+        raise RuntimeError(
+            f"llm_backend '{backend}' requires the Claude Code CLI ('claude' command) "
+            "but it was not found in PATH.\n"
+            "  • Install Claude Code: https://claude.ai/code\n"
+            "  • Or set a non-CLI backend in config/manager.yaml or NEURICO_MANAGER_BACKEND:\n"
+            "      anthropic_api   — requires ANTHROPIC_API_KEY\n"
+            "      openrouter      — requires OPENROUTER_API_KEY (supports Codex, Gemini, …)"
+        )
 
     return LLMBackend(backend=backend, model=model,
                       mcp_config_path=mcp_config_path, channel=channel,

--- a/src/interactive/llm_backend.py
+++ b/src/interactive/llm_backend.py
@@ -13,6 +13,8 @@ import json
 import os
 import shlex
 import subprocess
+import threading
+import time
 
 
 @dataclass
@@ -29,6 +31,9 @@ class LLMResponse:
     text: str
     tool_calls: List[ToolCall] = field(default_factory=list)
     raw: Any = None
+    streamed: bool = False  # True if text was already sent to channel during generation
+    had_tools: bool = False  # True if any mcp__neurico__* tools were called this session
+    ask_user_exchanges: List[Dict[str, Any]] = field(default_factory=list)
 
 
 class LLMBackend:
@@ -37,14 +42,22 @@ class LLMBackend:
     parsed responses with tool calls.
     """
 
-    def __init__(self, backend: str = "cli", model: Optional[str] = None):
+    def __init__(self, backend: str = "cli", model: Optional[str] = None,
+                 mcp_config_path: Optional[str] = None, channel=None,
+                 ipc_dir: Optional[str] = None):
         """
         Args:
-            backend: "cli", "anthropic_api", or "openrouter"
+            backend: "cli", "mcp", "anthropic_api", or "openrouter"
             model: Model name override (None = default for backend)
+            mcp_config_path: Path to .mcp.json (required when backend="mcp")
+            channel: UserChannel for real-time UI updates during MCP sessions
+            ipc_dir: Directory for ask_user IPC with the MCP server subprocess
         """
         self.backend = backend
         self.model = model
+        self.mcp_config_path = mcp_config_path
+        self.channel = channel
+        self.ipc_dir = Path(ipc_dir) if ipc_dir else None
 
     def send(self, messages: List[Dict[str, Any]],
              tools: Optional[List[Dict[str, Any]]] = None) -> LLMResponse:
@@ -61,6 +74,8 @@ class LLMBackend:
         """
         if self.backend == "cli":
             return self._send_cli(messages, tools)
+        elif self.backend == "mcp":
+            return self._send_mcp(messages, self.mcp_config_path)
         elif self.backend == "anthropic_api":
             return self._send_anthropic_api(messages, tools)
         elif self.backend == "openrouter":
@@ -81,6 +96,18 @@ class LLMBackend:
         cmd = "claude -p --verbose --output-format stream-json"
         if self.model:
             cmd += f" --model {self.model}"
+        # CRITICAL: the manager is itself driven by `claude -p` — a full Claude
+        # Code agent that has its OWN native tools (Bash/Read/…). If those are
+        # available, the inner agent tries to invoke the manager's tools through
+        # the native mechanism (the harness rejects them as "No such tool") or
+        # uses Bash/Read to "discover" it's a plain Claude Code session and
+        # breaks out of the manager persona entirely. Disabling all native tools
+        # removes that escape hatch: the ONLY way it can act is to emit the
+        # <tool_call> text blocks our shim parses (see _parse_cli_response).
+        # This is the root-cause fix for the manager "identity collapse" on the
+        # cli backend. (The mcp backend solves the same problem structurally via
+        # native MCP tool registration — see _send_mcp.)
+        cmd += ' --tools ""'
 
         process = subprocess.Popen(
             shlex.split(cmd),
@@ -99,6 +126,170 @@ class LLMBackend:
             raise RuntimeError(f"CLI backend error: {error_msg}")
 
         return self._parse_cli_response(stdout)
+
+    def _send_mcp(self, messages: List[Dict[str, Any]],
+                  mcp_config_path: Optional[str] = None) -> LLMResponse:
+        """
+        Send via claude -p with NeuriCo tools registered as an MCP server.
+
+        Reads stdout line-by-line so tool call events can be forwarded to
+        the UI channel in real time instead of blocking until the session ends.
+        stderr is drained in a background thread to prevent deadlock.
+        """
+        prompt = self._messages_to_prompt(messages, tools=None)
+
+        cmd = "claude -p --verbose --output-format stream-json"
+        cmd += ' --allowedTools "mcp__neurico__run_agent,mcp__neurico__check_workspace,mcp__neurico__read_agent_logs,mcp__neurico__ask_user,mcp__neurico__update_session,mcp__neurico__update_research_state,mcp__neurico__assess,mcp__neurico__design_panel"'
+        if mcp_config_path:
+            cmd += f' --mcp-config "{mcp_config_path}"'
+        if self.model:
+            cmd += f" --model {self.model}"
+
+        process = subprocess.Popen(
+            shlex.split(cmd),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1
+        )
+
+        # Write prompt and close stdin immediately so claude -p starts processing
+        process.stdin.write(prompt)
+        process.stdin.close()
+
+        # Drain stderr in background to prevent pipe deadlock
+        stderr_lines: List[str] = []
+        def _drain_stderr():
+            for line in iter(process.stderr.readline, ''):
+                stderr_lines.append(line)
+        threading.Thread(target=_drain_stderr, daemon=True).start()
+
+        # IPC watcher: intercepts ask_user calls from the MCP server subprocess
+        # and routes them through the web channel instead of the terminal.
+        # Protocol: MCP server writes ask_user_request.json, we call channel.prompt(),
+        # write ask_user_response.json so the MCP server can return the answer.
+        ask_user_exchanges: List[Dict[str, Any]] = []
+        stop_ipc = threading.Event()
+
+        def _ipc_watcher():
+            if not self.ipc_dir or not self.channel:
+                return
+            req_file = self.ipc_dir / "ask_user_request.json"
+            resp_file = self.ipc_dir / "ask_user_response.json"
+            while not stop_ipc.is_set():
+                if req_file.exists():
+                    answer = ""
+                    question = ""
+                    options = None
+                    try:
+                        data = json.loads(req_file.read_text(encoding="utf-8"))
+                        req_file.unlink()
+                        question = data.get("message", "")
+                        options = data.get("options") or None
+                        answer = self.channel.prompt(message=question, options=options)
+                        if answer is None:
+                            answer = ""
+                        ask_user_exchanges.append(
+                            {"question": question, "options": options, "answer": answer}
+                        )
+                    except Exception:
+                        pass
+                    finally:
+                        # Always write the response so the MCP server is never left
+                        # polling forever — even if prompt() raised or channel closed.
+                        try:
+                            resp_file.write_text(
+                                json.dumps({"response": answer}), encoding="utf-8"
+                            )
+                        except Exception:
+                            pass
+                time.sleep(0.3)
+
+        if self.ipc_dir and self.channel:
+            # Clean up any stale files from a previous session
+            for fname in ("ask_user_request.json", "ask_user_response.json"):
+                stale = self.ipc_dir / fname
+                if stale.exists():
+                    stale.unlink()
+            threading.Thread(target=_ipc_watcher, daemon=True).start()
+
+        # Read stdout line by line — forward events to channel in real time
+        last_text = ""
+        raw_events = []
+        text_streamed = False
+        had_tools = False
+
+        for line in iter(process.stdout.readline, ''):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+                raw_events.append(event)
+            except json.JSONDecodeError:
+                continue
+
+            etype = event.get("type", "")
+
+            if etype == "assistant" and "message" in event:
+                content_blocks = event["message"].get("content", [])
+                has_tool_use = any(b.get("type") == "tool_use" for b in content_blocks)
+                for block in content_blocks:
+                    if block.get("type") == "text":
+                        text = block["text"].strip()
+                        if text:
+                            last_text = block["text"]
+                            # Stream to channel only on final-answer turns
+                            # (turns with tool_use are intermediate reasoning rounds)
+                            if not has_tool_use and self.channel:
+                                self.channel.send(text, kind="manager")
+                                text_streamed = True
+                    elif block.get("type") == "tool_use":
+                        raw_name = block.get("name", "")
+                        if not raw_name.startswith("mcp__neurico__"):
+                            continue  # native Claude Code tool — skip
+                        had_tools = True
+                        if self.channel:
+                            name = raw_name.removeprefix("mcp__neurico__")
+                            echo = self._tool_echo(name, block.get("input", {}))
+                            if echo:
+                                self.channel.send(echo, kind="tool")
+
+            elif etype == "result":
+                result_text = event.get("result", "")
+                if result_text:
+                    last_text = result_text
+
+        stop_ipc.set()
+        process.wait()
+
+        if process.returncode != 0:
+            error_msg = "".join(stderr_lines).strip() or f"claude -p exited with code {process.returncode}"
+            raise RuntimeError(f"MCP backend error: {error_msg}")
+
+        return LLMResponse(text=last_text, tool_calls=[], raw=raw_events,
+                           streamed=text_streamed, had_tools=had_tools,
+                           ask_user_exchanges=ask_user_exchanges)
+
+    def _tool_echo(self, name: str, args: Dict[str, Any]) -> Optional[str]:
+        """Human-readable label for an MCP tool call, for the UI channel."""
+        if name == "ask_user":
+            return None
+        if name == "check_workspace":
+            verb = "Read" if args.get("action") == "read" else "Looked at"
+            return f"🔍 {verb} workspace ({args.get('path', '.')})"
+        if name == "read_agent_logs":
+            return f"📂 Checked agent logs ({args.get('run_id', '')})"
+        if name == "update_session":
+            return "📝 Updated session notes"
+        if name == "run_agent":
+            return f"🚀 Launched {args.get('agent', 'agent')}"
+        # World-model tools are silent in chat — they surface live on the
+        # Research whiteboard instead of adding noise to the conversation.
+        if name in ("update_research_state", "assess", "design_panel"):
+            return None
+        return f"🔧 {name}"
 
     def _messages_to_prompt(self, messages: List[Dict[str, Any]],
                             tools: Optional[List[Dict[str, Any]]] = None) -> str:
@@ -369,16 +560,45 @@ class LLMBackend:
         return LLMResponse(text=text, tool_calls=tool_calls, raw=data)
 
 
-def create_backend(config: Dict[str, Any]) -> LLMBackend:
+def create_backend(config: Dict[str, Any],
+                   mcp_config_path: Optional[str] = None,
+                   channel=None,
+                   ipc_dir: Optional[str] = None) -> LLMBackend:
     """
     Create an LLM backend from configuration.
 
     Config can come from config/manager.yaml or environment variables.
     Environment variables take precedence.
+
+    mcp_config_path: path to .mcp.json, required when backend="mcp".
+    channel: UserChannel forwarded to LLMBackend for real-time tool echoes.
+    ipc_dir: directory for ask_user IPC with the MCP server subprocess.
     """
-    backend = os.environ.get("NEURICO_MANAGER_BACKEND",
-                             config.get("manager", {}).get("llm_backend", "cli"))
+    import shutil
+
+    configured = os.environ.get("NEURICO_MANAGER_BACKEND",
+                                config.get("manager", {}).get("llm_backend")) or None
     model = os.environ.get("NEURICO_MANAGER_MODEL",
                            config.get("manager", {}).get("llm_model")) or None
 
-    return LLMBackend(backend=backend, model=model)
+    if configured:
+        backend = configured
+        if backend in ("mcp", "cli") and shutil.which("claude") is None:
+            raise RuntimeError(
+                f"llm_backend '{backend}' requires the Claude Code CLI ('claude' command) "
+                "but it was not found in PATH.\n"
+                "  • Install Claude Code: https://claude.ai/code\n"
+                "  • Or set a non-CLI backend in config/manager.yaml or NEURICO_MANAGER_BACKEND:\n"
+                "      anthropic_api   — requires ANTHROPIC_API_KEY\n"
+                "      openrouter      — requires OPENROUTER_API_KEY (supports Codex, Gemini, …)"
+            )
+    else:
+        # Auto-detect based on provider: Claude → mcp (native tool calling via claude -p),
+        # anything else (Codex, Gemini, …) → cli (XML tool definitions in prompt)
+        provider = os.environ.get("NEURICO_PROVIDER",
+                                  config.get("manager", {}).get("default_provider", "claude"))
+        backend = "mcp" if provider == "claude" else "cli"
+
+    return LLMBackend(backend=backend, model=model,
+                      mcp_config_path=mcp_config_path, channel=channel,
+                      ipc_dir=ipc_dir)

--- a/src/interactive/llm_backend.py
+++ b/src/interactive/llm_backend.py
@@ -135,6 +135,18 @@ class LLMBackend:
                           "ask_user", "update_session", "update_research_state",
                           "assess", "design_panel")
 
+    # Native Claude Code tools the manager must never use directly — any write
+    # among them deadlocks on an unanswerable permission prompt in headless
+    # print mode (see _send_mcp). Passed to `claude -p --disallowedTools` so the
+    # inner agent cannot even attempt them and is forced to delegate via
+    # run_agent. Read-only tools are included too so the manager can't "discover"
+    # it's a plain Claude Code session and break out of the manager persona.
+    _NATIVE_TOOLS_DISALLOWED = ",".join((
+        "Bash", "Edit", "Write", "MultiEdit", "NotebookEdit",
+        "Read", "Glob", "Grep", "LS", "WebFetch", "WebSearch",
+        "Task", "TodoWrite",
+    ))
+
     def _send_mcp(self, messages: List[Dict[str, Any]],
                   mcp_config_path: Optional[str] = None,
                   tools: Optional[List[Dict[str, Any]]] = None) -> LLMResponse:
@@ -153,6 +165,17 @@ class LLMBackend:
 
         cmd = "claude -p --verbose --output-format stream-json"
         cmd += f' --allowedTools "{allowed}"'
+        # CRITICAL: --allowedTools only PRE-APPROVES the NeuriCo MCP tools; it
+        # does NOT make them exclusive. The inner `claude -p` agent still SEES
+        # its native Claude Code tools (Bash/Edit/Write/…) and, under pressure,
+        # will try to edit workspace files directly. Those writes are not
+        # allow-listed, so each one blocks on a permission prompt — which, in
+        # headless print mode, can never surface to the user. The session then
+        # deadlocks ("I don't have permission to write") with no way out.
+        # Disallowing the native tools removes that escape hatch entirely: the
+        # ONLY way the manager can touch code is to delegate via run_agent (the
+        # CLI backend achieves the same thing structurally with `--tools ""`).
+        cmd += f' --disallowedTools "{self._NATIVE_TOOLS_DISALLOWED}"'
         if mcp_config_path:
             cmd += f' --mcp-config "{mcp_config_path}"'
         if self.model:

--- a/src/interactive/manager.py
+++ b/src/interactive/manager.py
@@ -38,7 +38,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from interactive.session_state import SessionState
 from interactive.research_state import ResearchState
-from interactive.llm_backend import LLMBackend, LLMResponse, create_backend
+from interactive.llm_backend import LLMBackend, LLMResponse, create_backend, resolve_backend
 from interactive.tools import ToolExecutor
 from interactive.channel import UserChannel, TerminalChannel
 from interactive.mcp_config import write_mcp_config
@@ -139,8 +139,14 @@ def load_tool_definitions() -> List[Dict[str, Any]]:
 
 
 def load_system_prompt(idea: Dict[str, Any], workspace: Path,
-                       provider: str, config: Dict[str, Any]) -> str:
-    """Load and render the system prompt template."""
+                       provider: str, config: Dict[str, Any],
+                       backend: str = "cli") -> str:
+    """Load and render the system prompt template.
+
+    `backend` selects the tool-invocation protocol: the cli backend drives the
+    model through a text `<tool_call>` shim, but the mcp/api backends register
+    tools natively — so the same XML instructions would be actively wrong there
+    (the model would emit XML text that nobody parses, dropping the call)."""
     prompt_file = PROJECT_ROOT / "templates" / "manager" / "system_prompt.txt"
     if not prompt_file.exists():
         raise FileNotFoundError(f"System prompt not found: {prompt_file}")
@@ -177,11 +183,31 @@ def load_system_prompt(idea: Dict[str, Any], workspace: Path,
     rendered = rendered.replace("{{ provider }}", provider)
     rendered = rendered.replace("{{ engagement_instructions }}", engagement_instructions)
 
+    if backend == "cli":
+        tool_protocol = (
+            "To invoke a tool, write a `<tool_call name=\"tool_name\">"
+            "{\"arg\": \"value\"}</tool_call>` block in your response — this "
+            "text-based protocol is the ONLY way to act here. The generic Claude "
+            "Code tools (`Bash`, `Read`, `Write`, `Edit`, `Grep`, `Glob`, "
+            "`Agent`, `AskUserQuestion`, …) are disabled and will error every "
+            "single time; there is no workaround.")
+    else:
+        tool_protocol = (
+            "Invoke the eight tools natively — call them directly, the same way "
+            "you call any tool. Do NOT write `<tool_call>` XML blocks as text: in "
+            "this environment that text is ignored and your action is silently "
+            "lost. Do not use the generic Claude Code tools (`Bash`, `Read`, "
+            "`Write`, `Edit`, `Grep`, `Glob`, `Agent`, `AskUserQuestion`); use "
+            "the eight NeuriCo tools above instead — e.g. `check_workspace` to "
+            "read or list files, `run_agent` to run code.")
+    rendered = rendered.replace("{{ tool_protocol }}", tool_protocol)
+
     return rendered
 
 
-def find_idea(idea_id: str) -> Optional[Dict[str, Any]]:
-    """Find an idea by ID across submitted/in_progress/completed folders."""
+def find_idea(idea_id: str) -> "tuple[Optional[Dict[str, Any]], Optional[Path]]":
+    """Find an idea by ID across submitted/in_progress/completed folders.
+    Returns (idea_dict, yaml_path), or (None, None) if not found."""
     ideas_dir = PROJECT_ROOT / "ideas"
     for folder in ["submitted", "in_progress", "completed"]:
         folder_path = ideas_dir / folder
@@ -259,12 +285,7 @@ class InteractiveManager:
         # the auto-detection in create_backend(): Claude → mcp, others → cli.
         mcp_config_path = None
         ipc_dir = None
-        backend_name = os.environ.get("NEURICO_MANAGER_BACKEND",
-                                      config.get("manager", {}).get("llm_backend")) or None
-        if backend_name is None:
-            _provider = os.environ.get("NEURICO_PROVIDER",
-                                       config.get("manager", {}).get("default_provider", "claude"))
-            backend_name = "mcp" if _provider == "claude" else "cli"
+        backend_name = resolve_backend(config)
         if backend_name == "mcp":
             # File IPC dir so the out-of-process MCP server can route ask_user
             # through the web channel instead of the terminal.
@@ -292,7 +313,8 @@ class InteractiveManager:
         # Base system prompt; the live research-state digest is appended fresh
         # each turn (see _agent_step) so the manager always reasons over current
         # state without polluting the persisted conversation history.
-        self.system_prompt = load_system_prompt(idea, workspace, provider, config)
+        self.system_prompt = load_system_prompt(idea, workspace, provider, config,
+                                                 backend=self.backend.backend)
         self.base_system_prompt = self.system_prompt
 
         # Conversation history (in-memory, backed by session)
@@ -302,6 +324,15 @@ class InteractiveManager:
         manager_config = config.get("manager", {})
         self.poll_interval = manager_config.get("poll_interval", 60)
         self.engagement_interval = manager_config.get("engagement_interval", 1800)
+
+        # Bound autonomous runaway: in MCP mode the manager loops back whenever a
+        # session did tool work without asking the human (see _agent_step). With
+        # no ceiling a model that always uses a tool but never calls ask_user
+        # would spawn `claude -p` forever, burning cost with no checkpoint. After
+        # this many consecutive tool-only loops we force a human checkpoint; the
+        # counter resets on any user input.
+        self.max_autonomous_steps = manager_config.get("max_autonomous_steps", 25)
+        self._autonomous_steps = 0
 
         self._shutdown = False
 
@@ -374,6 +405,10 @@ class InteractiveManager:
         # manager reasons over its up-to-date world model every turn. messages[0]
         # is always the system message (set in run()); we rewrite only its
         # content and never persist this ephemeral digest to history.
+        # reload() first: in MCP mode the tools mutate research_state.json from a
+        # separate subprocess, so without this the digest would be permanently
+        # stale (the in-process ResearchState never sees those writes).
+        self.research.reload()
         if self.messages and self.messages[0]["role"] == "system":
             self.messages[0]["content"] = (
                 self.base_system_prompt + self.research.digest_section())
@@ -425,17 +460,10 @@ class InteractiveManager:
             # When tools were called, the session did real work — loop back so
             # the manager continues autonomously. ask_user exchanges (if any)
             # are added to the conversation so the next session has context.
-            assistant_msg = {"role": "assistant", "content": response.text}
-            self.messages.append(assistant_msg)
-            self.session.append_message(assistant_msg)
-
-            clean = clean_chat_text(response.text)
-            if not response.streamed and clean:
-                self.channel.send(clean, kind="manager")
-
             # Persist ask_user Q&A so the next MCP session sees what the user said.
-            # Add both sides: assistant asking the question and the user's reply,
-            # so the model has full context rather than an orphaned user message.
+            # These happened *during* generation, so record them BEFORE the
+            # session's concluding text — both sides (assistant asking, user
+            # replying) so the model has full context, not an orphaned message.
             for exchange in response.ask_user_exchanges:
                 q_msg = {"role": "assistant",
                          "content": f"[asked user]: {exchange['question']}"}
@@ -445,20 +473,40 @@ class InteractiveManager:
                 self.messages.append(exch_user_msg)
                 self.session.append_message(exch_user_msg)
 
-            if response.had_tools:
-                # Manager did real work this session — loop back autonomously
-                return
+            assistant_msg = {"role": "assistant", "content": response.text}
+            self.messages.append(assistant_msg)
+            self.session.append_message(assistant_msg)
 
-            # No tools called: the manager yielded the floor to the human. Route
-            # the text THROUGH prompt() (not a plain send) so it's tagged as a
-            # question — rendered as the highlighted "needs your reply" card —
-            # even when the manager asked in prose instead of calling ask_user.
-            # (clean may be '' if the whole turn was noise; fall back to raw.)
+            clean = clean_chat_text(response.text)
+            if not response.streamed and clean:
+                self.channel.send(clean, kind="manager")
+
+            if response.had_tools:
+                # Manager did real work this session. Loop back autonomously —
+                # unless we've hit the autonomous-step ceiling, in which case fall
+                # through to a forced human checkpoint to bound cost/runaway.
+                self._autonomous_steps += 1
+                if self._autonomous_steps < self.max_autonomous_steps:
+                    return
+                self._autonomous_steps = 0
+                self.channel.send(
+                    f"(Checkpoint: I've run {self.max_autonomous_steps} autonomous "
+                    "steps without checking in. Reply to steer, or say 'continue'.)",
+                    kind="system")
+                # fall through to prompt() below
+
+            # No tools called (or checkpoint reached): yield the floor to the
+            # human. Route the text THROUGH prompt() (not a plain send) so it's
+            # tagged as a question — rendered as the highlighted "needs your
+            # reply" card — even when the manager asked in prose instead of
+            # calling ask_user. (clean may be '' if the whole turn was noise.)
             prompt_message = None if response.streamed else (clean or response.text)
             user_input = self.channel.prompt(message=prompt_message)
             if user_input is None:
                 self._shutdown = True
                 return
+            # Human steered — reset the autonomous budget.
+            self._autonomous_steps = 0
 
             user_input = user_input.strip()
             if not user_input:
@@ -565,8 +613,8 @@ def main():
     parser.add_argument(
         "--backend",
         default=None,
-        choices=["cli", "anthropic_api", "openrouter"],
-        help="LLM backend for manager reasoning (default: from config)"
+        choices=["mcp", "cli", "anthropic_api", "openrouter"],
+        help="LLM backend for manager reasoning (default: auto — mcp for claude, cli otherwise)"
     )
     parser.add_argument(
         "--cli",

--- a/src/interactive/manager.py
+++ b/src/interactive/manager.py
@@ -41,6 +41,7 @@ from interactive.research_state import ResearchState
 from interactive.llm_backend import LLMBackend, LLMResponse, create_backend
 from interactive.tools import ToolExecutor
 from interactive.channel import UserChannel, TerminalChannel
+from interactive.mcp_config import write_mcp_config
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +59,11 @@ from interactive.channel import UserChannel, TerminalChannel
 # eating inline backtick mentions like "`<tool_call>`" in meta-chatter.
 _TOOLCALL_BLOCK_RE = re.compile(r"<tool_call\b[^>]*\bname\s*=.*?</tool_call>",
                                 re.DOTALL | re.IGNORECASE)
+
+# Hallucinated tool results produced by the cli backend before real results
+# are injected — strip these so they never reach the chat display.
+_TOOLRESULT_BLOCK_RE = re.compile(r"<tool_result\b.*?</tool_result>",
+                                   re.DOTALL | re.IGNORECASE)
 
 # A "sentence" (bounded by . ! ? or a newline) that is purely about the tool
 # mechanism — noise to a human. The leading [^.!?\n]* anchors the match to the
@@ -79,6 +85,7 @@ def clean_chat_text(text: str) -> str:
     if not text:
         return ""
     text = _TOOLCALL_BLOCK_RE.sub("", text)
+    text = _TOOLRESULT_BLOCK_RE.sub("", text)
     text = _META_SENTENCE_RE.sub("", text)
     text = re.sub(r"[ \t]{2,}", " ", text)
     text = re.sub(r"\n{3,}", "\n\n", text)
@@ -246,7 +253,38 @@ class InteractiveManager:
         # The manager's world model — what makes it reason like a PI rather than
         # a tool dispatcher. Threaded into the executor so tools read/write it.
         self.research = ResearchState(workspace)
-        self.backend = create_backend(config)
+
+        # Resolve the backend up front so we can write the MCP config before
+        # the backend is created (the .mcp.json path must exist first). Mirrors
+        # the auto-detection in create_backend(): Claude → mcp, others → cli.
+        mcp_config_path = None
+        ipc_dir = None
+        backend_name = os.environ.get("NEURICO_MANAGER_BACKEND",
+                                      config.get("manager", {}).get("llm_backend")) or None
+        if backend_name is None:
+            _provider = os.environ.get("NEURICO_PROVIDER",
+                                       config.get("manager", {}).get("default_provider", "claude"))
+            backend_name = "mcp" if _provider == "claude" else "cli"
+        if backend_name == "mcp":
+            # File IPC dir so the out-of-process MCP server can route ask_user
+            # through the web channel instead of the terminal.
+            ipc_path = workspace / ".neurico" / "ipc"
+            ipc_path.mkdir(parents=True, exist_ok=True)
+            ipc_dir = str(ipc_path)
+
+            mcp_config_file = write_mcp_config(
+                work_dir=workspace,
+                idea_file=idea_file,
+                provider=provider,
+                idea_id=idea_id,
+                idea_title=idea_title,
+                project_root=PROJECT_ROOT,
+            )
+            mcp_config_path = str(mcp_config_file)
+            print(f"  MCP config: {mcp_config_file}")
+
+        self.backend = create_backend(config, mcp_config_path=mcp_config_path,
+                                      channel=self.channel, ipc_dir=ipc_dir)
         self.tools = ToolExecutor(workspace, self.session, idea_file, provider,
                                   PROJECT_ROOT, channel=self.channel,
                                   research=self.research)
@@ -379,19 +417,45 @@ class InteractiveManager:
                 self.session.append_message(tool_result_msg)
 
         else:
-            # No tool calls — the manager is yielding the floor to the human, so
-            # this turn IS effectively a question (the loop blocks on input next).
+            # No tool calls returned to the Python loop.
+            # In CLI mode this means the model finished — yield to user.
+            # In MCP mode the full tool loop ran inside claude -p, so we only
+            # yield to user when no mcp__neurico__* tools were called at all
+            # (i.e. the model produced a pure-text conclusion with no tool use).
+            # When tools were called, the session did real work — loop back so
+            # the manager continues autonomously. ask_user exchanges (if any)
+            # are added to the conversation so the next session has context.
             assistant_msg = {"role": "assistant", "content": response.text}
             self.messages.append(assistant_msg)
             self.session.append_message(assistant_msg)
 
             clean = clean_chat_text(response.text)
-            # Route the text THROUGH prompt() (not a plain send) so it's tagged as
-            # a question — rendered as the highlighted "needs your reply" card with
-            # the input box highlighted — even when the manager asked in prose
-            # instead of calling the ask_user tool. (clean may be '' if the whole
-            # turn was tool-mechanism noise; fall back to the raw text.)
-            user_input = self.channel.prompt(message=(clean or response.text))
+            if not response.streamed and clean:
+                self.channel.send(clean, kind="manager")
+
+            # Persist ask_user Q&A so the next MCP session sees what the user said.
+            # Add both sides: assistant asking the question and the user's reply,
+            # so the model has full context rather than an orphaned user message.
+            for exchange in response.ask_user_exchanges:
+                q_msg = {"role": "assistant",
+                         "content": f"[asked user]: {exchange['question']}"}
+                self.messages.append(q_msg)
+                self.session.append_message(q_msg)
+                exch_user_msg = {"role": "user", "content": exchange["answer"]}
+                self.messages.append(exch_user_msg)
+                self.session.append_message(exch_user_msg)
+
+            if response.had_tools:
+                # Manager did real work this session — loop back autonomously
+                return
+
+            # No tools called: the manager yielded the floor to the human. Route
+            # the text THROUGH prompt() (not a plain send) so it's tagged as a
+            # question — rendered as the highlighted "needs your reply" card —
+            # even when the manager asked in prose instead of calling ask_user.
+            # (clean may be '' if the whole turn was noise; fall back to raw.)
+            prompt_message = None if response.streamed else (clean or response.text)
+            user_input = self.channel.prompt(message=prompt_message)
             if user_input is None:
                 self._shutdown = True
                 return

--- a/src/interactive/mcp_config.py
+++ b/src/interactive/mcp_config.py
@@ -1,0 +1,45 @@
+"""
+MCP Configuration Writer for Interactive Mode
+
+Writes a .mcp.json file into the workspace directory that registers
+the NeuriCo MCP server for a specific session. Claude Code discovers
+this file when launched from the workspace directory.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def write_mcp_config(work_dir: Path, idea_file: Path, provider: str,
+                     idea_id: str, idea_title: str,
+                     project_root: Path) -> Path:
+    """
+    Write .mcp.json into work_dir, registering the NeuriCo MCP server
+    with session-specific environment variables.
+
+    Returns the path to the written config file.
+    """
+    python_cmd = sys.executable
+
+    config = {
+        "mcpServers": {
+            "neurico": {
+                "command": python_cmd,
+                "args": [
+                    str(project_root / "src" / "interactive" / "mcp_server.py")
+                ],
+                "env": {
+                    "NEURICO_WORK_DIR": str(work_dir),
+                    "NEURICO_IDEA_FILE": str(idea_file),
+                    "NEURICO_PROVIDER": provider,
+                    "NEURICO_IDEA_ID": idea_id,
+                    "NEURICO_IDEA_TITLE": idea_title,
+                }
+            }
+        }
+    }
+
+    config_path = work_dir / ".mcp.json"
+    config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
+    return config_path

--- a/src/interactive/mcp_server.py
+++ b/src/interactive/mcp_server.py
@@ -344,17 +344,26 @@ def create_server(work_dir: Path, idea_file: Path,
     _ASK_USER_TIMEOUT = 3600  # 1 hour — failsafe if manager dies
 
     def _ask_user_via_ipc(arguments: dict) -> str:
-        """Route ask_user through file IPC so the manager can show it in the web UI."""
-        import time as _time
+        """Route ask_user through file IPC so the manager can show it in the web UI.
+
+        Each request carries a unique id; we only accept a response echoing that
+        id, so a stale response left by an earlier (e.g. timed-out) ask can't be
+        misread as the answer to this one. Writes are atomic (temp + os.replace)."""
+        import time as _time, uuid
         req_file = ipc_dir / "ask_user_request.json"
         resp_file = ipc_dir / "ask_user_response.json"
-        req_file.write_text(
-            json.dumps({
-                "message": arguments.get("message", ""),
-                "options": arguments.get("options", []),
-            }),
-            encoding="utf-8",
-        )
+        req_id = uuid.uuid4().hex
+
+        def _atomic_write_json(path: Path, obj: dict) -> None:
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_text(json.dumps(obj), encoding="utf-8")
+            os.replace(tmp, path)
+
+        _atomic_write_json(req_file, {
+            "id": req_id,
+            "message": arguments.get("message", ""),
+            "options": arguments.get("options", []),
+        })
         # Poll for the response the manager writes back.
         # Timeout after _ASK_USER_TIMEOUT seconds so a crashed/closed manager
         # does not leave claude -p hanging indefinitely.
@@ -363,8 +372,11 @@ def create_server(work_dir: Path, idea_file: Path,
             if resp_file.exists():
                 try:
                     data = json.loads(resp_file.read_text(encoding="utf-8"))
+                    if data.get("id") == req_id:
+                        resp_file.unlink()
+                        return data.get("response", "")
+                    # Stale response for a different (earlier) request — discard it.
                     resp_file.unlink()
-                    return data.get("response", "")
                 except Exception:
                     pass
             _time.sleep(0.3)

--- a/src/interactive/mcp_server.py
+++ b/src/interactive/mcp_server.py
@@ -1,0 +1,410 @@
+"""
+NeuriCo MCP Server for Interactive Mode
+
+Exposes the 5 NeuriCo manager tools as an MCP server so that
+claude -p can register them at the API level via --allowedTools.
+
+This eliminates two structural problems with the cli backend:
+1. NeuriCo tools are registered at the API level with correct schemas,
+   so the model calls them natively rather than generating XML text.
+   Note: --allowedTools auto-approves these tools without prompting the
+   user — it is NOT a whitelist that blocks native Claude Code tools.
+2. Claude Code enforces stop_reason: tool_use, so generation halts
+   at every tool call and hallucinated <tool_result> blocks become
+   impossible.
+
+Usage:
+    Started automatically by manager.py when llm_backend: mcp.
+    Environment variables are set by mcp_config.py before launch.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+# MCP SDK — install with: pip install mcp
+try:
+    from mcp.server import Server
+    from mcp.server.stdio import stdio_server
+    from mcp import types
+except ImportError:
+    print("Error: 'mcp' package not installed. Run: pip install mcp", file=sys.stderr)
+    sys.exit(1)
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from interactive.tools import ToolExecutor
+from interactive.session_state import SessionState
+from interactive.research_state import ResearchState
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+
+def create_server(work_dir: Path, idea_file: Path,
+                  provider: str, session: SessionState) -> Server:
+    server = Server("neurico-manager")
+    # The world model is file-backed (research_state.json in work_dir), so the
+    # executor here — running in the MCP subprocess — writes the same file the
+    # manager's web_server polls. Construct it explicitly against work_dir so the
+    # whiteboard tools (update_research_state/assess/design_panel) and the
+    # browser stay in sync across the process boundary.
+    research = ResearchState(work_dir)
+    executor = ToolExecutor(work_dir, session, idea_file, provider, PROJECT_ROOT,
+                            research=research)
+
+    @server.list_tools()
+    async def list_tools() -> list[types.Tool]:
+        return [
+            types.Tool(
+                name="run_agent",
+                description=(
+                    "Launch a research agent inside Docker. The agent runs in the "
+                    "background and you can check its status later with read_agent_logs."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "agent": {
+                            "type": "string",
+                            "enum": ["resource_finder", "experiment_runner",
+                                     "paper_writer", "comment_handler"],
+                            "description": "Which agent to run",
+                        },
+                        "provider": {
+                            "type": "string",
+                            "enum": ["claude", "codex", "gemini"],
+                            "description": "AI provider for the agent",
+                        },
+                        "paper_style": {
+                            "type": "string",
+                            "enum": ["neurips", "icml", "acl", "ams"],
+                            "description": "Paper style (paper_writer only)",
+                        },
+                        "use_scribe": {
+                            "type": "boolean",
+                            "description": "Use Jupyter notebook integration (experiment_runner only)",
+                        },
+                    },
+                    "required": ["agent"],
+                },
+            ),
+            types.Tool(
+                name="check_workspace",
+                description=(
+                    "List directory contents or read a file in the research workspace. "
+                    "Use action='list' to see what files exist, action='read' to view a file."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["list", "read"],
+                            "description": "list: show directory contents. read: show file content.",
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Relative path within the workspace. Use '.' for root.",
+                        },
+                        "max_lines": {
+                            "type": "integer",
+                            "description": "Max lines to return when reading a file (default 200)",
+                        },
+                    },
+                    "required": ["action", "path"],
+                },
+            ),
+            types.Tool(
+                name="read_agent_logs",
+                description=(
+                    "Read logs and status for a running or completed agent run. "
+                    "Use this to monitor progress or diagnose failures."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "run_id": {
+                            "type": "string",
+                            "description": "The run_id of the agent invocation to check",
+                        },
+                        "tail_lines": {
+                            "type": "integer",
+                            "description": "Number of log lines from the end to return (default 100)",
+                        },
+                    },
+                    "required": ["run_id"],
+                },
+            ),
+            types.Tool(
+                name="ask_user",
+                description=(
+                    "Present a message or question to the human researcher and wait for "
+                    "their response. Use for critical decision points."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "message": {
+                            "type": "string",
+                            "description": "The message to show the user. Lead with findings.",
+                        },
+                        "options": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Optional list of choices to present to the user.",
+                        },
+                    },
+                    "required": ["message"],
+                },
+            ),
+            types.Tool(
+                name="update_session",
+                description=(
+                    "Save key findings, open questions, or phase to persistent session state. "
+                    "Only call this after verifying results exist with check_workspace."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "key_findings": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Key findings to append to the session",
+                        },
+                        "open_questions": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Open questions to track (replaces existing list)",
+                        },
+                        "phase": {
+                            "type": "string",
+                            "description": "Current research phase label",
+                        },
+                    },
+                },
+            ),
+            types.Tool(
+                name="update_research_state",
+                description=(
+                    "Update your WORLD MODEL of the investigation — the structured "
+                    "picture you reason over and that the human sees on the Research "
+                    "whiteboard. Use this continuously, the way a PI keeps a running "
+                    "mental model: when you form or revise a hypothesis, confirm or "
+                    "kill one, get a result, identify the crux, or make a decision."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "narrative": {
+                            "type": "string",
+                            "description": "One short paragraph on where the research stands right now.",
+                        },
+                        "current_best": {
+                            "type": "string",
+                            "description": "The current best result / champion approach, with its key number(s).",
+                        },
+                        "crux": {
+                            "type": "string",
+                            "description": "The single most decision-relevant open issue right now.",
+                        },
+                        "hypotheses": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                            "description": (
+                                "Hypotheses to add or update (upsert by id or matching "
+                                "statement). Each: {\"statement\": \"...\", \"status\": "
+                                "\"alive|uncertain|supported|dead\", \"evidence\": \"...\", "
+                                "\"id\": \"H2\"(optional)}."
+                            ),
+                        },
+                        "findings": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Confirmed results/observations to record (append, deduped).",
+                        },
+                        "dead_ends": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Directions found unproductive — recorded so they are not retried.",
+                        },
+                        "open_questions": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Open questions to track (replaces the list).",
+                        },
+                        "resolved_questions": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Open questions that have now been ANSWERED — removed from "
+                                "the list (matched case-insensitively)."
+                            ),
+                        },
+                        "decision": {
+                            "type": "object",
+                            "description": (
+                                "A decision just made, to log with its reasoning: "
+                                "{\"question\": \"...\", \"chosen\": \"...\", "
+                                "\"rationale\": \"...\", \"options\": [\"...\"](optional)}."
+                            ),
+                        },
+                    },
+                },
+            ),
+            types.Tool(
+                name="assess",
+                description=(
+                    "Record YOUR READ of the situation at this moment — the reflection "
+                    "a good PI does before acting. Call at meaningful junctures: after "
+                    "an agent completes, before launching an expensive run, and before "
+                    "deciding whether to involve the human. Reflection, not action: if "
+                    "you conclude the human should be engaged, you still call ask_user."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "situation": {
+                            "type": "string",
+                            "description": "What is happening / what just changed.",
+                        },
+                        "uncertainty": {
+                            "type": "string",
+                            "description": "What you are unsure about right now.",
+                        },
+                        "crux": {
+                            "type": "string",
+                            "description": "The decisive factor — what most affects the next decision.",
+                        },
+                        "decision_pending": {
+                            "type": "string",
+                            "description": "The decision on the table, if any (else leave empty).",
+                        },
+                        "engage_user": {
+                            "type": "boolean",
+                            "description": "Whether a human expert in your seat would pull the user in right now.",
+                        },
+                        "rationale": {
+                            "type": "string",
+                            "description": "Why you would or would not engage the user.",
+                        },
+                        "issue": {
+                            "type": "string",
+                            "description": (
+                                "If you hit a problem at this juncture — confusion, an "
+                                "error, a tool that didn't work, or a mistake you recovered "
+                                "from — describe it honestly. Recorded as an incident."
+                            ),
+                        },
+                    },
+                    "required": ["situation", "engage_user"],
+                },
+            ),
+            types.Tool(
+                name="design_panel",
+                description=(
+                    "Shape the Research whiteboard for THIS run: choose the ORDER of "
+                    "sections and define CUSTOM sections from a fixed block vocabulary. "
+                    "Do this ONCE near the start (after you understand the idea); "
+                    "afterwards call it only to refresh a custom section's data. Supply "
+                    "DATA, never markup."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "layout": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Ordered list of section ids to render, top to bottom. "
+                                "May mix built-in ids (crux, current_best, narrative, "
+                                "assessment, hypotheses, open_questions, decisions, "
+                                "experiments) and custom section ids. Omit to keep the "
+                                "default order."
+                            ),
+                        },
+                        "sections": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                            "description": (
+                                "Custom sections to create or update (upsert by id). Each: "
+                                "{\"id\": \"candidates\", \"title\": \"...\", \"kind\": "
+                                "\"table\", \"data\": ...}. `kind` is one of text, "
+                                "bullet_list, key_value, table, status_list. Re-send a "
+                                "section with new `data` to update it in place."
+                            ),
+                        },
+                    },
+                },
+            ),
+        ]
+
+    ipc_dir = work_dir / ".neurico" / "ipc"
+
+    _ASK_USER_TIMEOUT = 3600  # 1 hour — failsafe if manager dies
+
+    def _ask_user_via_ipc(arguments: dict) -> str:
+        """Route ask_user through file IPC so the manager can show it in the web UI."""
+        import time as _time
+        req_file = ipc_dir / "ask_user_request.json"
+        resp_file = ipc_dir / "ask_user_response.json"
+        req_file.write_text(
+            json.dumps({
+                "message": arguments.get("message", ""),
+                "options": arguments.get("options", []),
+            }),
+            encoding="utf-8",
+        )
+        # Poll for the response the manager writes back.
+        # Timeout after _ASK_USER_TIMEOUT seconds so a crashed/closed manager
+        # does not leave claude -p hanging indefinitely.
+        deadline = _time.monotonic() + _ASK_USER_TIMEOUT
+        while _time.monotonic() < deadline:
+            if resp_file.exists():
+                try:
+                    data = json.loads(resp_file.read_text(encoding="utf-8"))
+                    resp_file.unlink()
+                    return data.get("response", "")
+                except Exception:
+                    pass
+            _time.sleep(0.3)
+        # Timed out — tell the model the user didn't respond so it re-asks next turn
+        print(f"[MCP] ask_user IPC timed out after {_ASK_USER_TIMEOUT}s — notifying model",
+              file=sys.stderr)
+        return (
+            "[The user did not respond within the timeout period. "
+            "Please re-ask the same question in your next message to the user.]"
+        )
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+        # Route ask_user through web-channel IPC when available, else terminal
+        if name == "ask_user" and ipc_dir.exists():
+            result = await asyncio.to_thread(_ask_user_via_ipc, arguments)
+        else:
+            result = await asyncio.to_thread(executor.execute, name, arguments)
+        return [types.TextContent(type="text", text=result)]
+
+    return server
+
+
+async def main():
+    work_dir = Path(os.environ["NEURICO_WORK_DIR"])
+    idea_file = Path(os.environ["NEURICO_IDEA_FILE"])
+    provider = os.environ.get("NEURICO_PROVIDER", "claude")
+    idea_id = os.environ.get("NEURICO_IDEA_ID", "unknown")
+    idea_title = os.environ.get("NEURICO_IDEA_TITLE", "Unknown")
+
+    session = SessionState(work_dir, idea_id, idea_title, provider)
+    server = create_server(work_dir, idea_file, provider, session)
+
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options()
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/interactive/mcp_server.py
+++ b/src/interactive/mcp_server.py
@@ -85,6 +85,17 @@ def create_server(work_dir: Path, idea_file: Path,
                             "type": "boolean",
                             "description": "Use Jupyter notebook integration (experiment_runner only)",
                         },
+                        "instructions": {
+                            "type": "string",
+                            "description": (
+                                "comment_handler only, REQUIRED there: the targeted "
+                                "change request to apply to the existing workspace, "
+                                "in plain language. This is how a code change reaches "
+                                "the agent — you have no file-writing tools, so never "
+                                "edit files yourself; delegate via comment_handler "
+                                "(small change) or experiment_runner (larger re-run)."
+                            ),
+                        },
                     },
                     "required": ["agent"],
                 },

--- a/src/interactive/tools.py
+++ b/src/interactive/tools.py
@@ -102,6 +102,18 @@ class ToolExecutor:
         if agent_name not in valid_agents:
             return f"Error: Unknown agent '{agent_name}'. Choose from: {valid_agents}"
 
+        # comment_handler applies one targeted change to the existing workspace.
+        # In interactive mode the request arrives over chat, not as a GitHub
+        # `comments:` field, so it MUST be passed explicitly as `instructions`.
+        # Without this the container agent dead-ends on "No comments found" and
+        # the manager is tempted to edit files itself — which it cannot do.
+        instructions = args.get("instructions") or args.get("request")
+        if agent_name == "comment_handler" and not instructions:
+            return ("Error: comment_handler needs an 'instructions' parameter "
+                    "describing the targeted change to make (the request text). "
+                    "Pass the change request there — do NOT try to edit files "
+                    "yourself; you have no file-writing tools.")
+
         provider = args.get("provider", self.provider)
         run_id = self.session.generate_run_id(agent_name)
 
@@ -138,6 +150,8 @@ class ToolExecutor:
             cmd_parts.extend(["--paper-style", args["paper_style"]])
         if agent_name == "experiment_runner" and args.get("use_scribe"):
             cmd_parts.append("--use-scribe")
+        if agent_name == "comment_handler" and instructions:
+            cmd_parts.extend(["--instructions", str(instructions)])
 
         # Record in session
         self.session.record_agent_start(agent_name, run_id)

--- a/src/interactive/tools.py
+++ b/src/interactive/tools.py
@@ -72,6 +72,9 @@ class ToolExecutor:
             "design_panel": self._design_panel,
         }
 
+        # The mcp backend delivers tool names namespaced as mcp__neurico__<name>;
+        # strip the prefix so both backends dispatch through the same handlers.
+        tool_name = tool_name.removeprefix("mcp__neurico__")
         handler = handlers.get(tool_name)
         if not handler:
             # Auto-log the failure so the world model stays honest: an unknown-tool

--- a/src/interactive/tools.py
+++ b/src/interactive/tools.py
@@ -312,7 +312,42 @@ class ToolExecutor:
                 except Exception:
                     continue
 
+        # Finalize the experiment record from disk whenever a run is observed.
+        # In MCP mode run_agent fires in the MCP subprocess, whose in-memory
+        # _running_agents map dies with it, so the manager-side polling that
+        # normally flips experiments to done/failed never runs — this disk-driven
+        # path keeps the world model honest in every backend.
+        self._finalize_experiment_from_disk(run_id)
+
         return '\n'.join(parts)
+
+    def _finalize_experiment_from_disk(self, run_id: str) -> None:
+        """Flip the experiment record to done/failed by inspecting run artifacts
+        on disk (status.json / result.json / error.json). Idempotent —
+        update_experiment skips no-op writes — so it's safe to call on every
+        read_agent_logs."""
+        run_dir = self.work_dir / ".neurico" / "runs" / run_id
+        status = None
+        if (run_dir / "error.json").exists():
+            status = "failed"
+        elif (run_dir / "result.json").exists():
+            status = "done"
+        else:
+            status_file = run_dir / "status.json"
+            if status_file.exists():
+                try:
+                    with open(status_file) as f:
+                        st = str(json.load(f).get("status", "")).lower()
+                except (OSError, json.JSONDecodeError):
+                    st = ""
+                if st in ("done", "completed", "complete", "success", "succeeded"):
+                    status = "done"
+                elif st in ("failed", "error", "errored"):
+                    status = "failed"
+        if status:
+            self.research.update_experiment(
+                run_id, status=status,
+                result=self._summarize_run_result(run_id) or None)
 
     def _ask_user(self, args: Dict[str, Any]) -> str:
         """Present a message to the user and collect their response."""

--- a/templates/manager/system_prompt.txt
+++ b/templates/manager/system_prompt.txt
@@ -81,6 +81,10 @@ The substitutes for common operations are:
 - Need to run a shell command or script → use `run_agent` to delegate to an agent inside Docker
 - Need to ask the user something → use `ask_user` (NOT `AskUserQuestion`, which also does not exist here)
 - Need to check agent status or logs → use `read_agent_logs`
+- Need to CHANGE or ADD code / rerun an experiment → delegate it; you have NO file-writing tools:
+  * Small, targeted change to the existing workspace (add one model, fix a metric, regenerate a figure) → `run_agent(agent="comment_handler", instructions="<the request in plain language>")`. The `instructions` field is how the request reaches the agent — it is REQUIRED.
+  * Larger change that re-runs the pipeline from the plan → `run_agent(agent="experiment_runner", ...)`.
+  Either way the worker runs with full permissions inside Docker. Never try to use `Edit`/`Write`/`Bash` yourself — those tools are not available to you, and attempting them will stall the session on a permission prompt the user can never see.
 
 If you find yourself wanting to call any tool not in the list of eight above, stop and identify which of the eight is the correct substitute.
 

--- a/templates/manager/system_prompt.txt
+++ b/templates/manager/system_prompt.txt
@@ -73,9 +73,7 @@ Your ONLY available tools are exactly these eight:
 - `assess` — record your read of the situation and whether to engage the human
 - `design_panel` — shape the Research whiteboard for this run: order the sections and define custom ones (see "Design Your Research Panel" below)
 
-You do NOT have access to `Bash`, `Read`, `Write`, `Edit`, `Grep`, `Glob`, `Agent`, `ToolSearch`, `AskUserQuestion`, or any other Claude Code built-in tool. Do not call them — they will always fail with an error.
-
-You may be aware that you are running inside a Claude Code environment which normally provides tools like `Bash`, `Read`, and `Glob`. Those tools are NOT available to you in this context. They have been intentionally disabled. Calling them will produce an error every single time — there is no workaround.
+{{ tool_protocol }}
 
 The substitutes for common operations are:
 - Need to read a file → use `check_workspace` with `action="read"`
@@ -89,7 +87,7 @@ If you find yourself wanting to call any tool not in the list of eight above, st
 ## Critical Rules — Violations Break the Session
 
 **Rule 1: Never generate tool results yourself.**
-Tool results are provided to you by the system after you make a tool call. Never write `<tool_result>`, `<tool-result>`, or any similar block in your response text. If you generate fake tool results, they will be stored as real history and corrupt every subsequent turn. Only write `<tool_call>` blocks to invoke tools — never fabricate what the result will be.
+Tool results are provided to you by the system after you make a tool call. Never write `<tool_result>`, `<tool-result>`, or any similar block in your response text. If you generate fake tool results, they will be stored as real history and corrupt every subsequent turn. Invoke tools only through the tool protocol described under **Your Tools** above — never fabricate what a result will be.
 
 **Rule 2: Never ask the user questions in plain text.**
 Any question or decision you present to the human MUST go through the `ask_user` tool. Do not write questions like "Which would you prefer?" or "Shall I proceed?" directly in your response text — the human cannot respond to plain text in this interface. If you need a decision, call `ask_user`. If you have nothing to ask and no tool to call, say what you observed and wait.

--- a/templates/manager/tools.yaml
+++ b/templates/manager/tools.yaml
@@ -28,6 +28,17 @@ tools:
         type: boolean
         description: Use Jupyter notebook integration (only for experiment_runner)
         required: false
+      instructions:
+        type: string
+        description: |
+          For comment_handler ONLY, and REQUIRED there: the targeted change
+          request to apply to the existing workspace, in plain language (e.g.
+          "Add an Age-only baseline classifier to src/experiment.py and rerun").
+          This is how a targeted change reaches the agent in interactive mode —
+          you have no file-writing tools of your own, so any code change must go
+          through comment_handler (small, targeted) or experiment_runner (larger
+          re-runs). Never attempt to edit files directly.
+        required: false
       rationale:
         type: string
         description: |


### PR DESCRIPTION
Split out of #111 (3 of 4). Base: `split/pr3-research` (PR 113).

Adopted the changes in PR 110

Adds an MCP backend so the manager invokes real registered tools (native tool
calls) instead of the text `<tool_call>` shim — the structural fix for the
tool-fabrication/thrashing that #104 could only patch via prompt rules.
Includes the backend portion of the review-findings pass.

⚠️ Base is PR 113, not `main`. Merge after PR 113; retarget to `main` once PR 113 lands.