### PR TITLE
feat(interactive): offline-eval annotation thumbs

### DIFF
--- a/DECISION_ANNOTATION_CHANGES.md
+++ b/DECISION_ANNOTATION_CHANGES.md
@@ -1,0 +1,272 @@
+# Manager-as-Research-Expert: a Shared World Model + Whiteboard
+
+> **Status: implemented (core), this branch.** The load-bearing pieces below are
+> built and smoke-tested; the self-eval / annotation / multi-agent items at the
+> end are explicitly Planned/Stretch. Builds on the browser-UI work in
+> [INTERACTIVE_WEB_CHANGES.md](INTERACTIVE_WEB_CHANGES.md).
+
+This run reshapes the interactive **manager** from a tool-dispatch loop into a
+research *expert* — a PI / AI co-author that holds a model of the whole
+investigation, reasons over it, and knows when to pull in the human — and turns
+the dashboard into the **shared whiteboard** both the manager and the human read.
+
+## Why
+
+The goal is a manager that behaves like a research expert. That rests on two
+underlying capabilities a human expert has:
+
+1. **A world model** — an explicit picture of the research (hypotheses alive/
+   dead, results, current best, the decisive open question, open questions).
+2. **Judgement over it** — taste about what matters now, what's a dead end, and
+   when to involve the human.
+
+The old manager had neither: it reasoned over its *last tool call*, its state
+file was `phase + agents_run + flat conversation`, and the dashboard was a stats
+strip. So it couldn't be "omniscient," and its decisions couldn't be evaluated
+from the trace. The fix is to give the manager a **shared research state** and
+make it think like a PI over that state. Doing so simultaneously: makes the
+manager legibly omniscient, gives the dashboard real content (the whiteboard),
+grounds concrete review questions (they become assessments over the state), and
+creates the substrate a human/model can later annotate for failures.
+
+We borrow AutoScientists' **state-and-evidence machinery** (a shared state `S`,
+a dead-end registry, critique-before-compute, a research-insights view) but keep
+the part it removes — **one expert orchestrator + the human in the loop**. Our
+bet is the opposite of theirs: a great PI-like manager with the human woven in,
+not leaderless self-organization.
+
+## What was built
+
+### 1. Shared research state — the world model — **Done**
+[`src/interactive/research_state.py`](src/interactive/research_state.py) — a
+`ResearchState` persisted to `<ws>/.neurico/research_state.json` (atomic writes).
+Holds: `narrative`, `current_best`, `crux`, `hypotheses` (id/statement/status of
+`alive|uncertain|supported|dead`/evidence), `experiments` (with the launch
+rationale + result), `findings` (`result|dead_end|note`), `open_questions`,
+`decisions` (with rationale), and an append-only `assessments` log. Two key
+projections: `digest_section()` (compact text the manager reads each turn) and
+`snapshot()` (for the dashboard).
+
+### 2. Manager reasons over the state — **Done**
+[`manager.py`](src/interactive/manager.py): constructs the state, threads it into
+the executor, and each cycle rewrites the system prompt's tail with the live
+`digest_section()` — so the manager always reasons over its current world model
+without polluting persisted history. The system prompt
+([system_prompt.txt](templates/manager/system_prompt.txt)) is rewritten to cast
+the manager as the PI / co-author who **must** keep the world model current and
+**assess before acting**.
+
+### 3. Two new manager tools — **Done**
+[tools.py](src/interactive/tools.py) + [tools.yaml](templates/manager/tools.yaml):
+- `update_research_state` — upsert hypotheses, record findings/dead-ends, set
+  crux/current_best/narrative, open questions, and log decisions with rationale.
+- `assess` — record the manager's read (situation, uncertainty, crux, pending
+  decision, **engage_user** + rationale). Reflection, not action: if it judges
+  the human should be engaged, it still calls `ask_user`. These assessments are
+  exactly the decision points an annotator/model would grade.
+- Both tolerate the CLI backend's JSON-string-encoded args (existing quirk).
+- The manager now has **seven** tools (prompt + rules updated accordingly).
+
+### 4. Critique-before-compute gate — **Done**
+`run_agent` gains `rationale` + `hypothesis` params; the prompt requires a
+rationale (which hypothesis, why the spend is worth it, not a dead-end retry),
+and [tools.py](src/interactive/tools.py) records each launch as an `experiment`
+in the world model and marks it `done`/`failed` on exit. No silent compute.
+
+### 5. Dashboard → shared whiteboard — **Done**
+[web_server.py](src/interactive/web_server.py): a polling thread emits a
+`research` SSE event when `research_state.json` changes, and the right pane is
+now **tabbed**: **🔬 Research** (default) and **⚙️ Activity** (the old live log).
+The Research tab renders the world model as a whiteboard — crux card, current
+best, narrative, the manager's latest **read** (with an "would engage you /
+proceeding solo" chip), the hypothesis list (status-colored), open questions,
+decisions, and experiments. All manager-authored text is HTML-escaped client
+side. `update_research_state`/`assess` are silent in chat (the whiteboard is
+their surface), keeping the conversation clean.
+
+### 6. PI-designed Research panel (Level 2) — **Done**
+The whiteboard is no longer a fixed eight-slot template; the manager **shapes it
+per run**. The key separation: *layout* (PI-decided, stable) is split from *data*
+(streamed continuously), so this costs ~one extra tool call near run start, not a
+regeneration per update.
+- **State** ([research_state.py](src/interactive/research_state.py)) gains
+  `panel_layout` (an ordered list of section ids) and `sections` (custom sections
+  `{title, kind, data}`). Old state files forward-migrate (missing keys default
+  in). `snapshot()`/`digest_section()` expose the panel so the manager remembers
+  what it designed.
+- **Tool** ([tools.py](src/interactive/tools.py) + [tools.yaml](templates/manager/tools.yaml)):
+  a new `design_panel` — set the section order and define custom sections from a
+  **fixed block vocabulary** (`text | bullet_list | key_value | table |
+  status_list`). The manager supplies *data, never markup*, so the client-side
+  escaping that keeps the board XSS-safe is preserved. Tolerates the CLI
+  backend's JSON-string args (including nested `data`). The manager now has
+  **eight** tools (prompt + rules updated; a stale "five" reference fixed).
+- **Render** ([web_server.py](src/interactive/web_server.py)): `setResearch`
+  rebuilds `#researchbody` in `panel_layout` order each update, mixing built-in
+  section renderers (`CORE`) with a generic block renderer (`customInner`).
+  Built-in ids (`crux`, `current_best`, `narrative`, `assessment`, `hypotheses`,
+  `open_questions`, `decisions`, `experiments`) can be reordered or interleaved
+  with custom ones; an empty layout keeps the default order. `design_panel` is
+  silent in chat (the whiteboard is its surface). *Drive-by fix:* the assessment
+  card now falls back to the last `assessments` entry, since the browser receives
+  the raw state file (which has no derived `latest_assessment`). Section headers
+  (`.r-h`) were also bolded/brightened for readability.
+
+### 7. World-model honesty & self-consistency — **Done**
+The first real run exposed three drift failures in the saved
+`research_state.json`: a hypothesis left `alive` after its experiment confirmed
+it; resolved `open_questions` never pruned; `experiment.result` left `""`; and —
+worst for the *failure-finding* goal — a mid-run tool-confusion episode that left
+**no trace** in the state (the board narrated a clean success). This run makes
+the model keep itself honest, mostly mechanically:
+- **Experiment results written back** ([tools.py](src/interactive/tools.py)
+  `_summarize_run_result`): on completion the run's `result.json`/`error.json` is
+  read and stored on the experiment record — no more `result: ""`.
+- **Incidents auto-logged** ([research_state.py](src/interactive/research_state.py)
+  `add_incident`, wired in [tools.py](src/interactive/tools.py) `execute`): an
+  unknown-tool call (e.g. the manager reaching for `Bash`/`Read`/`AskUserQuestion`
+  when it gets confused) or a handler exception is recorded as an incident —
+  *automatically*, regardless of manager discipline. The manager can also
+  self-report struggle via `assess(issue="…")`. This is what turns the board from
+  a success-narrator into a failure-finder.
+- **Consistency warnings** (`consistency_warnings()`): detects a hypothesis still
+  `alive`/`uncertain` after a completed run that tested it, and stale
+  `open_questions` once results/decisions exist. Surfaced both to the manager (in
+  the digest, as a ⚠ to-do) and to the human (whiteboard banner).
+- **Precise question pruning** (`resolve_questions`, new `resolved_questions`
+  arg on `update_research_state`): drop answered questions without re-listing the
+  whole set — the path that was being skipped.
+- **Whiteboard** ([web_server.py](src/interactive/web_server.py)): new built-in
+  sections **⚠ Needs attention** (warnings, top) and **⚠ Incidents** (bottom);
+  experiment rows now show their `→ result`. These two are **non-suppressible** —
+  a PI-designed panel layout (§6 `design_panel`) may reorder them but cannot hide
+  them, so a drifting manager can't conceal its own failures by omitting them
+  from the layout. Prompt updated to flip hypothesis status / prune questions on
+  resolution, fix ⚠ warnings before moving on, and report struggle honestly.
+
+### 8. MCP tool backend — embracing #110 — **Done**
+The world-model tools now ride on the **MCP backend from
+[PR #110](https://github.com/ChicagoHAI/NeuriCo/pull/110)** ("MCP Tool Backend for
+Interactive Mode"), which we merged in rather than competing with. The two efforts
+were built independently on the same base and overlapped on `llm_backend.py` /
+`manager.py` / `tools.py`; this run reconciles them so we get **both** the robust
+tool layer *and* the PI world-model layer.
+
+- **Why #110 is the right substrate.** The old `cli` backend faked tools in text:
+  tool defs were injected as XML and the model had to emit `<tool_call>` blocks we
+  regex-parsed. Two structural failure modes followed — the model hallucinated
+  `<tool_result>` blocks, and the inner `claude -p` (a full Claude Code agent with
+  its own Bash/Read) suffered "identity collapse," reaching for native tools or
+  breaking persona. #110 registers the manager tools as a real **MCP server**
+  ([mcp_server.py](src/interactive/mcp_server.py) + [mcp_config.py](src/interactive/mcp_config.py)),
+  so `claude -p` calls them natively at the API level. Claude Code enforces
+  `stop_reason: tool_use`, so generation halts at each real tool call and the
+  hallucination/identity-collapse classes vanish structurally. It also streams
+  tool/text events to the web channel in real time and routes `ask_user` through
+  file IPC (the MCP server runs out-of-process). This is now the **default backend
+  for the `claude` provider**; non-Claude providers stay on `cli`.
+- **Grafting the world model onto it.** Because the MCP server is a thin adapter
+  over the existing `ToolExecutor`, the three world-model tools needed only to be
+  registered: `update_research_state`, `assess`, and `design_panel` are added to
+  `mcp_server.py`'s `list_tools()` with schemas and to the `--allowedTools`
+  allowlist in [llm_backend.py](src/interactive/llm_backend.py). The server
+  constructs its `ToolExecutor` with a `ResearchState` pointed at the workspace;
+  since the state is **file-backed** (`research_state.json`) and the web server
+  *polls* that file, the whiteboard stays in sync across the process boundary with
+  no extra plumbing. `tools.py` strips the `mcp__neurico__` prefix so both backends
+  dispatch through the same handlers; the three tools stay **silent in chat** on
+  the MCP path too (echoes suppressed in `llm_backend._tool_echo`).
+- **`cli` backend still hardened.** For non-Claude providers (or `llm_backend: cli`),
+  we keep our root-cause identity-collapse fix — `claude -p` is launched with
+  `--tools ""` to remove the native-tool escape hatch, so the XML shim is the only
+  way the model can act. The MCP and CLI paths now solve the same problem two ways.
+- **Dependency.** `mcp_server.py` imports the `mcp` SDK directly; added `mcp>=1.0`
+  to [pyproject.toml](pyproject.toml) (previously only pulled in transitively via
+  `fastmcp`). The server prints a clean "run: pip install mcp" error if absent, and
+  `create_backend` preflights that the `claude` CLI is on PATH.
+
+### 9. Offline-eval annotation layer — **Done**
+The whiteboard now lets a human grade the manager's judgement with a 👍/👎, so a
+session becomes labeled evaluation data. **Offline only — nothing here feeds back
+into the live run**; it's the ground-truth substrate for judging the manager
+later (per-decision verdicts, failure taxonomy, prompt/model A/B).
+- **Subjects = the manager's decision points** (not log noise): each `assess`
+  entry (the *🧭 Manager's read* card), each logged `decision`, and each manager
+  **chat bubble**. These are the units that encode judgement and map onto the
+  review questions.
+- **Store** ([annotations.py](src/interactive/annotations.py)): append-only JSONL
+  at `<ws>/.neurico/annotations.jsonl`, one line per click, last-write-wins per
+  key, with `verdict: up|down|none` (`none` = un-toggled). Each record **snapshots
+  the subject's text** so it is self-contained — assessment/decision keys join
+  back to `research_state.json` by id, but chat-bubble `seq`s reset across resumed
+  runs, so the snapshot is the durable identifier there.
+- **Keys.** Assessments gained a stable `id` (`A1`, `A2`…) in
+  [research_state.py](src/interactive/research_state.py) (decisions already had
+  `D…`); bubbles key on the channel `seq` (stable within a run via SSE history
+  replay).
+- **Wiring** ([web_server.py](src/interactive/web_server.py)): `POST /annotate`
+  records a thumb; `GET /annotations` returns the `{key: verdict}` map so the UI
+  re-paints thumb state on load/reconnect and survives the whiteboard's 2 s
+  re-render. Thumbs are pure client→server; the manager loop never sees them.
+
+## How it works
+
+```
+   Human ⇄ Manager (PI / co-author)  ──reads digest each turn──┐
+                │ update_research_state / assess / design_panel  │
+                │ / run_agent  (+ auto incidents, ⚠ warnings)     │
+                ▼                                                │
+        ResearchState  (world model: hypotheses, crux,           │
+        .neurico/research_state.json   experiments, decisions, …)│
+                │ polled (2s)                                     │
+                ▼                                                 │
+        InteractiveWebServer ──SSE 'research'──► 🔬 Research whiteboard
+                              ──SSE 'agentlog'─► ⚙️ Activity log
+```
+
+## Scope, tradeoffs, open questions
+
+- **Backward compatible.** `--cli` terminal mode and autonomous `./neurico run`
+  are untouched; the state file is additive. The executor creates a state lazily
+  so it still works standalone.
+- **Polled, not in-process.** The whiteboard reads `research_state.json` (like
+  the dashboard reads `manager_session.json`) — identical for fresh/resumed
+  sessions, decoupled from the loop, ~2s latency.
+- **The manager must cooperate — but less than before.** The world model is
+  still best when the manager keeps it current via `update_research_state`/
+  `assess`, and the prompt pushes hard on that. But the failure modes that bit us
+  in the first real run are now caught *mechanically*: experiment results are
+  written back from disk, tool errors/unknown-tool calls auto-log as incidents,
+  and a consistency check surfaces hypothesis-status drift and stale questions as
+  ⚠ warnings the manager is told to fix. So an undisciplined manager now produces
+  a board that *flags its own gaps* rather than one that silently looks clean.
+- **Open:** should the self-eval use the manager's backend or a fixed judge?
+  The whiteboard is now PI-*shaped* (the manager designs its layout per run via
+  `design_panel`, item 6) but still human-*read-only* — should the human be able
+  to edit the state (steer by editing) or restructure the panel too?
+
+## Next (Planned / Stretch — not in this run)
+
+- **Self-eval pass** — feed the `assessments` + state to a model with the five
+  questions → a per-assessment verdict file. Now cheap, because the substrate
+  (structured assessments over a real state) exists. *(Planned.)*
+- **Annotation layer** — *Done (offline-eval thumbs), see §9.* Next here: richer
+  labels than 👍/👎 (a failure category + free-text reason), and a small reader
+  that joins `annotations.jsonl` to the state for a per-decision verdict report.
+- **"Lab meeting" escalation** — for genuinely hard calls, let the single
+  manager spawn a critic/analyst or two (AutoScientists-style discussion), then
+  speak to the user as one PI. Keeps the single-expert relationship while
+  getting diversity where it matters. *(Stretch — deliberately NOT a standing
+  multi-agent committee.)*
+- **Feedback linkage + replay** — tag user turns, track which are honored at
+  later decisions, and branch a run to test counterfactuals ("additional data
+  generation"). *(Stretch.)*
+
+## Notes for reviewers
+
+- The philosophical move: the manager is the **subject** (the expert whose
+  judgement we want to be good) *and* the world model is what makes that
+  judgement legible. Concrete review questions are downstream of this, not the spec.
+- We intentionally kept **one** manager (the "be the PI" framing)
+  rather than going multi-agent; the only multi-agent idea retained is the
+  optional internal "lab meeting" for hard calls.

--- a/DECISION_ANNOTATION_CHANGES.md
+++ b/DECISION_ANNOTATION_CHANGES.md
@@ -1,9 +1,31 @@
-# Manager-as-Research-Expert: a Shared World Model + Whiteboard
+# Manager-as-Research-Expert: World Model, MCP Backend & Eval Annotations
 
-> **Status: implemented (core), this branch.** The load-bearing pieces below are
-> built and smoke-tested; the self-eval / annotation / multi-agent items at the
-> end are explicitly Planned/Stretch. Builds on the browser-UI work in
-> [INTERACTIVE_WEB_CHANGES.md](INTERACTIVE_WEB_CHANGES.md).
+> **Status: implemented, this branch.** All three parts below are built and
+> smoke-tested. Stacks on the browser-UI work (#109,
+> [INTERACTIVE_WEB_CHANGES.md](INTERACTIVE_WEB_CHANGES.md)) and embraces the MCP
+> backend from #110. The remaining self-eval / richer-annotation / multi-agent
+> items at the very end are explicitly Planned/Stretch.
+
+## TL;DR — what's in this PR
+
+Three commits that turn the interactive **manager** into a research *expert* and
+make its judgement gradeable:
+
+1. **Manager world model + research whiteboard** (§1–7) — the manager holds an
+   explicit `ResearchState` (hypotheses, crux, experiments, decisions,
+   assessments, incidents), reasons over it each turn, and surfaces it to the
+   human as a live "Research" whiteboard. New tools `update_research_state`,
+   `assess`, `design_panel`; critique-before-compute on `run_agent`.
+2. **MCP tool backend** (§8) — runs the manager's tools as a real MCP server so
+   `claude -p` calls them natively, removing the hallucinated-tool-result and
+   "identity collapse" failures *structurally*. Adapted from #110 and extended to
+   register the world-model tools as `mcp__neurico__*`.
+3. **Offline-eval annotation thumbs** (§9) — a reviewer 👍/👎 the manager's
+   decision points (assess cards, decisions, manager bubbles) so a session becomes
+   labeled evaluation data. Offline only — nothing feeds back into the live run.
+
+The throughline: §1–7 give the manager a *judgement* worth having, §8 makes that
+judgement reliable to execute, and §9 makes it *measurable*.
 
 This run reshapes the interactive **manager** from a tool-dispatch loop into a
 research *expert* — a PI / AI co-author that holds a model of the whole
@@ -244,6 +266,37 @@ later (per-decision verdicts, failure taxonomy, prompt/model A/B).
   The whiteboard is now PI-*shaped* (the manager designs its layout per run via
   `design_panel`, item 6) but still human-*read-only* — should the human be able
   to edit the state (steer by editing) or restructure the panel too?
+
+## Known issues fixed (post-review hardening)
+
+A review pass over the whole diff (including the embraced #110 backend) surfaced
+a cluster of bugs — all fixed on this branch. Most of the MCP ones are inherited
+from #110; the annotation ones are ours.
+
+**MCP backend (mostly inherited from #110):**
+- **Stale world model in MCP mode** — tools run in the MCP *subprocess*, so the
+  manager's per-turn digest never saw its own updates. The manager now
+  `reload()`s the state from disk each turn. *(This one was ours — the seam
+  between the in-process world model and #110's subprocess execution.)*
+- **Runaway autonomous loop** — the `had_tools` loop-back had no ceiling. Bounded
+  by `max_autonomous_steps` (default 25) with a forced human checkpoint.
+- **Wrong tool protocol in MCP** — the prompt told the model to emit `<tool_call>`
+  XML (a cli-shim artefact) even in MCP, where it's dropped. The prompt is now
+  backend-conditional (native tool-calling for mcp/api, XML only for cli).
+- **Experiment lifecycle** — `run_agent` records now finalize to done/failed from
+  disk (`status`/`result`/`error.json`), not from an in-process process map that
+  dies with the subprocess.
+- **ask_user IPC races** — requests carry a uuid and responses echo it (no
+  cross-question answers); writes are atomic (temp + `os.replace`).
+- **Backend selection** — `--backend mcp` is now selectable and a single
+  `resolve_backend()` is the source of truth for both `.mcp.json` provisioning
+  and the running backend.
+
+**Annotation layer (ours):**
+- Chat-bubble verdicts key on a **content hash** of the message (stable across
+  resumed sessions), not the per-process SSE `seq` which restarts at 0.
+- The `annotations.jsonl` append is **lock-guarded** against interleaved writes
+  from concurrent thumb clicks under the threaded server.
 
 ## Next (Planned / Stretch — not in this run)
 

--- a/src/interactive/annotations.py
+++ b/src/interactive/annotations.py
@@ -12,15 +12,17 @@ run. The records are the ground-truth substrate for evaluating the manager's
 judgement later (per-decision verdicts, failure taxonomy, prompt/model A/B).
 
 Stored append-only as JSONL at ``<workspace>/.neurico/annotations.jsonl`` — one
-line per click, last write wins per ``key``. Each record snapshots the subject's
-text so it is self-contained: assessment/decision keys join back to
-research_state.json by id, but chat-bubble seqs reset across resumed runs, so the
-snapshot is the durable identifier there.
+line per click, last write wins per ``key``. Each record also snapshots the
+subject's text so it is self-contained. Keys are durable across resumed sessions:
+assessment/decision keys (``assess:A3`` / ``dec:D2``) join back to
+research_state.json by id, and chat-bubble keys (``msg:<hash>``) are a content
+hash of the message text rather than a per-process sequence number.
 """
 
 from __future__ import annotations
 
 import json
+import threading
 from datetime import datetime
 from pathlib import Path
 from typing import Dict
@@ -28,6 +30,11 @@ from typing import Dict
 VALID_KINDS = ("assessment", "decision", "message")
 # "none" clears a prior verdict (the user un-toggled the thumb).
 VALID_VERDICTS = ("up", "down", "none")
+
+# The web server is threaded, so two near-simultaneous thumb clicks could
+# interleave appends and corrupt a line (silently losing a verdict). Serialize
+# writes through a process-wide lock.
+_write_lock = threading.Lock()
 
 
 def _now() -> str:
@@ -58,8 +65,10 @@ def append_annotation(work_dir: Path, *, key: str, kind: str, verdict: str,
     }
     path = annotations_file(work_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "a", encoding="utf-8") as fh:
-        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    line = json.dumps(record, ensure_ascii=False) + "\n"
+    with _write_lock:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line)
     return record
 
 

--- a/src/interactive/annotations.py
+++ b/src/interactive/annotations.py
@@ -1,0 +1,94 @@
+"""
+Offline-eval annotations — human 👍/👎 on the manager's decision points.
+
+A researcher reviewing a session can thumbs-up / thumbs-down three kinds of
+subject on the web UI:
+  - assessment  — a manager `assess` entry (situation / crux / engage_user)
+  - decision    — a logged `decision` (question / chosen / rationale)
+  - message     — a manager chat bubble
+
+This is *purely an offline-eval artifact*: nothing here feeds back into the live
+run. The records are the ground-truth substrate for evaluating the manager's
+judgement later (per-decision verdicts, failure taxonomy, prompt/model A/B).
+
+Stored append-only as JSONL at ``<workspace>/.neurico/annotations.jsonl`` — one
+line per click, last write wins per ``key``. Each record snapshots the subject's
+text so it is self-contained: assessment/decision keys join back to
+research_state.json by id, but chat-bubble seqs reset across resumed runs, so the
+snapshot is the durable identifier there.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+VALID_KINDS = ("assessment", "decision", "message")
+# "none" clears a prior verdict (the user un-toggled the thumb).
+VALID_VERDICTS = ("up", "down", "none")
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def annotations_file(work_dir: Path) -> Path:
+    return Path(work_dir) / ".neurico" / "annotations.jsonl"
+
+
+def append_annotation(work_dir: Path, *, key: str, kind: str, verdict: str,
+                      snapshot: str = "") -> Dict[str, str]:
+    """Append one annotation record. Raises ValueError on bad input."""
+    key = (key or "").strip()
+    if not key:
+        raise ValueError("annotation key required")
+    if kind not in VALID_KINDS:
+        raise ValueError(f"bad kind {kind!r}")
+    if verdict not in VALID_VERDICTS:
+        raise ValueError(f"bad verdict {verdict!r}")
+
+    record = {
+        "ts": _now(),
+        "key": key,
+        "kind": kind,
+        "verdict": verdict,
+        "snapshot": (snapshot or "")[:500],
+    }
+    path = annotations_file(work_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return record
+
+
+def load_latest(work_dir: Path) -> Dict[str, str]:
+    """Fold the JSONL into a {key: verdict} map (last write wins). Cleared
+    ('none') keys are dropped, so the result is only the live up/down verdicts —
+    exactly what the UI needs to re-paint thumb state on load."""
+    path = annotations_file(work_dir)
+    latest: Dict[str, str] = {}
+    if not path.exists():
+        return latest
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                key = rec.get("key")
+                verdict = rec.get("verdict")
+                if not key:
+                    continue
+                if verdict in ("up", "down"):
+                    latest[key] = verdict
+                else:  # "none" or unknown → clear
+                    latest.pop(key, None)
+    except OSError:
+        pass
+    return latest

--- a/src/interactive/research_state.py
+++ b/src/interactive/research_state.py
@@ -84,7 +84,7 @@ class ResearchState:
             "findings": [],         # {text, kind, ts}   kind: result | dead_end | note
             "open_questions": [],   # [str]
             "decisions": [],        # {id, question, options, chosen, rationale, by, ts}
-            "assessments": [],      # {ts, situation, uncertainty, crux, decision_pending, engage_user, rationale}
+            "assessments": [],      # {id, ts, situation, uncertainty, crux, decision_pending, engage_user, rationale}
             "incidents": [],        # {ts, kind, detail} — auto-logged tool errors + self-reported struggle
             # Level 2 — the PI-designed panel. `panel_layout` is an ordered list
             # of section ids (built-in or custom); empty → default order. Each
@@ -235,6 +235,9 @@ class ResearchState:
                        crux: str = "", decision_pending: str = "",
                        engage_user: bool = False, rationale: str = "") -> None:
         self.state["assessments"].append({
+            # Stable id so offline-eval annotations can key on a specific
+            # assessment (decisions already carry one; ts alone could collide).
+            "id": self._next_id("assessments", "A"),
             "ts": _now(), "situation": (situation or "").strip(),
             "uncertainty": (uncertainty or "").strip(), "crux": (crux or "").strip(),
             "decision_pending": (decision_pending or "").strip(),

--- a/src/interactive/research_state.py
+++ b/src/interactive/research_state.py
@@ -94,6 +94,27 @@ class ResearchState:
         }
 
     # ------------------------------------------------------------------ io
+    def reload(self) -> None:
+        """Re-read state from disk *in place* (mutates self.state, keeps the same
+        object). Needed in MCP mode: tools run in a separate subprocess that owns
+        its own ResearchState and writes research_state.json, so the manager calls
+        this each turn before building its digest — otherwise it reasons over a
+        stale, never-updated copy. In-place (not a fresh object) so the
+        ToolExecutor's reference to this instance stays valid. Cheap and a no-op
+        in practice for backends whose tools run in-process (disk == memory)."""
+        if not self.state_file.exists():
+            return
+        try:
+            with open(self.state_file, encoding="utf-8") as f:
+                loaded = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return  # torn/missing read — keep what we have
+        if not isinstance(loaded, dict):
+            return
+        for k, v in self._blank().items():
+            loaded.setdefault(k, v)
+        self.state = loaded
+
     def _save(self) -> None:
         self.state["updated_at"] = _now()
         tmp = self.state_file.with_suffix(".json.tmp")
@@ -221,10 +242,10 @@ class ResearchState:
         changed = False
         for e in self.state["experiments"]:
             if e["run_id"] == run_id:
-                if status:
+                if status and e.get("status") != status:
                     e["status"] = status
                     changed = True
-                if result:
+                if result and e.get("result") != result.strip():
                     e["result"] = result.strip()
                     changed = True
                 break

--- a/src/interactive/web_server.py
+++ b/src/interactive/web_server.py
@@ -16,9 +16,11 @@ process and shares in-process queues with a WebChannel — no file polling for t
 conversation, no second process.
 
 Routes:
-  GET  /         -> the HTML page
-  GET  /stream   -> Server-Sent Events: conversation + agent-log + status + dashboard
-  POST /input    -> the browser submits the human's reply
+  GET  /            -> the HTML page
+  GET  /stream      -> Server-Sent Events: conversation + agent-log + status + dashboard
+  GET  /annotations -> {key: verdict} map of offline-eval thumbs (re-paint on load)
+  POST /input       -> the browser submits the human's reply
+  POST /annotate    -> record a 👍/👎 on an assessment / decision / manager bubble
 """
 
 from __future__ import annotations
@@ -34,6 +36,7 @@ from typing import Optional
 
 from interactive.channel import WebChannel
 from interactive import agent_log
+from interactive import annotations as _annotations
 
 
 # ---------------------------------------------------------------------------
@@ -374,6 +377,15 @@ PAGE = r"""<!DOCTYPE html>
   .qitem::before{content:"?";position:absolute;left:0;color:#58a6ff;font-weight:700}
   .decitem{font-size:12px;color:#c9d1d9;padding:4px 0;border-bottom:1px solid #161b22}
   .decitem .ch{color:#56d364}.decitem .rat{color:#6e7681;font-size:11px}
+
+  /* ---- offline-eval thumbs (👍/👎 on assessments, decisions, manager bubbles) ---- */
+  .ann{display:inline-flex;gap:2px;margin-left:6px;vertical-align:middle}
+  .ann-btn{background:none;border:none;cursor:pointer;font-size:13px;line-height:1;padding:0 2px;
+           opacity:.3;filter:grayscale(1);transition:opacity .1s}
+  .ann-btn:hover{opacity:.65}
+  .ann-btn.on{opacity:1;filter:none}
+  .ann-foot{margin-top:5px;display:flex;align-items:center;gap:4px}
+  .ann-foot .ann-lbl{font-size:10px;color:#6e7681;text-transform:uppercase;letter-spacing:.05em}
   .expitem{font-size:12px;color:#8b949e;padding:3px 0;font-family:monospace}
   .expitem .est{font-size:9px;padding:0 5px;border-radius:8px;margin-right:5px}
   .est-running{background:#1f3c5e;color:#79c0ff}.est-done{background:#1a3a2e;color:#56d364}.est-failed{background:#3a1e1e;color:#ff7b72}
@@ -495,6 +507,13 @@ PAGE = r"""<!DOCTYPE html>
     }
     if(whoEl) el.appendChild(whoEl);
     const t=document.createElement('div');t.textContent=d.text;el.appendChild(t);
+    // Offline-eval thumbs on manager bubbles (keyed by the event's seq, which is
+    // stable across reconnects within a run; the POST also snapshots the text).
+    if(role==='manager'&&d.seq!=null){
+      const af=document.createElement('div');af.className='ann-foot';
+      af.innerHTML=annHTML('msg:'+d.seq,d.text);
+      el.appendChild(af);
+    }
     chat.appendChild(el);
     if(stick) chat.scrollTop=chat.scrollHeight;
   }
@@ -651,6 +670,38 @@ PAGE = r"""<!DOCTYPE html>
   }
 
   // Built-in section renderers: id -> function(d) -> HTMLElement|null.
+  // ---- offline-eval annotations (👍/👎) ----
+  // ANN: key -> 'up'|'down' (current verdict, drives thumb highlight + survives
+  // the whiteboard's 2s re-render). SNIP: key -> text snapshot sent with the POST
+  // so the JSONL record is self-contained for offline eval. Keys are
+  // 'assess:<id>' | 'dec:<id>' | 'msg:<seq>'.
+  const ANN={}, SNIP={}, ANN_KIND={assess:'assessment',dec:'decision',msg:'message'};
+  function annHTML(key,snip){
+    if(snip!=null) SNIP[key]=String(snip);
+    const v=ANN[key]||'';
+    return '<span class="ann" data-key="'+esc(key)+'">'+
+      '<button class="ann-btn'+(v==='up'?' on':'')+'" data-v="up" title="Good call">👍</button>'+
+      '<button class="ann-btn'+(v==='down'?' on':'')+'" data-v="down" title="Bad call">👎</button></span>';
+  }
+  function applyAnn(){document.querySelectorAll('.ann').forEach(span=>{
+    const v=ANN[span.getAttribute('data-key')]||'';
+    span.querySelectorAll('.ann-btn').forEach(x=>x.classList.toggle('on',x.getAttribute('data-v')===v));
+  });}
+  document.addEventListener('click',e=>{
+    const b=e.target.closest&&e.target.closest('.ann-btn'); if(!b) return;
+    const span=b.closest('.ann'), key=span.getAttribute('data-key');
+    let v=b.getAttribute('data-v');
+    if(ANN[key]===v) v='none';                 // click the active thumb again → clear it
+    ANN[key]=(v==='none'?'':v);
+    span.querySelectorAll('.ann-btn').forEach(x=>x.classList.toggle('on',x.getAttribute('data-v')===ANN[key]));
+    fetch('/annotate',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({key:key,kind:ANN_KIND[key.split(':')[0]]||'message',
+        verdict:v,snapshot:(SNIP[key]||'').slice(0,500)})}).catch(()=>{});
+  });
+  // Re-paint thumbs for anything already in the DOM (chat bubbles) once we know
+  // the saved verdicts. The whiteboard re-reads ANN on its next poll on its own.
+  fetch('/annotations').then(r=>r.json()).then(m=>{if(m&&typeof m==='object')Object.assign(ANN,m);applyAnn();}).catch(()=>{});
+
   const CORE={
     warnings:d=>{
       const w=d.warnings||[]; if(!w.length) return null;
@@ -664,7 +715,9 @@ PAGE = r"""<!DOCTYPE html>
       const eng=a.engage_user?'<span class="eng yes">would engage you</span>':'<span class="eng no">proceeding solo</span>';
       return el('div','r-assess','<b>🧭 Manager\'s read</b>'+esc(a.situation||'')+
         (a.uncertainty?'<br><span style="color:#8b949e">Unsure: </span>'+esc(a.uncertainty):'')+
-        (a.rationale?'<br><span style="color:#8b949e">Why: </span>'+esc(a.rationale):'')+'<br>'+eng);
+        (a.rationale?'<br><span style="color:#8b949e">Why: </span>'+esc(a.rationale):'')+'<br>'+eng+
+        '<div class="ann-foot"><span class="ann-lbl">rate this read</span>'+
+        annHTML('assess:'+(a.id||a.ts||''),a.situation||a.crux||'')+'</div>');
     },
     hypotheses:d=>{
       const hyp=d.hypotheses||[]; if(!hyp.length) return null;
@@ -681,6 +734,7 @@ PAGE = r"""<!DOCTYPE html>
       const dec=d.decisions||[]; if(!dec.length) return null;
       return rsec('Decisions',dec.map(x=>'<div class="decitem">'+esc(x.question)+
         (x.chosen?' <span class="ch">→ '+esc(x.chosen)+'</span>':'')+
+        annHTML('dec:'+(x.id||x.question||''),x.question)+
         (x.rationale?'<br><span class="rat">'+esc(x.rationale)+'</span>':'')+'</div>').join(''));
     },
     experiments:d=>{
@@ -836,7 +890,7 @@ def _brand_file(project_root: Path, key: str) -> Optional[Path]:
 
 
 def _make_handler(channel: WebChannel, workspace_name: str, title: str,
-                  project_root: Path):
+                  project_root: Path, workspace_path: Path):
     page = PAGE.replace("{{WORKSPACE}}", workspace_name).replace("{{TITLE}}", title)
 
     class Handler(BaseHTTPRequestHandler):
@@ -900,6 +954,20 @@ def _make_handler(channel: WebChannel, workspace_name: str, title: str,
                 finally:
                     channel.unsubscribe(q)
 
+            elif self.path == "/annotations":
+                # Offline-eval thumbs, so the browser can re-paint thumb state on
+                # load / reconnect. {key: "up"|"down"}.
+                try:
+                    latest = _annotations.load_latest(workspace_path)
+                except Exception:
+                    latest = {}
+                body = json.dumps(latest).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
             else:
                 self.send_response(404)
                 self.end_headers()
@@ -917,6 +985,25 @@ def _make_handler(channel: WebChannel, workspace_name: str, title: str,
                     channel.submit_input(text)
                 self.send_response(204)
                 self.end_headers()
+
+            elif self.path == "/annotate":
+                # Record an offline-eval thumb. Never touches the live run.
+                length = int(self.headers.get("Content-Length", 0))
+                raw = self.rfile.read(length) if length else b""
+                try:
+                    payload = json.loads(raw.decode("utf-8"))
+                    _annotations.append_annotation(
+                        workspace_path,
+                        key=payload.get("key", ""),
+                        kind=payload.get("kind", ""),
+                        verdict=payload.get("verdict", ""),
+                        snapshot=payload.get("snapshot", ""),
+                    )
+                    self.send_response(204)
+                except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+                    self.send_response(400)
+                self.end_headers()
+
             else:
                 self.send_response(404)
                 self.end_headers()
@@ -950,7 +1037,7 @@ class InteractiveWebServer:
 
     def start(self) -> None:
         handler = _make_handler(self.channel, self.workspace.name, self.title,
-                                self.project_root)
+                                self.project_root, self.workspace)
         # Try the requested port, then a few above it if taken.
         last_err = None
         for port in range(self.port, self.port + 10):

--- a/src/interactive/web_server.py
+++ b/src/interactive/web_server.py
@@ -507,11 +507,12 @@ PAGE = r"""<!DOCTYPE html>
     }
     if(whoEl) el.appendChild(whoEl);
     const t=document.createElement('div');t.textContent=d.text;el.appendChild(t);
-    // Offline-eval thumbs on manager bubbles (keyed by the event's seq, which is
-    // stable across reconnects within a run; the POST also snapshots the text).
-    if(role==='manager'&&d.seq!=null){
+    // Offline-eval thumbs on manager bubbles, keyed by a content hash of the
+    // text so the verdict re-attaches to the same message across reconnects AND
+    // resumed sessions (the POST also snapshots the text).
+    if(role==='manager'&&d.text){
       const af=document.createElement('div');af.className='ann-foot';
-      af.innerHTML=annHTML('msg:'+d.seq,d.text);
+      af.innerHTML=annHTML('msg:'+hashStr(d.text),d.text);
       el.appendChild(af);
     }
     chat.appendChild(el);
@@ -676,6 +677,10 @@ PAGE = r"""<!DOCTYPE html>
   // so the JSONL record is self-contained for offline eval. Keys are
   // 'assess:<id>' | 'dec:<id>' | 'msg:<seq>'.
   const ANN={}, SNIP={}, ANN_KIND={assess:'assessment',dec:'decision',msg:'message'};
+  // Content hash so a chat-bubble annotation keys on the message TEXT, not the
+  // per-process SSE seq (which restarts at 0 on a resumed session and would
+  // collide / re-paint the wrong bubble). Same text → same key across runs.
+  function hashStr(s){let h=5381;s=String(s);for(let i=0;i<s.length;i++){h=((h*33)^s.charCodeAt(i))>>>0;}return h.toString(36);}
   function annHTML(key,snip){
     if(snip!=null) SNIP[key]=String(snip);
     const v=ANN[key]||'';


### PR DESCRIPTION
Split out of #111 (4 of 4). Base: `split/pr4-mcp` (PR 114).

Adds 👍/👎 offline-eval annotations on the manager's assessments/decisions/messages,
persisted for later evaluation. Includes the UI portion of the review-findings pass.

⚠️ Base is PR 114, not `main`. Merge last; retarget to `main` once PR 114 lands.