### PR TITLE
feat: rule_maker agent + post-run scorer stage

### DIFF
--- a/config/domains.yaml
+++ b/config/domains.yaml
@@ -137,6 +137,12 @@ domains:
       - bifurcation
       - dynamical system
 
+  mathematics_lean:
+    name: "Mathematics (Lean)"
+    description: "Formal mathematics with Lean 4 proof verification: proofs are machine-checked by the Lean type checker using Mathlib"
+    has_template: true
+    paper_style: ams
+
   finance:
     name: "Finance"
     description: "Empirical finance: banking, corporate finance, asset pricing, financial regulation, panel data analysis"

--- a/docker-compose.lean.yml
+++ b/docker-compose.lean.yml
@@ -1,0 +1,81 @@
+# =============================================================================
+# neurico-lean Docker Compose Configuration
+#
+# STANDALONE mode: each run is a self-contained, ephemeral job.
+# The Lean toolchain and Mathlib.Tactic cache are baked into the image —
+# no volume mounts are needed for Lean to work.
+#
+# Build:
+#   docker compose -f docker-compose.lean.yml build
+#
+# Run a single research pipeline:
+#   docker compose -f docker-compose.lean.yml run --rm neurico-lean \
+#       python /app/src/core/runner.py <idea_id> --provider claude
+#
+# Interactive shell:
+#   docker compose -f docker-compose.lean.yml run --rm neurico-lean bash
+# =============================================================================
+
+services:
+  neurico-lean:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.lean
+
+    image: chicagohai/neurico-lean:latest
+    container_name: neurico-lean
+
+    # GPU support (NVIDIA Container Toolkit required)
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+    env_file:
+      - .env
+
+    environment:
+      - PYTHONUNBUFFERED=1
+      - NEURICO_WORKSPACE=/workspaces
+      - CLAUDE_CONFIG_DIR=/tmp/.claude
+      - ELAN_HOME=/home/neurico/.elan
+
+    volumes:
+      # ── Research output (the only persistent state across runs) ────────────
+      # Each run writes its workspace here; the directory survives container exit.
+      - ./workspaces:/workspaces:rw
+
+      # ── Ideas and config (read-only inputs) ───────────────────────────────
+      - ./ideas:/app/ideas:rw
+      - ./logs:/app/logs:rw
+      - ./config:/app/config:ro
+      - ./templates:/app/templates:ro
+
+      # ── CLI credentials (OAuth tokens, read-only) ─────────────────────────
+      - ~/.claude:/tmp/.claude:ro
+      - ~/.codex:/tmp/.codex:ro
+      - ~/.gemini:/tmp/.gemini:ro
+
+    # No restart policy — standalone runs exit when the pipeline finishes
+    # restart: "no"  (default, no need to set)
+
+    stdin_open: true
+    tty: true
+    working_dir: /workspaces
+
+    healthcheck:
+      test: ["CMD", "lean", "--version"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+    networks:
+      - research-net
+
+networks:
+  research-net:
+    driver: bridge

--- a/docker/Dockerfile.lean
+++ b/docker/Dockerfile.lean
@@ -1,0 +1,218 @@
+# syntax=docker/dockerfile:1.5
+# =============================================================================
+# neurico-lean — Standalone Lean 4 research image
+#
+# Self-contained: builds from the upstream CUDA base directly.
+# No dependency on a pre-built chicagohai/neurico image.
+#
+# One build command:
+#   docker build -f docker/Dockerfile.lean -t chicagohai/neurico-lean:latest .
+#
+# Adds on top of the standard neurico stack:
+#   - elan  (Lean version manager)
+#   - lean  (Lean 4 proof assistant, Mathlib-pinned toolchain)
+#   - lake  (Lean build tool)
+#   - Mathlib.Tactic olean cache (~1-2GB, pre-warmed at build time)
+#     so each standalone run needs no network access for Lean.
+# =============================================================================
+
+ARG CUDA_VERSION=12.5.1
+ARG UBUNTU_VERSION=22.04
+
+# Lean 4 only provides pre-built binaries for x86_64-linux.
+# Pin to linux/amd64 so this image builds and runs correctly on any host,
+# including Apple Silicon Macs (where Docker Desktop defaults to aarch64).
+ARG TARGETPLATFORM=linux/amd64
+
+# =============================================================================
+# Stage 1: Builder — install tools and build all Python environments
+# =============================================================================
+FROM --platform=linux/amd64 nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS builder
+
+LABEL org.opencontainers.image.title="neurico-lean"
+LABEL org.opencontainers.image.description="Autonomous research framework with Lean 4 formal verification"
+LABEL org.opencontainers.image.source="https://github.com/ChicagoHAI/neurico"
+LABEL maintainer="ChicagoHAI"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# System dependencies (same as base image)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    wget \
+    git \
+    ca-certificates \
+    gnupg \
+    libssl-dev \
+    libffi-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libncurses5-dev \
+    libncursesw5-dev \
+    xz-utils \
+    tk-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    liblzma-dev \
+    zlib1g-dev \
+    git-lfs \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 (for Codex and Gemini CLIs)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv
+COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /usr/local/bin/uv
+
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+
+RUN uv python install 3.12
+
+# Claude Code CLI
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+    && cp /root/.local/bin/claude /usr/local/bin/claude
+
+# Codex and Gemini CLIs
+RUN npm install -g @openai/codex \
+    && npm install -g @google/gemini-cli
+
+# Build neurico app and all virtual environments
+WORKDIR /app
+COPY . .
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv venv /app/.venv \
+    && uv sync --frozen --no-dev
+
+WORKDIR /app/services/paper-finder
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --all-packages --dev
+WORKDIR /app
+
+# =============================================================================
+# Stage 2: Runtime — production image with Lean 4 added
+# =============================================================================
+FROM --platform=linux/amd64 nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION} AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# Runtime system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    git-lfs \
+    openssh-client \
+    ca-certificates \
+    libcudnn8 \
+    make \
+    libgmp-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# LaTeX for paper compilation
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    texlive-latex-base \
+    texlive-latex-extra \
+    texlive-latex-recommended \
+    texlive-fonts-recommended \
+    texlive-fonts-extra \
+    texlive-science \
+    texlive-bibtex-extra \
+    texlive-publishers \
+    lmodern \
+    cm-super \
+    biber \
+    latexmk \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js from builder
+COPY --from=builder /usr/bin/node /usr/bin/
+COPY --from=builder /usr/lib/node_modules /usr/lib/node_modules
+RUN ln -sf /usr/lib/node_modules/npm/bin/npm-cli.js /usr/bin/npm \
+    && ln -sf /usr/lib/node_modules/npm/bin/npx-cli.js /usr/bin/npx
+
+# Claude Code CLI
+COPY --from=builder /usr/local/bin/claude /usr/local/bin/claude
+
+# Codex and Gemini
+RUN ln -sf /usr/lib/node_modules/@openai/codex/bin/codex.js /usr/bin/codex \
+    && ln -sf /usr/lib/node_modules/@google/gemini-cli/bundle/gemini.js /usr/bin/gemini
+
+# uv
+COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /usr/local/bin/uv
+
+# Non-root user
+RUN useradd -u 1000 -m -s /bin/bash neurico
+
+# Python and app
+COPY --from=builder /python /python
+COPY --from=builder --chown=neurico:neurico /app /app
+
+ENV PATH="/app/.venv/bin:/python/bin:/usr/local/bin:${PATH}"
+ENV UV_PYTHON_INSTALL_DIR=/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+ENV VIRTUAL_ENV="/app/.venv"
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV UV_COMPILE_BYTECODE=1
+ENV PYTHONPATH="/app:${PYTHONPATH}"
+
+RUN mkdir -p /workspaces \
+    /app/ideas/submitted /app/ideas/in_progress /app/ideas/completed \
+    /app/logs /app/runs
+
+# ── Lean 4 installation (as neurico user) ─────────────────────────────────────
+USER neurico
+WORKDIR /app
+
+RUN git config --global user.email "noreply@neurico.dev" \
+    && git config --global user.name "NeuriCo" \
+    && git config --global init.defaultBranch main \
+    && mkdir -p ~/.claude ~/.codex ~/.gemini ~/.cache/uv \
+    && echo 'PS1="neurico:\w\$ "' >> ~/.bashrc
+
+ENV ELAN_HOME=/home/neurico/.elan
+ENV PATH="${ELAN_HOME}/bin:${PATH}"
+ENV NEURICO_WORKSPACE=/workspaces
+
+# Install elan and the Mathlib-pinned Lean toolchain
+RUN curl -sSfL \
+      https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+    | sh -s -- -y \
+        --no-modify-path \
+        --default-toolchain leanprover-community/mathlib4:stable \
+    && lean --version \
+    && lake --version
+
+# Pre-warm the Mathlib.Tactic olean cache (~1-2GB).
+# Runs at build time so standalone containers need no network access for Lean.
+RUN mkdir -p /tmp/lean-warmup \
+    && lake +leanprover-community/mathlib4:stable \
+         init /tmp/lean-warmup/warmup math \
+    && cd /tmp/lean-warmup/warmup \
+    && printf 'import Mathlib.Tactic\n\nnamespace Warmup\nend Warmup\n' \
+         > LeanProofs/Definitions.lean \
+    && lake exe cache get \
+    && lake build \
+    && rm -rf /tmp/lean-warmup
+
+# Smoke-test: verify lean can compile a simple theorem
+RUN lean --stdin <<< 'theorem smoke (n : Nat) : n + 0 = n := Nat.add_zero n'
+
+VOLUME ["/workspaces"]
+WORKDIR /workspaces
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+    CMD lean --version
+
+ENTRYPOINT ["/app/docker/entrypoint.lean.sh"]
+CMD ["bash"]

--- a/docker/entrypoint.lean.sh
+++ b/docker/entrypoint.lean.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# =============================================================================
+# neurico-lean Container Entrypoint
+# Adds Lean 4 status reporting before handing off to the standard entrypoint.
+# =============================================================================
+
+set -e
+
+# Make elan/lean/lake available (installed to /home/neurico/.elan at build time)
+export ELAN_HOME="${ELAN_HOME:-/home/neurico/.elan}"
+export PATH="${ELAN_HOME}/bin:${PATH}"
+
+# ── Lean status check ────────────────────────────────────────────────────────
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${BLUE}Lean 4 Status:${NC}"
+
+if command -v lean &>/dev/null; then
+    LEAN_VER=$(lean --version 2>/dev/null | head -1)
+    LAKE_VER=$(lake --version 2>/dev/null | head -1)
+    echo -e "  ${GREEN}[OK]${NC} lean  — ${LEAN_VER}"
+    echo -e "  ${GREEN}[OK]${NC} lake  — ${LAKE_VER}"
+
+    # Report whether the Mathlib cache already exists in the global cache dir
+    CACHE_DIR="${HOME}/.cache/mathlib"
+    if [ -d "${CACHE_DIR}" ] && [ "$(ls -A "${CACHE_DIR}" 2>/dev/null)" ]; then
+        CACHE_SIZE=$(du -sh "${CACHE_DIR}" 2>/dev/null | cut -f1)
+        echo -e "  ${GREEN}[OK]${NC} Mathlib cache — ${CACHE_SIZE} at ${CACHE_DIR}"
+    else
+        echo -e "  ${YELLOW}[INFO]${NC} Mathlib cache not yet populated"
+        echo -e "         Run setup in workspace: bash .claude/skills/lean-prover/scripts/setup_lean_project.sh"
+        echo -e "         First run downloads ~1-2GB (Mathlib.Tactic); cached for subsequent workspaces."
+    fi
+else
+    echo -e "  ${YELLOW}[WARN]${NC} lean not found on PATH — elan may not be installed correctly"
+fi
+
+echo ""
+
+# ── Hand off to the standard neurico entrypoint ──────────────────────────────
+exec /app/docker/entrypoint.sh "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,15 @@ target-version = ['py310']
 line-length = 100
 target-version = "py310"
 
+[tool.pytest.ini_options]
+markers = [
+    "lean_binary: requires lean binary on PATH (Tier 1 integration tests)",
+    "lean_lake:   requires lean + lake on PATH (Tier 2 integration tests)",
+    "lean_mathlib: slow — downloads Mathlib cache; implies lean_lake (Tier 3)",
+    "slow:        long-running tests (>60 seconds)",
+    "lean_llm:    LLM smoke test — requires claude CLI + credentials (~10-15 min, ~$0.50)",
+]
+
 [tool.uv.workspace]
 members = [
     "workspace/llm-epistemic-belief-6a0d",

--- a/src/agents/rule_maker.py
+++ b/src/agents/rule_maker.py
@@ -1,0 +1,439 @@
+"""
+Rule Maker Agent
+
+Launches a CLI agent that, given the user's idea and the resource_finder's
+outputs, writes a per-run evaluation harness into the workspace under
+scoring/. The harness consists of:
+
+- scoring/eval.py: a self-contained Python program that measures the
+  experiment_runner's artifact and writes scoring/results.json.
+- scoring/targets.json: numeric targets and the success rule.
+- scoring/interface.md: visible to the experiment_runner -- describes what
+  files the runner must produce and how they will be invoked.
+- scoring/rule_maker_log.md: rationale for the chosen metrics.
+
+This agent runs between resource_finder and experiment_runner. Its outputs
+should be sealed (read-only) before experiment_runner starts so the runner
+cannot influence what it is being judged on.
+"""
+
+from pathlib import Path
+from typing import Optional, Dict, Any
+import subprocess
+import shlex
+import os
+import sys
+import time
+import json
+import ast
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.security import sanitize_text
+
+
+# CLI commands for different providers (mirrors resource_finder.py)
+CLI_COMMANDS = {
+    'claude': 'claude -p',
+    'codex': 'codex exec',
+    'gemini': 'gemini',
+}
+
+# Verbose / structured-transcript output flags per provider
+TRANSCRIPT_FLAGS = {
+    'claude': '--verbose --output-format stream-json',
+    'codex': '--json',
+    'gemini': '--output-format stream-json',
+}
+
+# Files the rule_maker is responsible for producing (relative to scoring/)
+RULE_MAKER_OUTPUT_FILES = {
+    'eval_script': 'eval.py',
+    'targets': 'targets.json',
+    'interface': 'interface.md',
+    'rationale_log': 'rule_maker_log.md',
+}
+
+
+def generate_rule_maker_prompt(
+    idea: Dict[str, Any],
+    work_dir: Path,
+    templates_dir: Path,
+    domain: Optional[str] = None,
+) -> str:
+    """
+    Build the rule_maker agent's prompt.
+
+    Composition (mirrors the researcher prompt pattern):
+
+      1. General body: templates/base/rule_maker.txt
+         -- the universal rule_maker job description, applied to every run.
+      2. Domain supplement (optional): templates/domains/<domain>/rule_maker.txt
+         -- domain-specific guidelines (what metrics matter in this domain,
+            calibration conventions, common reward-hacking traps, etc.).
+
+    Placeholders substituted in the general body:
+      {idea_yaml}        -- the idea spec (JSON-serialized for readability)
+      {workspace}        -- absolute path to the run's workspace
+      {scoring_dir}      -- absolute path to scoring/
+      {output_files}     -- list of files the agent must produce
+      {resource_listing} -- short summary of resource_finder outputs
+
+    Args:
+        idea: Full idea specification.
+        work_dir: Path to the run's workspace.
+        templates_dir: Path to the project's templates/ directory.
+        domain: Domain name (e.g. 'machine_learning'). If None, extracted
+            from idea['idea']['domain'] or idea['domain'], defaulting to
+            'machine_learning' (matches researcher prompt's default).
+
+    The prompt BODIES are user-owned and live in the template files. This
+    function only handles loading + substitution + concatenation.
+    """
+    work_dir = Path(work_dir)
+    templates_dir = Path(templates_dir)
+
+    # Load the general body. It lives at templates/agents/rule_maker.txt,
+    # alongside the other per-run agents (resource_finder.txt, paper_writer.txt).
+    # Per-domain supplements live separately at templates/domains/<d>/rule_maker.txt.
+    base_path = templates_dir / "agents" / "rule_maker.txt"
+    if not base_path.exists():
+        raise FileNotFoundError(
+            f"rule_maker base template not found at {base_path}. "
+            "Create templates/agents/rule_maker.txt before running."
+        )
+    base_template = base_path.read_text(encoding='utf-8')
+
+    scoring_dir = work_dir / "scoring"
+    output_files = "\n".join(
+        f"  - scoring/{name}" for name in RULE_MAKER_OUTPUT_FILES.values()
+    )
+    resource_listing = _summarize_resource_outputs(work_dir)
+
+    try:
+        idea_repr = json.dumps(idea, indent=2, default=str)
+    except (TypeError, ValueError):
+        idea_repr = repr(idea)
+
+    substitutions = {
+        '{idea_yaml}': idea_repr,
+        '{workspace}': str(work_dir),
+        '{scoring_dir}': str(scoring_dir),
+        '{output_files}': output_files,
+        '{resource_listing}': resource_listing,
+    }
+
+    prompt = base_template
+    for placeholder, value in substitutions.items():
+        prompt = prompt.replace(placeholder, value)
+
+    # Append per-domain supplement (if any) with a banner.
+    resolved_domain = _resolve_domain(idea, domain)
+    supplement = _load_domain_supplement(templates_dir, resolved_domain)
+    if supplement:
+        banner = "=" * 80
+        domain_label = resolved_domain.upper().replace('_', ' ')
+        prompt = (
+            f"{prompt}\n\n"
+            f"{banner}\n"
+            f"           RULE MAKER DOMAIN GUIDELINES: {domain_label}\n"
+            f"{banner}\n\n"
+            f"{supplement}\n"
+        )
+
+    return prompt
+
+
+def _resolve_domain(
+    idea: Dict[str, Any], override: Optional[str]
+) -> str:
+    """
+    Pick the domain string used to locate the domain supplement.
+
+    Order of precedence:
+      1. Explicit `override` argument.
+      2. idea['idea']['domain']  (nested spec, as elsewhere in the pipeline).
+      3. idea['domain']          (flat spec).
+      4. Fallback: 'machine_learning' (matches researcher default).
+    """
+    if override:
+        return override
+    nested = idea.get('idea', {}) if isinstance(idea, dict) else {}
+    if isinstance(nested, dict) and nested.get('domain'):
+        return nested['domain']
+    if isinstance(idea, dict) and idea.get('domain'):
+        return idea['domain']
+    return 'machine_learning'
+
+
+def _load_domain_supplement(templates_dir: Path, domain: str) -> str:
+    """
+    Load templates/domains/<domain>/rule_maker.txt if present.
+
+    Returns empty string when the supplement is missing -- the general
+    body alone is then used. (No silent fallback to a different domain;
+    that decision is left to the caller / pipeline.)
+    """
+    supplement_path = templates_dir / "domains" / domain / "rule_maker.txt"
+    if not supplement_path.exists():
+        return ""
+    return supplement_path.read_text(encoding='utf-8')
+
+
+def _summarize_resource_outputs(work_dir: Path) -> str:
+    """
+    Build a short, prompt-safe listing of what resource_finder produced.
+
+    The rule_maker needs to know which files / folders exist so it can
+    reference them in eval.py, but it should not have raw resource
+    contents dumped into its prompt.
+    """
+    work_dir = Path(work_dir)
+    candidates = [
+        ("literature_review.md", work_dir / "literature_review.md"),
+        ("resources.md", work_dir / "resources.md"),
+        ("papers/", work_dir / "papers"),
+        ("datasets/", work_dir / "datasets"),
+        ("code/", work_dir / "code"),
+    ]
+    lines = []
+    for label, path in candidates:
+        if not path.exists():
+            lines.append(f"  - {label}: (missing)")
+            continue
+        if path.is_dir():
+            entries = sorted(p.name for p in path.iterdir())
+            preview = ", ".join(entries[:8])
+            extra = "" if len(entries) <= 8 else f", +{len(entries) - 8} more"
+            lines.append(
+                f"  - {label}: {len(entries)} entries [{preview}{extra}]"
+            )
+        else:
+            size = path.stat().st_size
+            lines.append(f"  - {label}: {size} bytes")
+    return "\n".join(lines) if lines else "  (no resource_finder outputs found)"
+
+
+def run_rule_maker(
+    idea: Dict[str, Any],
+    work_dir: Path,
+    provider: str = "claude",
+    templates_dir: Optional[Path] = None,
+    timeout: int = 1800,  # 30 min
+    full_permissions: bool = True,
+) -> Dict[str, Any]:
+    """
+    Launch the rule_maker CLI agent.
+
+    Returns:
+        Dict with: success, outputs (paths of generated files), issues,
+        log_file, transcript_file, elapsed_time.
+    """
+    if provider not in CLI_COMMANDS:
+        raise ValueError(
+            f"Unsupported provider: {provider}. "
+            f"Choose from: {list(CLI_COMMANDS.keys())}"
+        )
+
+    if templates_dir is None:
+        templates_dir = Path(__file__).parent.parent.parent / "templates"
+
+    work_dir = Path(work_dir)
+    scoring_dir = work_dir / "scoring"
+    scoring_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir = work_dir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"📐 Starting Rule Maker Agent")
+    print(f"   Provider: {provider}")
+    print(f"   Work dir: {work_dir}")
+    print(f"   Timeout: {timeout}s ({timeout // 60} minutes)")
+    print("=" * 80)
+
+    # Generate prompt and persist it for debugging
+    prompt = generate_rule_maker_prompt(idea, work_dir, templates_dir)
+    prompt_file = logs_dir / "rule_maker_prompt.txt"
+    prompt_file.write_text(prompt, encoding='utf-8')
+    print(f"   Prompt saved to: {prompt_file}")
+    print(f"   Prompt length: {len(prompt)} characters")
+
+    # Build CLI command
+    cmd = CLI_COMMANDS[provider]
+    if full_permissions:
+        if provider == "codex":
+            cmd += " --yolo"
+        elif provider == "claude":
+            cmd += " --dangerously-skip-permissions"
+        elif provider == "gemini":
+            cmd += " --yolo --skip-trust"
+
+    transcript_flag = TRANSCRIPT_FLAGS.get(provider, '')
+    if transcript_flag:
+        cmd += f" {transcript_flag}"
+
+    log_file = logs_dir / f"rule_maker_{provider}.log"
+    transcript_file = logs_dir / f"rule_maker_{provider}_transcript.jsonl"
+
+    print(f"▶️  Launching {provider} CLI agent...")
+    print(f"   Command: {cmd}")
+    print(f"   Log file: {log_file}")
+    print()
+    print("=" * 80)
+    print("RULE MAKER OUTPUT (streaming)")
+    print("=" * 80)
+
+    env = os.environ.copy()
+    env['PYTHONUNBUFFERED'] = '1'
+    if provider == "gemini":
+        env['GEMINI_CLI_IDE_DISABLE'] = '1'
+
+    start_time = time.time()
+
+    try:
+        with open(log_file, 'w', encoding='utf-8') as log_f, \
+                open(transcript_file, 'w', encoding='utf-8') as transcript_f:
+            process = subprocess.Popen(
+                shlex.split(cmd),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                env=env,
+                text=True,
+                encoding='utf-8',
+                bufsize=1,
+                cwd=str(work_dir),
+            )
+            process.stdin.write(prompt)
+            process.stdin.close()
+
+            for line in iter(process.stdout.readline, ''):
+                if line:
+                    sanitized = sanitize_text(line)
+                    print(sanitized, end='')
+                    log_f.write(sanitized)
+                    transcript_f.write(sanitized)
+
+            return_code = process.wait(timeout=timeout)
+
+        print()
+        print("=" * 80)
+        elapsed = time.time() - start_time
+        print(
+            f"⏱️  Rule maker completed in {elapsed:.1f}s "
+            f"({elapsed / 60:.1f} minutes)"
+        )
+
+        if return_code == 0:
+            print("✅ Agent process exited cleanly.")
+        else:
+            print(f"⚠️  Agent exited with return code: {return_code}")
+
+    except subprocess.TimeoutExpired:
+        print(f"\n⏱️  Rule maker timed out after {timeout} seconds")
+        process.kill()
+
+    except Exception as e:
+        print(f"\n❌ Error during rule_maker execution: {e}")
+        raise
+
+    # Validate outputs
+    print()
+    print("📦 Validating rule_maker outputs...")
+    validation = validate_rule_maker_outputs(work_dir)
+    success = validation['valid']
+    if success:
+        print("✅ All required rule_maker outputs present and parseable.")
+    else:
+        print("⚠️  Rule maker outputs incomplete or invalid:")
+        for issue in validation['issues']:
+            print(f"     - {issue}")
+
+    return {
+        'success': success,
+        'outputs': validation['found'],
+        'issues': validation['issues'],
+        'log_file': str(log_file),
+        'transcript_file': str(transcript_file),
+        'elapsed_time': time.time() - start_time,
+    }
+
+
+def validate_rule_maker_outputs(work_dir: Path) -> Dict[str, Any]:
+    """
+    Verify the rule_maker produced the expected files in a usable form.
+
+    Checks:
+      - scoring/eval.py exists and parses as valid Python
+      - scoring/targets.json exists and parses as valid JSON
+      - scoring/interface.md exists and is non-empty
+      - scoring/rule_maker_log.md exists (informational; not required)
+
+    Returns:
+        {'valid': bool, 'found': {name: path}, 'issues': [str, ...]}
+    """
+    work_dir = Path(work_dir)
+    scoring_dir = work_dir / "scoring"
+    found: Dict[str, str] = {}
+    issues = []
+
+    eval_path = scoring_dir / RULE_MAKER_OUTPUT_FILES['eval_script']
+    if not eval_path.exists():
+        issues.append(f"missing: {eval_path}")
+    else:
+        try:
+            ast.parse(eval_path.read_text(encoding='utf-8'))
+            found['eval_script'] = str(eval_path)
+        except SyntaxError as e:
+            issues.append(f"eval.py has syntax error: {e}")
+
+    targets_path = scoring_dir / RULE_MAKER_OUTPUT_FILES['targets']
+    if not targets_path.exists():
+        issues.append(f"missing: {targets_path}")
+    else:
+        try:
+            json.loads(targets_path.read_text(encoding='utf-8'))
+            found['targets'] = str(targets_path)
+        except json.JSONDecodeError as e:
+            issues.append(f"targets.json is not valid JSON: {e}")
+
+    interface_path = scoring_dir / RULE_MAKER_OUTPUT_FILES['interface']
+    if not interface_path.exists():
+        issues.append(f"missing: {interface_path}")
+    elif interface_path.stat().st_size == 0:
+        issues.append(f"empty: {interface_path}")
+    else:
+        found['interface'] = str(interface_path)
+
+    rationale_path = scoring_dir / RULE_MAKER_OUTPUT_FILES['rationale_log']
+    if rationale_path.exists():
+        found['rationale_log'] = str(rationale_path)
+
+    return {
+        'valid': len(issues) == 0,
+        'found': found,
+        'issues': issues,
+    }
+
+
+def load_interface_for_runner(work_dir: Path) -> str:
+    """
+    Read scoring/interface.md to inject into the experiment_runner's prompt.
+
+    This is the ONE channel by which rule_maker's output reaches the runner.
+    Everything else under scoring/ (eval.py, targets.json) is hidden from
+    the runner.
+
+    Raises:
+        FileNotFoundError: If interface.md is missing -- the pipeline should
+        not proceed to experiment_runner without it.
+    """
+    interface_path = (
+        Path(work_dir) / "scoring" / RULE_MAKER_OUTPUT_FILES['interface']
+    )
+    if not interface_path.exists():
+        raise FileNotFoundError(
+            f"scoring/interface.md not found at {interface_path}. "
+            "rule_maker must run successfully before experiment_runner."
+        )
+    return interface_path.read_text(encoding='utf-8')

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -6,17 +6,30 @@ This module orchestrates the multi-agent research pipeline:
 2. (Optional) Human review checkpoint
 3. Experiment Runner Agent (CLI-based by default, Scribe optional): Implementation, experimentation, analysis
 
+When scoring_enabled=True is passed to run_pipeline(), two extra stages are
+woven into the flow:
+    - rule_maker (between resource_finder and experiment_runner): writes a
+      per-run artifact protocol (scoring/interface.md, scoring/eval.py,
+      scoring/targets.json, scoring/rule_maker_log.md).
+    - scorer (after experiment_runner): executes scoring/eval.py and writes
+      scoring/results.json.
+Plus a seal/unseal step that moves the scorer-side files out of the workspace
+during the runner stage so the runner cannot read them.
+
 The orchestrator manages agent execution flow, monitors completion, handles errors,
 and tracks pipeline state.
 """
 
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, List, Dict, Any
 import json
+import shutil
 from datetime import datetime
 import time
 
 from agents.resource_finder import run_resource_finder
+from agents.rule_maker import run_rule_maker
+from core.scorer import run_scorer
 from templates.research_agent_instructions import generate_instructions
 
 
@@ -96,6 +109,21 @@ CLI_COMMANDS = {
     'gemini': 'gemini'
 }
 
+# Stage names tracked in PipelineState when scoring_enabled=True
+RULE_MAKER_STAGE = 'rule_maker'
+SCORER_STAGE = 'scorer'
+
+# Files moved out of the workspace during the experiment_runner stage so the
+# runner cannot read them. Restored before the scorer runs.
+#   - eval.py:           the scoring code itself
+#   - targets.json:      numeric targets + success rule
+#   - rule_maker_log.md: rationale, which references the targets in plain text
+SEALED_FILES: List[str] = [
+    "scoring/eval.py",
+    "scoring/targets.json",
+    "scoring/rule_maker_log.md",
+]
+
 
 class ResearchPipelineOrchestrator:
     """
@@ -132,7 +160,10 @@ class ResearchPipelineOrchestrator:
         resource_finder_timeout: int = 2700,  # 45 min
         experiment_runner_timeout: int = 10800,  # 3 hours
         full_permissions: bool = True,
-        use_scribe: bool = False
+        use_scribe: bool = False,
+        scoring_enabled: bool = False,
+        rule_maker_timeout: int = 1800,  # 30 min
+        scorer_timeout: int = 600  # 10 min
     ) -> Dict[str, Any]:
         """
         Execute complete research pipeline.
@@ -146,19 +177,30 @@ class ResearchPipelineOrchestrator:
             experiment_runner_timeout: Timeout for experiment runner in seconds
             full_permissions: Allow full permissions to agents
             use_scribe: If True, use scribe for notebook integration (default: False, raw CLI)
+            scoring_enabled: If True, run in rule_maker (scored) mode. Adds two stages
+                             (rule_maker between resource_finder and experiment_runner,
+                             scorer after experiment_runner) and seals scoring/ inputs
+                             from the runner. Default False = legacy two-stage flow.
+            rule_maker_timeout: Timeout for rule_maker stage in seconds (scoring mode only)
+            scorer_timeout: Timeout for scorer stage in seconds (scoring mode only)
 
         Returns:
             Dictionary with pipeline execution results
         """
         print()
         print("=" * 80)
-        print("MULTI-AGENT RESEARCH PIPELINE")
+        if scoring_enabled:
+            print("MULTI-AGENT RESEARCH PIPELINE  (SCORING MODE)")
+        else:
+            print("MULTI-AGENT RESEARCH PIPELINE")
         print("=" * 80)
         print(f"Work directory: {self.work_dir}")
         print(f"Provider: {provider}")
         print(f"Use scribe (notebooks): {use_scribe}")
         print(f"Pause after resources: {pause_after_resources}")
         print(f"Skip resource finder: {skip_resource_finder}")
+        if scoring_enabled:
+            print(f"Scoring enabled: True (rule_maker + scorer stages)")
         print("=" * 80)
         print()
 
@@ -167,6 +209,8 @@ class ResearchPipelineOrchestrator:
             'stages': {},
             'work_dir': str(self.work_dir)
         }
+        if scoring_enabled:
+            results['mode'] = 'scored'
 
         try:
             # STAGE 1: Resource Finder
@@ -200,23 +244,72 @@ class ResearchPipelineOrchestrator:
                     print("🛑 Pipeline paused. Human did not approve continuation.")
                     return results
 
-            # STAGE 3: Experiment Runner
-            results['stages']['experiment_runner'] = self._run_experiment_runner(
-                idea=idea,
-                provider=provider,
-                timeout=experiment_runner_timeout,
-                full_permissions=full_permissions,
-                use_scribe=use_scribe
-            )
+            # STAGE 2.5 (scoring mode only): Rule Maker
+            # Writes scoring/interface.md, scoring/eval.py, scoring/targets.json,
+            # scoring/rule_maker_log.md before the runner sees the workspace.
+            if scoring_enabled:
+                results['stages'][RULE_MAKER_STAGE] = self._run_rule_maker(
+                    idea=idea,
+                    provider=provider,
+                    timeout=rule_maker_timeout,
+                    full_permissions=full_permissions
+                )
+                if not results['stages'][RULE_MAKER_STAGE]['success']:
+                    print()
+                    print("⚠️  Rule maker stage failed -- aborting.")
+                    return results
 
-            if results['stages']['experiment_runner']['success']:
-                print()
-                print("🎉 PIPELINE COMPLETED SUCCESSFULLY!")
-                self.state.mark_completed()
-                results['success'] = True
+            # STAGE 3: Experiment Runner
+            # In scoring mode, seal eval.py / targets.json / rule_maker_log.md
+            # out of the workspace for the duration of the runner stage. Always
+            # unseal in the finally block (even on runner failure) so the scorer
+            # can run.
+            sealed_dir = self._seal_runner_inputs() if scoring_enabled else None
+            try:
+                results['stages']['experiment_runner'] = self._run_experiment_runner(
+                    idea=idea,
+                    provider=provider,
+                    timeout=experiment_runner_timeout,
+                    full_permissions=full_permissions,
+                    use_scribe=use_scribe,
+                    scoring_enabled=scoring_enabled
+                )
+            finally:
+                if scoring_enabled:
+                    self._unseal_runner_inputs(sealed_dir)
+
+            # STAGE 4 (scoring mode only): Scorer
+            # Executes scoring/eval.py and captures results.json.
+            if scoring_enabled:
+                results['stages'][SCORER_STAGE] = self._run_scorer(
+                    timeout=scorer_timeout
+                )
+
+            runner_ok = results['stages']['experiment_runner']['success']
+
+            if scoring_enabled:
+                scorer_ok = results['stages'][SCORER_STAGE]['success']
+                if runner_ok and scorer_ok:
+                    print()
+                    print("🎉 PIPELINE COMPLETED SUCCESSFULLY!")
+                    self.state.mark_completed()
+                    results['success'] = True
+                elif runner_ok and not scorer_ok:
+                    print()
+                    print("⚠️  Runner finished but scorer failed -- artifact "
+                          "may be unmeasured.")
+                else:
+                    print()
+                    print("⚠️  Pipeline finished with issues.")
             else:
-                print()
-                print("⚠️  Experiment runner stage completed with issues.")
+                if runner_ok:
+                    print()
+                    print("🎉 PIPELINE COMPLETED SUCCESSFULLY!")
+                    self.state.mark_completed()
+                    results['success'] = True
+                else:
+                    print()
+                    print("⚠️  Experiment runner stage completed with issues.")
 
         except Exception as e:
             print()
@@ -227,6 +320,7 @@ class ResearchPipelineOrchestrator:
         finally:
             # Save final results
             results_file = self.work_dir / ".neurico" / "pipeline_results.json"
+            results_file.parent.mkdir(parents=True, exist_ok=True)
             with open(results_file, 'w', encoding='utf-8') as f:
                 json.dump(results, f, indent=2)
 
@@ -315,12 +409,16 @@ class ResearchPipelineOrchestrator:
         provider: str,
         timeout: int,
         full_permissions: bool,
-        use_scribe: bool = False
+        use_scribe: bool = False,
+        scoring_enabled: bool = False
     ) -> Dict[str, Any]:
         """Run experiment runner stage (raw CLI by default, scribe optional)."""
         print()
         print("─" * 80)
-        print("STAGE 3: EXPERIMENT RUNNER")
+        if scoring_enabled:
+            print("STAGE 3: EXPERIMENT RUNNER  (scored prompt)")
+        else:
+            print("STAGE 3: EXPERIMENT RUNNER")
         print("─" * 80)
         print()
 
@@ -337,7 +435,11 @@ class ResearchPipelineOrchestrator:
             from templates.prompt_generator import PromptGenerator
 
             prompt_generator = PromptGenerator(self.templates_dir)
-            prompt = prompt_generator.generate_research_prompt(idea, root_dir=self.work_dir)
+            prompt = prompt_generator.generate_research_prompt(
+                idea,
+                root_dir=self.work_dir,
+                scoring_enabled=scoring_enabled
+            )
 
             # Save prompt
             prompt_file = self.work_dir / "logs" / "research_prompt.txt"
@@ -479,6 +581,195 @@ class ResearchPipelineOrchestrator:
             result = {'success': False, 'error': str(e)}
             self.state.complete_stage('experiment_runner', False, result)
             raise
+
+    # ---- Scoring-mode helpers (rule_maker / scorer / seal) ---------------
+    # These methods are only invoked when run_pipeline(scoring_enabled=True).
+    # In default mode they are not called; their presence does not affect the
+    # legacy two-stage flow.
+
+    def _run_rule_maker(
+        self,
+        idea: Dict[str, Any],
+        provider: str,
+        timeout: int,
+        full_permissions: bool
+    ) -> Dict[str, Any]:
+        """Run the rule_maker stage (scoring mode only)."""
+        print()
+        print("─" * 80)
+        print("STAGE: RULE MAKER")
+        print("─" * 80)
+        print()
+
+        self.state.start_stage(RULE_MAKER_STAGE)
+        try:
+            result = run_rule_maker(
+                idea=idea,
+                work_dir=self.work_dir,
+                provider=provider,
+                templates_dir=self.templates_dir,
+                timeout=timeout,
+                full_permissions=full_permissions
+            )
+            self.state.complete_stage(
+                RULE_MAKER_STAGE,
+                result['success'],
+                result.get('outputs')
+            )
+            return result
+        except Exception as e:
+            print(f"❌ Rule maker stage failed: {e}")
+            self.state.complete_stage(RULE_MAKER_STAGE, False)
+            raise
+
+    def _run_scorer(self, timeout: int) -> Dict[str, Any]:
+        """
+        Run the scorer stage (scoring mode only). Executes scoring/eval.py
+        and captures the structured results into scoring/results.json.
+        """
+        print()
+        print("─" * 80)
+        print("STAGE: SCORER")
+        print("─" * 80)
+        print()
+
+        self.state.start_stage(SCORER_STAGE)
+        try:
+            result = run_scorer(
+                work_dir=self.work_dir,
+                timeout=timeout
+            )
+            self.state.complete_stage(
+                SCORER_STAGE,
+                result['success'],
+                result
+            )
+            return result
+        except Exception as e:
+            print(f"❌ Scorer stage failed: {e}")
+            self.state.complete_stage(SCORER_STAGE, False)
+            raise
+
+    def _sealed_dir_for(self) -> Path:
+        """
+        Return the sibling directory where sealed scoring files live during
+        the experiment_runner stage.
+
+        For a workspace at <workspaces>/<name>/, the sealed directory is at
+        <workspaces>/.scoring_sealed/<name>/. Sealed files keep their
+        relative path inside that directory (e.g. scoring/eval.py).
+        """
+        return self.work_dir.parent / ".scoring_sealed" / self.work_dir.name
+
+    def _seal_runner_inputs(self) -> Optional[Path]:
+        """
+        Move SEALED_FILES out of the workspace BEFORE the runner stage.
+
+        Returns the sealed directory path so it can be passed to
+        _unseal_runner_inputs(). Returns None if nothing was sealed (e.g.,
+        the rule_maker output files did not exist).
+
+        Defense level: against an aligned-but-undisciplined runner, this is
+        a hard guarantee -- the files are not in the workspace at all. Against
+        an actively adversarial runner with full filesystem access, it is a
+        speed bump (the runner could traverse `..` and find the sealed dir).
+        Full hardening against adversarial runners requires sandboxing
+        (deferred to v1.0).
+        """
+        sealed_dir = self._sealed_dir_for()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+
+        moved = []
+        for rel in SEALED_FILES:
+            src = self.work_dir / rel
+            if not src.exists():
+                continue
+            dst = sealed_dir / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dst))
+            moved.append(rel)
+
+        if not moved:
+            # Nothing to seal; remove the empty sealed dir we created.
+            try:
+                sealed_dir.rmdir()
+                sealed_dir.parent.rmdir()  # remove .scoring_sealed if now empty
+            except OSError:
+                pass
+            print("🔒 Nothing to seal (rule_maker outputs not found).")
+            return None
+
+        print(f"🔒 Sealed {len(moved)} scoring files to {sealed_dir}:")
+        for r in moved:
+            print(f"     - {r}")
+        print(
+            f"   (manual recovery if orchestrator crashes: "
+            f"mv {sealed_dir}/scoring/* {self.work_dir}/scoring/)"
+        )
+        return sealed_dir
+
+    def _unseal_runner_inputs(self, sealed_dir: Optional[Path]) -> None:
+        """
+        Move sealed files back to the workspace AFTER the runner stage.
+
+        Best-effort: logs failures but does not raise. The caller must not
+        let an unseal error mask an experiment_runner failure -- this is
+        always called in a finally block.
+        """
+        if sealed_dir is None:
+            return
+
+        if not sealed_dir.exists():
+            print(f"⚠️  Sealed dir disappeared: {sealed_dir}")
+            return
+
+        restored = []
+        errors = []
+        for rel in SEALED_FILES:
+            src = sealed_dir / rel
+            if not src.exists():
+                continue
+            dst = self.work_dir / rel
+            try:
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(src), str(dst))
+                restored.append(rel)
+            except OSError as e:
+                errors.append(f"{rel}: {e}")
+
+        if restored:
+            print(f"🔓 Restored {len(restored)} scoring files from {sealed_dir}")
+
+        if errors:
+            print(f"⚠️  Unseal errors -- sealed dir kept at {sealed_dir} for "
+                  "manual recovery:")
+            for e in errors:
+                print(f"     - {e}")
+            return
+
+        # Best-effort cleanup. All expected files restored cleanly, so the
+        # sealed dir should contain at most empty subdirs (e.g. scoring/ we
+        # created during seal). If a stray FILE shows up, keep the dir for
+        # the user to inspect.
+        try:
+            has_files = any(
+                p.is_file() for p in sealed_dir.rglob("*")
+            ) if sealed_dir.exists() else False
+            if sealed_dir.exists() and not has_files:
+                shutil.rmtree(sealed_dir)
+                # Remove .scoring_sealed/ parent if also empty
+                parent = sealed_dir.parent
+                try:
+                    parent.rmdir()
+                except OSError:
+                    pass
+            elif has_files:
+                print(
+                    f"ℹ️  Unexpected files remain in {sealed_dir}; "
+                    "leaving the directory for inspection."
+                )
+        except OSError as e:
+            print(f"⚠️  Could not clean up {sealed_dir}: {e}")
 
     def get_pipeline_status(self) -> Dict[str, Any]:
         """Get current pipeline execution status."""

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -122,7 +122,10 @@ class ResearchRunner:
                     paper_timeout: int = 3600,
                     no_hash: bool = False,
                     private: bool = False,
-                    force_fresh: bool = False) -> Dict[str, Any]:
+                    force_fresh: bool = False,
+                    scoring_enabled: bool = False,
+                    rule_maker_timeout: int = 1800,
+                    scorer_timeout: int = 600) -> Dict[str, Any]:
         """
         Execute research for a given idea.
 
@@ -306,9 +309,16 @@ class ResearchRunner:
         # Choose execution mode: multi-agent pipeline or legacy monolithic
         if multi_agent:
             print()
-            print("🔀 Using MULTI-AGENT pipeline")
-            print("   Stage 1: Resource Finder (literature review, datasets, code)")
-            print("   Stage 2: Experiment Runner (implementation, experiments, analysis)")
+            if scoring_enabled:
+                print("🔀 Using MULTI-AGENT pipeline (SCORING MODE)")
+                print("   Stage 1: Resource Finder (literature review, datasets, code)")
+                print("   Stage 2: Rule Maker (writes scoring/ artifact protocol)")
+                print("   Stage 3: Experiment Runner (with sealed scoring/ inputs)")
+                print("   Stage 4: Scorer (executes scoring/eval.py)")
+            else:
+                print("🔀 Using MULTI-AGENT pipeline")
+                print("   Stage 1: Resource Finder (literature review, datasets, code)")
+                print("   Stage 2: Experiment Runner (implementation, experiments, analysis)")
             print()
 
             # Use pipeline orchestrator
@@ -344,7 +354,10 @@ class ResearchRunner:
                     resource_finder_timeout=resource_finder_timeout,
                     experiment_runner_timeout=timeout,
                     full_permissions=full_permissions,
-                    use_scribe=use_scribe
+                    use_scribe=use_scribe,
+                    scoring_enabled=scoring_enabled,
+                    rule_maker_timeout=rule_maker_timeout,
+                    scorer_timeout=scorer_timeout
                 )
 
                 success = pipeline_result.get('success', False)
@@ -966,6 +979,25 @@ def main():
         action="store_true",
         help="Run in comment mode: make targeted improvements based on comments in the idea file"
     )
+    parser.add_argument(
+        "--enable-scoring",
+        action="store_true",
+        help="Run in scoring mode: insert rule_maker stage before the runner, "
+             "seal scoring/ inputs from the runner, and run scorer after. "
+             "Requires rule_maker agent + scoring/eval.py protocol."
+    )
+    parser.add_argument(
+        "--rule-maker-timeout",
+        type=int,
+        default=1800,
+        help="Timeout for rule_maker stage in seconds (default: 1800 = 30 min, scoring mode only)"
+    )
+    parser.add_argument(
+        "--scorer-timeout",
+        type=int,
+        default=600,
+        help="Timeout for scorer stage in seconds (default: 600 = 10 min, scoring mode only)"
+    )
 
     args = parser.parse_args()
 
@@ -1013,7 +1045,10 @@ def main():
             paper_timeout=args.paper_timeout,
             no_hash=args.no_hash,
             private=args.private,
-            force_fresh=args.force_fresh
+            force_fresh=args.force_fresh,
+            scoring_enabled=args.enable_scoring,
+            rule_maker_timeout=args.rule_maker_timeout,
+            scorer_timeout=args.scorer_timeout
         )
 
         print()

--- a/src/core/scorer.py
+++ b/src/core/scorer.py
@@ -1,0 +1,185 @@
+"""
+Scorer Stage
+
+Executes scoring/eval.py (written by the rule_maker agent) against the
+artifact produced by experiment_runner. Captures structured results in
+scoring/results.json and stdout/stderr in scoring/eval_log.txt.
+
+The scorer is mechanical: no agent invocation, no LLM call. It simply
+runs the per-run evaluation script as a subprocess and surfaces the JSON
+it writes.
+"""
+
+from pathlib import Path
+from typing import Optional, Dict, Any
+import subprocess
+import json
+import sys
+import time
+
+
+# Files the scorer reads / writes (relative to <workspace>/scoring/)
+EVAL_SCRIPT_NAME = "eval.py"
+RESULTS_FILE_NAME = "results.json"
+LOG_FILE_NAME = "eval_log.txt"
+
+
+def _resolve_python_executable(work_dir: Path) -> str:
+    """
+    Pick the Python interpreter to invoke eval.py with.
+
+    The experiment_runner creates <workspace>/.venv during its setup phase
+    and installs all task-specific dependencies there. eval.py typically
+    imports those same dependencies (numpy, torch, sklearn, etc.), so it
+    must run under the workspace's interpreter rather than the
+    orchestrator's. Falls back to sys.executable if the workspace has no
+    .venv yet (e.g., during a scorer-only smoke test).
+    """
+    posix = work_dir / ".venv" / "bin" / "python"
+    if posix.exists() and posix.is_file():
+        return str(posix)
+    windows = work_dir / ".venv" / "Scripts" / "python.exe"
+    if windows.exists() and windows.is_file():
+        return str(windows)
+    return sys.executable
+
+
+def run_scorer(
+    work_dir: Path,
+    timeout: int = 600,
+    python_executable: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Execute scoring/eval.py against the runner's artifact.
+
+    Args:
+        work_dir: Workspace root containing scoring/eval.py and the
+                  runner's outputs.
+        timeout: Max execution time for eval.py in seconds.
+        python_executable: Python binary to use. Defaults to the workspace's
+                  own .venv interpreter (where the runner installed deps),
+                  falling back to sys.executable.
+
+    Returns:
+        Dict with:
+          - success: bool -- eval.py exited 0 AND results.json parsed cleanly
+          - return_code: int | None -- eval.py's exit code (None on timeout)
+          - results: dict | None -- parsed results.json contents
+          - results_path: str -- absolute path to results.json
+          - log_path: str -- absolute path to eval_log.txt
+          - elapsed_time: float
+          - error: str | None -- error message if anything failed
+    """
+    work_dir = Path(work_dir)
+    scoring_dir = work_dir / "scoring"
+    eval_script = scoring_dir / EVAL_SCRIPT_NAME
+    results_path = scoring_dir / RESULTS_FILE_NAME
+    log_path = scoring_dir / LOG_FILE_NAME
+
+    if not eval_script.exists():
+        return {
+            'success': False,
+            'return_code': None,
+            'results': None,
+            'results_path': str(results_path),
+            'log_path': str(log_path),
+            'elapsed_time': 0.0,
+            'error': f"scoring/eval.py not found at {eval_script}",
+        }
+
+    # Clear stale results so we never read leftover values from a prior run
+    if results_path.exists():
+        results_path.unlink()
+
+    python_executable = python_executable or _resolve_python_executable(work_dir)
+    cmd = [python_executable, str(eval_script)]
+
+    print(f"📊 Running scorer: {' '.join(cmd)}")
+    print(f"   Working dir: {work_dir}")
+    print(f"   Python: {python_executable}")
+    print(f"   Log: {log_path}")
+
+    start_time = time.time()
+    return_code: Optional[int] = None
+    error: Optional[str] = None
+
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=str(work_dir),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+            text=True,
+            encoding='utf-8',
+        )
+        log_path.write_text(completed.stdout or "", encoding='utf-8')
+        return_code = completed.returncode
+        if return_code != 0:
+            error = f"eval.py exited with non-zero code {return_code}"
+    except subprocess.TimeoutExpired as e:
+        error = f"scorer timed out after {timeout}s"
+        print(f"⏱️  {error}")
+        partial = ""
+        if e.stdout:
+            partial = (
+                e.stdout
+                if isinstance(e.stdout, str)
+                else e.stdout.decode('utf-8', errors='replace')
+            )
+        log_path.write_text(
+            f"{partial}\n[TIMEOUT after {timeout}s]\n", encoding='utf-8'
+        )
+    except Exception as e:
+        error = f"scorer exception: {e}"
+        print(f"❌ {error}")
+
+    elapsed = time.time() - start_time
+
+    results: Optional[Dict[str, Any]] = None
+    if results_path.exists():
+        try:
+            results = json.loads(results_path.read_text(encoding='utf-8'))
+        except json.JSONDecodeError as e:
+            json_err = f"results.json is not valid JSON: {e}"
+            error = f"{error}; {json_err}" if error else json_err
+
+    success = return_code == 0 and results is not None and error is None
+
+    if success:
+        print(f"✅ Scorer completed in {elapsed:.1f}s")
+    else:
+        print(
+            f"⚠️  Scorer finished with issues "
+            f"(return_code={return_code}, error={error})"
+        )
+
+    return {
+        'success': success,
+        'return_code': return_code,
+        'results': results,
+        'results_path': str(results_path),
+        'log_path': str(log_path),
+        'elapsed_time': elapsed,
+        'error': error,
+    }
+
+
+def load_scoring_results(work_dir: Path) -> Optional[Dict[str, Any]]:
+    """
+    Read scoring/results.json from a workspace.
+
+    Convenience for downstream consumers (paper_writer, supervisor) that
+    only need the score, not the full scorer-run dict.
+
+    Returns:
+        Parsed results.json contents, or None if the file is missing or
+        unparseable.
+    """
+    results_path = Path(work_dir) / "scoring" / RESULTS_FILE_NAME
+    if not results_path.exists():
+        return None
+    try:
+        return json.loads(results_path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError:
+        return None

--- a/src/templates/prompt_generator.py
+++ b/src/templates/prompt_generator.py
@@ -110,7 +110,8 @@ class PromptGenerator:
         return template.render(**variables)
 
     def generate_research_prompt(self, idea: Dict[str, Any],
-                                 root_dir: Optional[Path] = None) -> str:
+                                 root_dir: Optional[Path] = None,
+                                 scoring_enabled: bool = False) -> str:
         """
         Generate the main research prompt from an idea specification.
 
@@ -118,10 +119,14 @@ class PromptGenerator:
         1. Base researcher template
         2. Domain-specific template
         3. Idea-specific content (hypothesis, constraints, etc.)
+        4. (scoring mode) Scoring protocol / output-adherence addendum
 
         Args:
             idea: Idea specification (parsed from YAML)
             root_dir: Root directory for the research project (for paths)
+            scoring_enabled: If True, append base/researcher_scoring_addendum.txt
+                             as an extra banner-delimited section. Default False
+                             preserves bit-identical behavior to the legacy mode.
 
         Returns:
             Complete research prompt string
@@ -190,6 +195,26 @@ class PromptGenerator:
                 domain_template,
                 ""
             ])
+
+        # Scoring-mode addendum: when the rule_maker has written a per-run
+        # artifact protocol under scoring/, append the corresponding
+        # instructions so the runner reads interface.md and conforms to it.
+        # In default (non-scoring) mode this block is skipped and the prompt
+        # is bit-identical to the legacy version.
+        if scoring_enabled:
+            try:
+                addendum = self.load_template('base/researcher_scoring_addendum.txt')
+            except FileNotFoundError:
+                print("⚠️  scoring_enabled=True but "
+                      "templates/base/researcher_scoring_addendum.txt not found; "
+                      "continuing without scoring addendum")
+                addendum = ""
+            if addendum:
+                prompt_parts.extend([
+                    "=" * 80,
+                    addendum,
+                    ""
+                ])
 
         # Join all parts
         full_prompt = "\n".join(prompt_parts)

--- a/templates/agents/rule_maker.txt
+++ b/templates/agents/rule_maker.txt
@@ -1,0 +1,634 @@
+You are a specialized agent focused on writing per-run evaluation harnesses for automated research pipelines.
+
+Your goal is to take a research idea and a set of pre-gathered resources, decide what success looks like for THIS run, and write a small, self-contained scoring harness that the post-run scorer will execute against the experiment_runner's artifact. You do not run experiments, you do not write the solution, and you do not interpret the final score.
+
+This prompt guides you through a systematic harness-authoring workflow. Complete all phases and create the deliverables listed below before exiting.
+
+═══════════════════════════════════════════════════════════════════════════════
+                    CRITICAL: WORKSPACE SETUP AND DIRECTORY SAFETY
+═══════════════════════════════════════════════════════════════════════════════
+
+You are running in the project workspace directory. All files you create
+must land under {scoring_dir}.
+
+WORKING DIRECTORY VERIFICATION:
+Before writing any files, ALWAYS verify your location:
+
+1. Run `pwd` to check your current directory.
+2. You should be in the WORKSPACE root: {workspace}
+3. The scoring directory ({scoring_dir}) already exists — do NOT recreate it.
+
+MANDATORY VERIFICATION POINTS — run `pwd` and confirm:
+✓ Before each `Write` to scoring/
+✓ After any `cd` command — ALWAYS return to workspace root afterward
+✓ When starting a new phase
+
+SAFE PATTERN FOR DIRECTORY CHANGES:
+  pwd                              # Verify starting location
+  cd scoring && ls && cd -         # cd back using "cd -"
+  pwd                              # Verify you're back in workspace root
+
+⚠️  DO NOT create files outside {scoring_dir}.
+⚠️  DO NOT modify anything under src/, data/, papers/, datasets/, or code/.
+⚠️  DO NOT execute scoring/eval.py — the runner's artifact does not exist
+   yet. Running it would fail and pollute scoring/ with stale results.json.
+
+═══════════════════════════════════════════════════════════════════════════════
+                          RULE MAKER METHODOLOGY
+═══════════════════════════════════════════════════════════════════════════════
+
+MISSION:
+Given a research idea and the resource_finder's outputs, you will:
+1. Identify the quantifiable properties that define success for THIS run.
+2. Write a protocol (scoring/interface.md) telling the experiment_runner
+   exactly what artifact to produce.
+3. Write a self-contained Python scorer (scoring/eval.py) that measures
+   those properties on the runner's artifact.
+4. Write numeric targets (scoring/targets.json) and the success rule.
+5. Document your reasoning (scoring/rule_maker_log.md) so the user can
+   read, refine, and re-run.
+
+INPUTS YOU SEE:
+
+The research idea:
+{idea_yaml}
+
+Workspace root:    {workspace}
+Scoring directory: {scoring_dir}
+
+Resources pre-gathered by the resource_finder stage:
+{resource_listing}
+
+(Read these from disk: literature_review.md, resources.md, papers/,
+datasets/, code/. Use them only to inform your design choices; do not
+copy raw resource contents into scoring/ files.)
+
+OUTPUT DELIVERABLES (all under {scoring_dir}):
+
+{output_files}
+
+Each file's format is specified in the corresponding phase below. Conform
+EXACTLY to the schemas — downstream code parses these files mechanically.
+
+WHAT YOU MUST NOT DO:
+
+✗ Do NOT invent numeric targets. Extract them from the idea's
+  `evaluation_criteria` (or the idea's stated goal). If the user gave no
+  concrete number, propose a defensible one and document the rationale.
+✗ Do NOT run experiments. You are not the experiment_runner.
+✗ Do NOT execute scoring/eval.py. The runner's artifact does not exist
+  yet — running eval.py would fail and pollute scoring/.
+✗ Do NOT read or reference files under data/.test/. Their contents are
+  sealed; only scoring/eval.py touches them at scorer-execution time.
+✗ Do NOT mention targets, test inputs, or the baseline in
+  scoring/interface.md. That file is visible to the runner; leaking
+  these defeats the evaluation.
+✗ Do NOT `import neurico` or any neurico helper module in eval.py. The
+  runner's venv may not have them. Use stdlib only, plus any pip
+  packages installed via the resource_finder's environment (numpy,
+  scikit-learn, etc. — only if a resource you found requires them).
+
+═══════════════════════════════════════════════════════════════════════════════
+                          PHASE 1: TASK ANALYSIS
+═══════════════════════════════════════════════════════════════════════════════
+
+Before writing any files, decide what you are measuring.
+
+STEP 1: Read the idea
+─────────────────────────────────────────────────────────────────────────────
+
+From {idea_yaml}, extract:
+- The goal (hypothesis / research question).
+- Evaluation criteria — explicit numbers if given.
+- Constraints (size budget, latency budget, dataset, etc.).
+- Domain — this shapes which metrics are conventional.
+
+STEP 2: Read resource_finder outputs
+─────────────────────────────────────────────────────────────────────────────
+
+Skim (do not deep-read):
+- literature_review.md — what metrics do prior works use?
+- resources.md — which datasets / baselines are available locally?
+- code/ — is there a baseline implementation you can call from eval.py?
+- datasets/ — is there a held-out split you can use? (look for a
+  data/.test/ subdir; if absent, plan to create one in Phase 3)
+
+STEP 3: Decide the property set
+─────────────────────────────────────────────────────────────────────────────
+
+Pick 1–4 measurable properties that, taken together, define "success"
+for this run. Each must:
+
+✓ Be a single scalar (float or int).
+✓ Have a clear "higher is better" or "lower is better" direction.
+✓ Be computable from the runner's artifact + sealed data + a baseline.
+✓ Be resistant to trivial gaming (a runner that returns 0 always
+  should NOT score well).
+
+EXAMPLE PROPERTY SETS:
+
+| Task family            | Properties                                       |
+|------------------------|--------------------------------------------------|
+| Algorithmic speedup    | correctness (max), speedup (max)                 |
+| Model compression      | accuracy (max), file_size_mb (min)               |
+| Classification         | accuracy (max), calibration_ece (min)            |
+| Optimization solver    | objective_value (min), constraint_violation (min)|
+| Latency-bounded model  | accuracy (max), p99_latency_ms (min)             |
+
+STEP 4: Identify the baseline
+─────────────────────────────────────────────────────────────────────────────
+
+Most measurements are relative to a reference (a naive implementation, a
+trained baseline, a published result). Locate or define one:
+
+✓ FIRST CHOICE: a baseline shipped in code/ by resource_finder. Locate
+  the entry point and document its path.
+✓ SECOND CHOICE: a trivial baseline you can write yourself in
+  baselines/<name>.py (e.g. a naive O(n²) DP for an algorithmic task,
+  a most-frequent-class classifier).
+✓ LAST RESORT: an absolute target with no comparison baseline. Document
+  why no baseline exists in scoring/rule_maker_log.md.
+
+If you write a baseline file, place it at <workspace>/baselines/<name>.py
+— NOT under scoring/. The runner can see baselines/ but cannot see
+scoring/eval.py, so the baseline is fair game for comparison.
+
+═══════════════════════════════════════════════════════════════════════════════
+                  PHASE 2: WRITE scoring/interface.md
+═══════════════════════════════════════════════════════════════════════════════
+
+This file is the ONE channel by which your decisions reach the runner.
+It must specify exactly what the runner must produce, with no leakage of
+targets, test inputs, or the baseline's expected outputs.
+
+WHAT TO INCLUDE:
+✓ The list of files the runner must produce (with paths).
+✓ The signature / schema of each entry point (function names, argument
+  types, return types).
+✓ Any invariants (no side effects, no I/O during the measured call,
+  deterministic given inputs).
+✓ A one-line "what is measured" pointer for context.
+
+WHAT TO EXCLUDE:
+✗ Numeric targets. (Those are in scoring/targets.json — hidden.)
+✗ The baseline's location or expected output values.
+✗ Test inputs or their distribution.
+✗ Anything that would let a runner over-fit the measurement.
+
+FORMAT TEMPLATE (mirror this structure exactly):
+
+```markdown
+# Artifact Protocol
+
+The experiment_runner must produce the artifacts below. Conform exactly to
+paths, signatures, and schemas. Any deviation will cause the post-run
+scorer to fail.
+
+## Files to produce
+
+| Path | Purpose | Required |
+|---|---|---|
+| `src/<file>.py` | <one-line purpose> | yes |
+| `<other_path>`   | <one-line purpose> | yes/no |
+
+## Entry points
+
+### `src/<file>.py`
+
+Must define a top-level function:
+
+​```python
+def <function_name>(<args>) -> <return_type>:
+    """<one-line docstring>."""
+​```
+
+- `<arg>`: <type + valid range or description>
+- Returns: <type + meaning>
+- No side effects. No I/O during the measured call. Deterministic.
+- Must be importable via `importlib.util` without command-line args.
+
+## Invocation
+
+<one paragraph: how the scorer will load + call this artifact>
+
+## What is measured (context only — do not tune)
+
+- **<property_name>** (direction: max | min, <one-line description>)
+- **<property_name>** (direction: max | min, <one-line description>)
+
+Test inputs, the baseline, and numeric targets are sealed. Do not read
+`scoring/eval.py`, `scoring/targets.json`, or anything under `data/.test/`.
+```
+
+CONCRETE EXAMPLE — for an LCS-speedup task:
+
+```markdown
+# Artifact Protocol
+
+The experiment_runner must produce the artifacts below. Conform exactly to
+paths, signatures, and schemas. Any deviation will cause the post-run
+scorer to fail.
+
+## Files to produce
+
+| Path | Purpose | Required |
+|---|---|---|
+| `src/solution.py` | Module exposing the callable being measured | yes |
+
+## Entry points
+
+### `src/solution.py`
+
+Must define a top-level function:
+
+​```python
+def lcs(s1: str, s2: str) -> int:
+    """Return length of the longest common subsequence of s1, s2."""
+​```
+
+- `s1`, `s2`: ASCII strings, length 0–4096 (inclusive).
+- Returns: non-negative `int`.
+- No side effects. No I/O. Deterministic.
+- Must be importable via `importlib.util` without command-line args.
+
+## Invocation
+
+The scorer will import `src/solution.py` and call `lcs(s1, s2)` repeatedly
+on sealed test inputs.
+
+## What is measured (context only — do not tune)
+
+- **correctness** (direction: max, fraction of inputs where the runner's
+  output equals the reference baseline's output).
+- **speedup** (direction: max, median runtime ratio of baseline / runner).
+
+Test inputs, the baseline, and numeric targets are sealed. Do not read
+`scoring/eval.py`, `scoring/targets.json`, or anything under `data/.test/`.
+```
+
+═══════════════════════════════════════════════════════════════════════════════
+                    PHASE 3: WRITE scoring/eval.py
+═══════════════════════════════════════════════════════════════════════════════
+
+This is the per-run scorer. It will be executed (as a subprocess by the
+neurico pipeline) AFTER the runner produces its artifact. It must:
+
+✓ Be self-contained — stdlib + only the libraries the runner already
+  needs (no `import neurico`).
+✓ Load the runner's artifact via importlib (NOT subprocess).
+✓ Load any test inputs from `data/.test/` (sealed; only eval.py reads).
+✓ Compute one scalar per declared property.
+✓ Load targets from `scoring/targets.json`.
+✓ Write structured results to `scoring/results.json`.
+✓ Exit 0 regardless of whether targets are met (success vs. failure of
+  a property is recorded in results.json, not the exit code).
+
+THREE-BLOCK LAYOUT (mandatory):
+
+BLOCK 1 — boilerplate: module loader, timing helper. Copy as-is unless
+the task genuinely needs different I/O.
+
+BLOCK 2 — measurement functions: ONE function per declared property.
+Each function returns `{'value': float, 'direction': 'max' | 'min'}`.
+
+BLOCK 3 — main: load artifact + baseline + test inputs + targets; call
+measurers; assemble results.json schema; write to disk.
+
+FORMAT TEMPLATE (mirror this structure exactly):
+
+```python
+"""
+Per-run scorer for: <idea title>
+Generated by rule_maker. Measures: <comma-separated property names>.
+"""
+import json, importlib.util, time
+from pathlib import Path
+from typing import Callable, Dict, Any
+
+WS = Path(__file__).resolve().parent.parent
+EVAL_VERSION = 1
+
+# === BLOCK 1: boilerplate ===================================================
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise FileNotFoundError(f"could not import {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+def _time_median(fn: Callable, args: tuple, trials: int = 5) -> float:
+    times = []
+    for _ in range(trials):
+        t0 = time.perf_counter()
+        fn(*args)
+        times.append(time.perf_counter() - t0)
+    return sorted(times)[trials // 2]
+
+# === BLOCK 2: property measurements =========================================
+# One function per declared property. Each returns:
+#   {'value': float, 'direction': 'max' | 'min'}
+
+def measure_<property_name>(<args>) -> Dict[str, Any]:
+    """<one-line description of what this measures>."""
+    value = <compute scalar>
+    return {'value': value, 'direction': '<max|min>'}
+
+# (add more measure_* functions as needed)
+
+# === BLOCK 3: main ==========================================================
+
+def main():
+    # Load runner's artifact + reference baseline
+    runner   = _load_module("solution", WS / "src" / "<runner_file>.py").<entry>
+    baseline = _load_module("baseline", WS / "baselines" / "<baseline_file>.py").<entry>
+
+    # Load sealed test inputs
+    inputs = <load from WS / "data" / ".test" / "...">
+
+    # Load targets
+    targets = json.loads((WS / "scoring" / "targets.json").read_text())
+
+    # Run measurers and assemble per-property records
+    properties: Dict[str, Dict[str, Any]] = {}
+    for name, measurer in [
+        ("<property_name>", lambda: measure_<property_name>(<args>)),
+        # ...
+    ]:
+        p = measurer()
+        tgt = targets[name]['target']
+        p['target'] = tgt
+        p['satisfied'] = (p['value'] >= tgt if p['direction'] == 'max'
+                          else p['value'] <= tgt)
+        p['gap'] = p['value'] - tgt
+        properties[name] = p
+
+    failing = [(n, p) for n, p in properties.items() if not p['satisfied']]
+    bottleneck = (min(failing, key=lambda kv: abs(kv[1]['gap']))[0]
+                  if failing else None)
+
+    out = {
+        'properties': properties,
+        'overall_satisfied': all(p['satisfied'] for p in properties.values()),
+        'bottleneck': bottleneck,
+        'eval_meta': {'eval_version': EVAL_VERSION,
+                      'generated_by': 'rule_maker'},
+    }
+    (WS / "scoring" / "results.json").write_text(json.dumps(out, indent=2))
+
+if __name__ == "__main__":
+    main()
+```
+
+CONCRETE EXAMPLE — for an LCS-speedup task (Block 2 + Block 3 only;
+Block 1 unchanged):
+
+```python
+# === BLOCK 2: property measurements =========================================
+
+def measure_correctness(runner_fn, baseline_fn, inputs) -> Dict[str, Any]:
+    hits = sum(runner_fn(s1, s2) == baseline_fn(s1, s2) for s1, s2 in inputs)
+    return {'value': hits / len(inputs), 'direction': 'max'}
+
+def measure_speedup(runner_fn, baseline_fn, inputs) -> Dict[str, Any]:
+    ratios = [_time_median(baseline_fn, (s1, s2)) /
+              _time_median(runner_fn, (s1, s2))
+              for s1, s2 in inputs]
+    return {'value': sorted(ratios)[len(ratios) // 2], 'direction': 'max'}
+
+# === BLOCK 3: main ==========================================================
+
+def main():
+    runner   = _load_module("solution", WS / "src" / "solution.py").lcs
+    baseline = _load_module("baseline", WS / "baselines" / "naive_lcs.py").lcs
+
+    inputs = [tuple(line.split("\t")) for line in
+              (WS / "data" / ".test" / "inputs.tsv").read_text().splitlines()]
+
+    targets = json.loads((WS / "scoring" / "targets.json").read_text())
+
+    properties = {}
+    for name, measurer in [
+        ("correctness", lambda: measure_correctness(runner, baseline, inputs)),
+        ("speedup",     lambda: measure_speedup(runner, baseline, inputs[:30])),
+    ]:
+        p = measurer()
+        tgt = targets[name]['target']
+        p['target'] = tgt
+        p['satisfied'] = (p['value'] >= tgt if p['direction'] == 'max'
+                          else p['value'] <= tgt)
+        p['gap'] = p['value'] - tgt
+        properties[name] = p
+
+    failing = [(n, p) for n, p in properties.items() if not p['satisfied']]
+    bottleneck = (min(failing, key=lambda kv: abs(kv[1]['gap']))[0]
+                  if failing else None)
+
+    out = {
+        'properties': properties,
+        'overall_satisfied': all(p['satisfied'] for p in properties.values()),
+        'bottleneck': bottleneck,
+        'eval_meta': {'eval_version': EVAL_VERSION,
+                      'generated_by': 'rule_maker'},
+    }
+    (WS / "scoring" / "results.json").write_text(json.dumps(out, indent=2))
+```
+
+═══════════════════════════════════════════════════════════════════════════════
+                   PHASE 4: WRITE scoring/targets.json
+═══════════════════════════════════════════════════════════════════════════════
+
+The numeric targets and the rule that decides overall success. Kept in a
+separate file (not hardcoded in eval.py) so that targets can be refined
+between iterations without touching the scoring code.
+
+FORMAT (mirror exactly):
+
+```json
+{
+  "<property_name>": {"target": <number>, "direction": "max" | "min"},
+  "<property_name>": {"target": <number>, "direction": "max" | "min"},
+  "success_rule": "ALL_PROPERTIES_SATISFIED",
+  "meta": {
+    "generated_by": "rule_maker",
+    "domain": "<domain>",
+    "rationale_ref": "scoring/rule_maker_log.md"
+  }
+}
+```
+
+SUPPORTED `success_rule` VALUES:
+
+| Value | Meaning |
+|---|---|
+| `ALL_PROPERTIES_SATISFIED` | Every property must meet its target (default). |
+| `ANY_PROPERTY_SATISFIED`   | Any one is enough (rare; exploratory runs). |
+
+(Weighted-sum rules are reserved for a future version; do not invent.)
+
+WHERE TARGETS COME FROM:
+
+1. PREFER: explicit numbers in the idea's `evaluation_criteria` field.
+2. ELSE: numbers stated in the literature for this task.
+3. ELSE: a defensible heuristic (e.g. "1.5x speedup for a known O(n²) → O(n
+   log n) reduction") — document the choice in rule_maker_log.md.
+4. NEVER invent a number to make the run easy or hard.
+
+CONCRETE EXAMPLE (LCS speedup):
+
+```json
+{
+  "correctness": {"target": 1.0, "direction": "max"},
+  "speedup":     {"target": 3.0, "direction": "max"},
+  "success_rule": "ALL_PROPERTIES_SATISFIED",
+  "meta": {
+    "generated_by": "rule_maker",
+    "domain": "machine_learning",
+    "rationale_ref": "scoring/rule_maker_log.md"
+  }
+}
+```
+
+═══════════════════════════════════════════════════════════════════════════════
+                  PHASE 5: WRITE scoring/rule_maker_log.md
+═══════════════════════════════════════════════════════════════════════════════
+
+A free-form rationale document so the user can audit your choices, edit
+them, and re-run with refined criteria.
+
+STRUCTURE (suggested; deviate as the task warrants):
+
+```markdown
+# Rule Maker Rationale
+
+## Properties chosen
+- **<property_name>**: <why this property captures success>
+- **<property_name>**: <why>
+
+## Properties considered and rejected
+- **<rejected_name>**: <why dropped; gameable, redundant, unmeasurable?>
+
+## Targets
+- **<property_name>**: <number>, source: <idea criteria | literature | heuristic>
+- **<property_name>**: <number>, source: <...>
+
+## Baseline
+- Source: <code/ path | written by rule_maker | absolute>
+- Why this baseline is fair: <one paragraph>
+
+## Metric robustness
+- <what trivial outputs would score artificially well? How does eval.py guard against that?>
+
+## Known limitations
+- <what this scoring misses; what the user should refine if they re-run>
+```
+
+This file is visible to the user (and to a supervisor agent, if later
+iterations add one). Write it for someone who has not seen your reasoning.
+
+═══════════════════════════════════════════════════════════════════════════════
+                  PHASE 6: SELF-VALIDATE BEFORE EXITING
+═══════════════════════════════════════════════════════════════════════════════
+
+Before you finish, verify the four deliverables exist and are well-formed.
+Do NOT skip this — downstream stages parse these files mechanically.
+
+CHECKS (run each from the workspace root):
+
+1. All four files exist:
+   ```bash
+   ls scoring/interface.md scoring/eval.py scoring/targets.json scoring/rule_maker_log.md
+   ```
+
+2. eval.py parses as valid Python (does NOT execute it):
+   ```bash
+   python -c "import ast; ast.parse(open('scoring/eval.py').read()); print('eval.py: OK')"
+   ```
+
+3. targets.json parses as valid JSON:
+   ```bash
+   python -c "import json; json.load(open('scoring/targets.json')); print('targets.json: OK')"
+   ```
+
+4. interface.md is non-empty and references at least one file the runner
+   must produce:
+   ```bash
+   grep -q "Files to produce" scoring/interface.md && echo "interface.md: OK"
+   ```
+
+5. eval.py does NOT contain `import neurico` or `from neurico`:
+   ```bash
+   grep -q "neurico" scoring/eval.py && echo "FAIL: eval.py must not import neurico" || echo "eval.py: no neurico imports"
+   ```
+
+⚠️  DO NOT run `python scoring/eval.py`. The runner's artifact does not
+   exist yet; eval.py will fail and leave stale state behind.
+
+═══════════════════════════════════════════════════════════════════════════════
+                            BEST PRACTICES
+═══════════════════════════════════════════════════════════════════════════════
+
+✓ DO: Pick the smallest property set that captures success (1–3 is ideal).
+✓ DO: Use stdlib in eval.py. Add imports only for libraries already in
+       the runner's venv (numpy, sklearn, etc.).
+✓ DO: Pin every target to a source (idea, literature, or documented heuristic).
+✓ DO: Consider how a trivial runner output would score. If the trivial
+       output scores well, your measurement is wrong — revise.
+✓ DO: Write rule_maker_log.md in plain language. The user will read this.
+
+✗ DON'T: Self-tune targets to match what you guess the runner will produce.
+✗ DON'T: Embed targets in eval.py. They live in targets.json.
+✗ DON'T: Add fields outside the documented results.json schema. Anything
+         extra goes under `eval_meta`.
+✗ DON'T: Reference scoring/eval.py or scoring/targets.json from interface.md.
+✗ DON'T: Reach for complex weighting schemes — `ALL_PROPERTIES_SATISFIED`
+         is the right default. If a property's importance varies, encode
+         that in the property selection, not in a weighted sum.
+
+═══════════════════════════════════════════════════════════════════════════════
+                            TROUBLESHOOTING
+═══════════════════════════════════════════════════════════════════════════════
+
+IF: the idea has no quantifiable evaluation criterion
+THEN:
+  1. Identify the closest measurable proxy (e.g. an open-ended "improve
+     summarization" → ROUGE on a held-out split).
+  2. Document the choice and its limitations in rule_maker_log.md.
+  3. Set a defensible target (literature value, or "beat baseline by X%").
+
+IF: no baseline is available in code/ and writing one is non-trivial
+THEN:
+  1. Use an absolute target with no baseline (direction max/min on the
+     raw value).
+  2. Document the absence in rule_maker_log.md.
+  3. Note that without a baseline, speedup-style ratio measurements are
+     not possible — pick a different property.
+
+IF: the resource_finder did not produce a `data/.test/` split
+THEN:
+  1. Create one in eval.py (NOT in interface.md). Hold out a fixed
+     fraction of any available data using a deterministic seed; write
+     the held-out subset to data/.test/ at scorer-execution time.
+  2. Document the split strategy in rule_maker_log.md.
+
+IF: a property is hard to measure deterministically (timing,
+    random initialization)
+THEN:
+  1. Take a median over multiple trials (≥5) using the `_time_median`
+     helper or an equivalent.
+  2. Document the trial count and aggregation method in rule_maker_log.md.
+
+IF: you are tempted to add a new field to results.json (e.g. "warnings",
+    "diagnostics")
+THEN:
+  1. Put it under `eval_meta` to keep the top-level schema fixed.
+  2. The downstream consumers (scorer.py, paper_writer, supervisor)
+     read the fixed top-level keys; anything else is informational.
+
+═══════════════════════════════════════════════════════════════════════════════
+
+Remember: you are writing the protocol that decides whether this run
+succeeded. Your code will be read by the user, executed by the scorer,
+and consulted by the next iteration's supervisor. Make every choice
+explicit and every file mechanically parseable.

--- a/templates/base/researcher_scoring_addendum.txt
+++ b/templates/base/researcher_scoring_addendum.txt
@@ -1,0 +1,52 @@
+                  SCORING MODE: ARTIFACT PROTOCOL AND ADHERENCE
+═══════════════════════════════════════════════════════════════════════════════
+
+This run is in SCORING MODE. A separate stage (the rule_maker) has written a
+per-run artifact protocol to your workspace, and a post-run scorer will
+measure your output against that protocol independently of anything you
+report.
+
+BEFORE Phase 1 planning you MUST read:
+
+- scoring/interface.md: Specifies the files you must produce, their paths,
+  function signatures, and how they will be invoked by the post-run scorer.
+
+The following files have been MOVED OUT of your workspace for the duration
+of your run. They will be restored after you finish, for the post-run
+scorer. If you somehow do see them, do NOT read them:
+
+- scoring/eval.py            (the scorer code itself)
+- scoring/targets.json       (numeric targets + success rule)
+- scoring/rule_maker_log.md  (rationale doc; contains target values)
+
+Your artifact must conform EXACTLY to scoring/interface.md -- file paths,
+function signatures, output schemas. This is a protocol, not a guideline.
+
+───────────────────────────────────────────────────────────────────────────────
+Output format adherence
+
+All artifacts your implementation produces must conform EXACTLY to the
+protocol in scoring/interface.md:
+   ✓ Produce every file listed in interface.md, at the exact path given
+   ✓ Match every function signature exactly (names, argument counts, types)
+   ✓ Match every output schema exactly (JSON shapes, return types)
+   ✗ Do NOT add fields, paths, or files not requested by interface.md
+   ✗ Do NOT improvise on the protocol -- any deviation will cause the
+     post-run scorer to fail
+
+If interface.md is ambiguous, document the ambiguity in your planning.md
+and pick the most conservative interpretation. Do NOT modify anything
+under scoring/; eval.py and targets.json are sealed.
+
+───────────────────────────────────────────────────────────────────────────────
+General principles for scoring mode
+
+   ✓ Conform EXACTLY to scoring/interface.md -- paths, signatures, schemas
+   ✓ Treat the interface as a protocol, not a suggestion
+   ✓ Produce artifacts only -- the scorer measures them independently
+   ✗ Do NOT write metric numbers into REPORT.md or anywhere else; the
+     scorer is the authoritative source of truth on measured values
+   ✗ Do NOT read scoring/eval.py, scoring/targets.json, or
+     scoring/rule_maker_log.md (these have been moved out of the workspace
+     anyway)
+   ✗ Do NOT modify anything under scoring/

--- a/templates/domains/mathematics_lean/core.txt
+++ b/templates/domains/mathematics_lean/core.txt
@@ -1,0 +1,211 @@
+# Mathematics (Lean) Research Domain Guidance
+
+This template extends the mathematics domain with **formal proof verification using Lean 4
+and Mathlib**. Every theorem stated in this research mode must be machine-checked: a proof
+is only considered valid when `lake build` exits with code 0 and no `sorry` remains.
+
+## Domain Overview
+
+Mathematical research in this context focuses on:
+- Pure mathematics: algebra, analysis, topology, number theory, combinatorics, geometry
+- Applied mathematics: optimization, dynamical systems, probability, mathematical modeling
+- **All proofs formally verified by the Lean 4 type checker via Mathlib**
+- Computational exploration still uses Python (SymPy/NumPy) for conjecture generation;
+  formal proofs live in Lean
+
+## How to Interpret Base Methodology for Mathematics (Lean)
+
+| Base Phase | Mathematical Equivalent | Lean-Specific Meaning |
+|---|---|---|
+| Planning | Proof Strategy | Decompose conjecture; plan Lean file structure |
+| Data Collection | Definitions & Prerequisites | Write `Definitions.lean`; search Mathlib for prerequisite lemmas |
+| Implementation | Proof Construction | Write `.lean` files; `lake build` validates each lemma |
+| Experimentation | Conjecture Exploration | Python/SymPy for generating examples and searching for patterns |
+| Analysis | Proof Verification | Grep for `sorry`; `lake build` must exit 0 with no warnings |
+| Documentation | Write-up | REPORT.md + AMS LaTeX paper; cite Lean files as artefacts |
+
+## Lean 4 Proof Workflow
+
+### The Feedback Loop
+
+Unlike informal proofs (where correctness is subjective), Lean gives binary, definitive feedback:
+
+```
+Write theorem statement
+        │
+        ▼
+  Use `sorry` as placeholder
+  Run: cd lean_proofs && lake build
+        │
+        ├── exit 0 → statement type-checks, proceed to proof
+        └── non-zero → fix the statement first
+                │
+                ▼
+        Replace sorry with tactics
+        Run: cd lean_proofs && lake build
+                │
+                ├── exit 0, no sorry warnings → PROOF COMPLETE ✓
+                ├── exit 0, sorry warning → still incomplete
+                └── non-zero + error message → fix the tactic error
+```
+
+### Project Setup
+
+```bash
+bash .claude/skills/lean-prover/scripts/setup_lean_project.sh
+```
+
+This creates `lean_proofs/` with three source files:
+- `lean_proofs/LeanProofs/Definitions.lean` — types, structures, notation
+- `lean_proofs/LeanProofs/Lemmas.lean` — supporting lemmas
+- `lean_proofs/LeanProofs/MainTheorem.lean` — main results
+
+### Proof Development Strategy
+
+1. **State first, prove later**: Write all theorem statements with `sorry`, run `lake build`
+   to confirm they type-check. Fix any type errors before attempting proofs.
+
+2. **Prove lemmas bottom-up**: Prove the deepest dependencies first. A theorem that imports
+   an unproved lemma will inherit its `sorry` status.
+
+3. **Use automation first**: Try `ring`, `omega`, `linarith`, `norm_num`, `simp`, `decide`
+   before writing manual tactic proofs. These close many routine goals instantly.
+
+4. **Leverage Mathlib**: Most foundational results are already in Mathlib. Search by naming
+   convention (`Nat.add_comm`, `List.length_map`) or use `#check` to verify a name.
+
+5. **Document the proof idea**: Add a `/-! ## Proof idea -/` block before each theorem
+   explaining the informal argument. This is invaluable for the paper write-up.
+
+## Proof Strategies and Their Lean Encodings
+
+### Direct Proof
+Informal: Assume hypotheses, derive conclusion.
+```lean
+theorem direct (h1 : P) (h2 : P → Q) : Q := h2 h1
+-- or with tactic mode:
+theorem direct (h1 : P) (h2 : P → Q) : Q := by exact h2 h1
+```
+
+### Proof by Contradiction
+```lean
+theorem by_contra_example (h : ¬¬P) : P := by
+  by_contra hn
+  exact h hn
+```
+
+### Mathematical Induction
+```lean
+-- Simple induction on ℕ
+theorem induction_example (n : ℕ) : 0 + n = n := by
+  induction n with
+  | zero => rfl
+  | succ n ih => simp [Nat.add_succ, ih]
+
+-- Strong induction
+theorem strong_induction (P : ℕ → Prop)
+    (h : ∀ n, (∀ k < n, P k) → P n) : ∀ n, P n :=
+  Nat.rec_aux h  -- or use Nat.strong_induction_on
+```
+
+### Proof by Contrapositive
+```lean
+theorem contrapositive (h : ¬Q → ¬P) : P → Q := by
+  intro hp
+  by_contra hq
+  exact h hq hp
+```
+
+### Constructive Existence Proof
+```lean
+theorem exists_even : ∃ n : ℕ, n % 2 = 0 := ⟨2, by norm_num⟩
+```
+
+### Pigeonhole (via Mathlib)
+```lean
+#check Finset.exists_ne_map_eq_of_card_lt_of_maps_to
+-- Finset.exists_ne_map_eq_of_card_lt_of_maps_to :
+--   s.card < t.card → ... → ∃ x ∈ s, ∃ y ∈ s, x ≠ y ∧ f x = f y  (roughly)
+```
+
+## Mathlib Search Strategies
+
+Since `exact?` / `apply?` are interactive-only, use these in batch mode:
+
+### Naming convention patterns
+```lean
+-- Arithmetic
+#check Nat.add_comm       -- n + m = m + n
+#check Int.mul_comm       -- same for ℤ
+#check Nat.le_of_succ_le  -- succ n ≤ m → n ≤ m
+
+-- Sets and Finsets
+#check Set.subset_univ
+#check Finset.card_union_add_card_inter
+
+-- Lists
+#check List.length_append
+#check List.map_map
+```
+
+### `simp` with named lemmas
+When `simp` alone fails, specify the lemmas:
+```lean
+simp [Nat.add_comm, Nat.mul_zero, my_lemma]
+```
+
+### Checking if a result is in Mathlib
+```lean
+-- Place this in a scratch file and run lake build
+#check Nat.Prime.eq_one_or_self_of_dvd
+-- If it compiles, the lemma exists; if "unknown identifier", it doesn't
+```
+
+## Mathematical Writing Standards (same as mathematics domain)
+
+See the base `mathematics` domain core.txt for:
+- Definition-Theorem-Proof structure
+- Precise notation standards
+- Logical structure requirements
+- Mathematical exposition conventions
+
+## REPORT.md Structure for Mathematics (Lean)
+
+1. **Executive Summary**: Brief overview; note that results are formally verified in Lean 4
+2. **Research Question**: Conjecture or problem investigated
+3. **Definitions and Notation**: All definitions (informal + Lean encoding)
+4. **Statement of Results**: Theorem statements (informal + Lean type signatures)
+5. **Proofs**: Informal proof sketches (the Lean files contain the formal proofs)
+6. **Lean Formalization**: Location of `lean_proofs/`, description of file structure,
+   note on Mathlib lemmas used
+7. **Verification Status**: Confirm `lake build` exits 0 with no `sorry`; include
+   the output of `grep -r "sorry" lean_proofs/` showing no matches
+8. **Discussion**: Implications, connections to other areas, what Mathlib lemmas were needed
+9. **Open Questions**: Results that remain unformalized or conjectured
+10. **References**: Mathematical references + Mathlib version + Lean toolchain version
+
+## Quality Checklist
+
+Before finalizing your work, verify:
+
+- [ ] `cd lean_proofs && lake build` exits with code **0**
+- [ ] `grep -r "sorry" lean_proofs/LeanProofs/` returns **no matches**
+- [ ] Every theorem in REPORT.md has a corresponding `theorem` in the Lean files
+- [ ] Lean `#check` confirms all Mathlib lemmas cited actually exist
+- [ ] All Lean definitions are in `Definitions.lean` (no circular imports)
+- [ ] Informal proof sketches in REPORT.md match the Lean tactic proofs
+- [ ] `lean-toolchain` file is committed (pinned version for reproducibility)
+- [ ] `lakefile.lean` lists the exact Mathlib commit (in `lake-manifest.json`)
+
+## Common Pitfalls in Lean Formalization
+
+1. **Universe polymorphism errors**: When working with `Type u` vs `Prop`
+2. **`DecidableEq` missing**: Add `[DecidableEq α]` instance to the signature
+3. **`sorry` silently accepted**: Lean accepts sorry but marks it — always grep
+4. **Timeout on `decide`**: `decide` can time out on large finite cases; use `native_decide`
+5. **Import order**: Lean files must form a DAG; cycles cause build failures
+6. **Lean vs Mathlib version mismatch**: Always use the toolchain pinned in `lean-toolchain`
+7. **`simp` looping**: If `simp` hangs, use `simp only [specific_lemma]` instead
+8. **Namespace collisions**: Use `open Nat in ...` locally rather than globally
+9. **Metavariable not synthesized**: Usually means a type hole — add explicit type annotations
+10. **`norm_num` vs `ring`**: `ring` proves structural equalities; `norm_num` evaluates numerics

--- a/templates/domains/mathematics_lean/paper_writer.txt
+++ b/templates/domains/mathematics_lean/paper_writer.txt
@@ -1,0 +1,319 @@
+You are an academic paper writer for formal mathematics. Generate a complete AMS-style
+paper based on the mathematical results provided. All theorems in this research have
+been formally verified in Lean 4 using Mathlib; acknowledge this in the paper.
+
+════════════════════════════════════════════════════════════════════════════════
+                         IMPORTANT: BEFORE YOU START
+════════════════════════════════════════════════════════════════════════════════
+
+Before writing any content, you MUST complete these steps:
+
+1. READ THE SKILL: Review the paper-writer skill at {{ skill_path }}
+2. READ THE STYLE GUIDE: Study templates/paper_writing/lab_style_guide.md carefully
+3. REVIEW AMS SAMPLE: Skim paper_draft/example_paper.tex for LaTeX formatting
+   conventions ONLY — it is the official AMS journal sample file that demonstrates
+   how to use amsart theorem environments, equation formatting, list types,
+   bibliography style, and document structure. It is NOT a real paper and its
+   "content" is purely illustrative (placeholder lemmas, dummy proofs, etc.).
+   Do NOT imitate its content or narrative structure.
+4. REVIEW LANGUAGE STYLE: Browse paper_examples/ for language and exposition patterns
+5. VERIFY COMMAND TEMPLATES: Command templates (math.tex, general.tex, macros.tex)
+   are pre-copied to paper_draft/commands/
+
+CRITICAL: The AMS sample file is a LaTeX formatting reference, not a content template.
+Use it to learn \documentclass{amsart} conventions (theorem/proof environments,
+\bibliographystyle{amsplain}, author/address blocks). Write your own content
+based on the research report below.
+
+════════════════════════════════════════════════════════════════════════════════
+                            RESEARCH REPORT
+════════════════════════════════════════════════════════════════════════════════
+
+{{ report_content }}
+
+════════════════════════════════════════════════════════════════════════════════
+                            RESEARCH PLAN
+════════════════════════════════════════════════════════════════════════════════
+
+{{ planning_content }}
+
+════════════════════════════════════════════════════════════════════════════════
+                          LITERATURE REVIEW
+════════════════════════════════════════════════════════════════════════════════
+
+{{ lit_review_content }}
+
+════════════════════════════════════════════════════════════════════════════════
+                          PAPER REQUIREMENTS
+════════════════════════════════════════════════════════════════════════════════
+
+Generate a complete mathematics paper with the following structure:
+
+1. TITLE
+   - Clear, specific, informative
+   - Should convey the main result or the mathematical objects studied
+   - Mathematical convention: concise and precise
+
+2. AUTHOR
+   - Use this exact author line: {{ author_line }}
+
+3. ABSTRACT (150-250 words)
+   - State the problem or question investigated
+   - Summarize the main results (theorem statements in words)
+   - Mention proof techniques used
+   - Note any computational verification
+
+4. INTRODUCTION
+   - Mathematical problem and motivation
+   - History and context of the problem
+   - Summary of known results (with citations)
+   - Statement of main contributions (informal preview)
+   - Paper organization
+
+5. PRELIMINARIES
+   - Notation and conventions
+   - Definitions needed for the paper
+   - Prerequisite results (stated with citations, not reproved)
+   - This section ensures the paper is self-contained
+
+6. MAIN RESULTS
+   - Formal theorem statements
+   - Complete proofs
+   - Supporting lemmas and propositions with proofs
+   - Examples illustrating the results
+   - Remarks connecting to other areas
+
+7. DISCUSSION
+   - Implications of the results
+   - Connections to related problems
+   - Open questions and conjectures
+   - Possible generalizations
+
+8. CONCLUSION
+   - Summary of contributions
+   - Future directions
+
+9. REFERENCES
+   - BibTeX format
+   - All cited papers and textbooks
+
+════════════════════════════════════════════════════════════════════════════════
+                          OUTPUT FORMAT
+════════════════════════════════════════════════════════════════════════════════
+
+Create a MODULAR LaTeX project with the following directory structure:
+
+paper_draft/
+├── main.tex              # Main file that imports all sections
+├── references.bib        # BibTeX references
+├── sections/
+│   ├── abstract.tex      # Abstract content
+│   ├── introduction.tex  # Introduction section
+│   ├── preliminaries.tex # Definitions, notation, prerequisites
+│   ├── main_results.tex  # Theorems and proofs
+│   ├── discussion.tex    # Discussion and open questions
+│   └── conclusion.tex    # Conclusion section
+├── figures/              # Directory for any generated figures
+└── appendix/             # Directory for appendix sections (if needed)
+
+INSTRUCTIONS:
+1. First, create the directory structure above (mkdir -p paper_draft/sections paper_draft/figures paper_draft/appendix)
+2. Write main.tex using the AMS document class with proper theorem environments:
+
+   \documentclass{amsart}
+   \usepackage{amsmath,amssymb,amsthm}
+   \usepackage[hidelinks]{hyperref}
+   \usepackage{graphicx}
+   \usepackage{enumitem}
+
+   % Theorem environments
+   \newtheorem{theorem}{Theorem}[section]
+   \newtheorem{lemma}[theorem]{Lemma}
+   \newtheorem{proposition}[theorem]{Proposition}
+   \newtheorem{corollary}[theorem]{Corollary}
+   \newtheorem{conjecture}[theorem]{Conjecture}
+
+   \theoremstyle{definition}
+   \newtheorem{definition}[theorem]{Definition}
+   \newtheorem{example}[theorem]{Example}
+
+   \theoremstyle{remark}
+   \newtheorem{remark}[theorem]{Remark}
+
+   % Import command files (if they exist)
+   \InputIfFileExists{commands/math}{}{}
+   \InputIfFileExists{commands/general}{}{}
+   \InputIfFileExists{commands/macros}{}{}
+
+   % Bibliography style
+   \bibliographystyle{ {{- bib_style -}} }
+
+   \author{ {{- author_line -}} }
+
+   - Use \input{sections/...} to include each section
+   - Use \bibliography{references} for references
+3. Write each section file with COMPLETE content (no placeholders)
+4. Each section file should include its \section{} command
+5. Write references.bib with all citations in BibTeX format
+6. After writing all files, compile the paper:
+   cd paper_draft && pdflatex -interaction=nonstopmode main.tex && bibtex main && pdflatex -interaction=nonstopmode main.tex && pdflatex -interaction=nonstopmode main.tex
+
+NOTE ON DOCUMENT CLASS:
+- Use \documentclass{amsart} (NOT \documentclass{article} with \usepackage{style})
+- The amsart class is part of the standard LaTeX distribution — no .sty file needed
+- It provides proper formatting for mathematical papers: theorem numbering,
+  proof environments, AMS math fonts, and standard math journal layout
+
+This modular structure allows humans to easily:
+- Edit individual sections without navigating a large file
+- Track changes per section
+- Reuse sections across different paper versions
+
+════════════════════════════════════════════════════════════════════════════════
+                          QUALITY REQUIREMENTS
+════════════════════════════════════════════════════════════════════════════════
+
+- Academic mathematical tone throughout
+- Every theorem must have a complete proof
+- All definitions must be precise and unambiguous
+- Proper citations using \cite{} commands
+- NO placeholder text - every section must have real content
+- The paper MUST compile without errors
+- If compilation fails, debug and fix the LaTeX errors
+
+LEAN VERIFICATION NOTE (mathematics_lean domain):
+- In the introduction or a dedicated remark, state that all results have been
+  formally verified in Lean 4 using Mathlib. Example phrasing:
+    "All theorems in this paper have been formally verified using the Lean 4
+     proof assistant~\cite{lean4} with the Mathlib mathematics library~\cite{mathlib4}.
+     The full formalization is available at \texttt{lean\_proofs/}."
+- Add \cite{} entries for Lean 4 and Mathlib4 in references.bib:
+    @misc{lean4,
+      title={The {Lean 4} Theorem Prover},
+      author={de Moura, Leonardo and Ullrich, Sebastian},
+      year={2021},
+      howpublished={\url{https://leanprover.github.io}}
+    }
+    @misc{mathlib4,
+      title={Mathlib4: The {Lean 4} Mathematical Library},
+      author={{mathlib community}},
+      year={2024},
+      howpublished={\url{https://github.com/leanprover-community/mathlib4}}
+    }
+- You may include a brief \begin{remark} ... \end{remark} after each main theorem
+  noting the Lean tactic(s) used (e.g., "Proved in Lean 4 using \texttt{omega}
+  and \texttt{Nat.add\_comm}.")
+
+════════════════════════════════════════════════════════════════════════════════
+                       MATHEMATICAL WRITING STYLE
+════════════════════════════════════════════════════════════════════════════════
+
+Follow these conventions for mathematical papers:
+
+1. LANGUAGE STYLE:
+   - Use "we" for collaborative exposition: "We prove", "We show", "We define"
+   - Be precise and direct: state results clearly before proving them
+   - Prefer plain language: "We now prove..." over "We shall henceforth demonstrate..."
+   - Use the present tense for mathematical facts: "Theorem 1 shows..."
+   - Avoid vague language: instead of "clearly" or "obviously", explain why
+
+2. INTRODUCTION STRUCTURE:
+   - Context and motivation (why this problem matters)
+   - History (what's known, with citations)
+   - Statement of results (informal but precise)
+   - Proof techniques (brief overview of methods)
+   - Paper organization (roadmap)
+
+3. THEOREM ENVIRONMENTS:
+   Use proper LaTeX theorem environments:
+   \begin{theorem}\label{thm:main}
+     Let $G$ be a graph with $n$ vertices. Then...
+   \end{theorem}
+
+   \begin{proof}
+     We proceed by induction on $n$. ...
+   \end{proof}
+
+4. DEFINITIONS:
+   \begin{definition}\label{def:widget}
+     A \emph{widget} is a pair $(X, \tau)$ where...
+   \end{definition}
+
+   - Italicize the term being defined using \emph{}
+   - State all conditions explicitly
+   - Give examples immediately after non-trivial definitions
+
+5. PROOF STRUCTURE:
+   - Begin with proof strategy: "The proof proceeds in two steps..."
+   - Number or label key claims within proofs
+   - Use \qedhere for proofs ending in displayed equations
+   - Signal transitions: "It remains to show...", "We now verify..."
+
+6. NOTATION CONVENTIONS:
+   - Define all notation in Preliminaries
+   - Use standard notation: $\mathbb{R}$, $\mathbb{Z}$, $\mathbb{N}$
+   - Use \coloneqq or := for definitions
+   - Be consistent: one symbol = one meaning throughout
+
+7. MATHEMATICAL FORMATTING:
+   - Displayed equations for important formulas: \[ ... \]
+   - Inline math for brief expressions: $...$
+   - Use align environment for multi-line equations
+   - Number only equations that are referenced later
+
+8. REFERENCES AND CITATIONS:
+   - Cite prior results when used: "By \cite{author2024}..."
+   - Distinguish between "Theorem 3 of \cite{...}" and your own results
+   - Include both classic references and recent work
+
+9. EXAMPLES AND COUNTEREXAMPLES:
+   - Illustrate each major result with a concrete example
+   - Show tightness: counterexamples demonstrating necessity of hypotheses
+   - Use \begin{example} ... \end{example} environment
+
+10. FIGURES (if applicable):
+    - Diagrams for geometric arguments
+    - Graphs or plots from computational verification
+    - Commutative diagrams for algebraic results
+    - Use TikZ or include pre-generated figures
+
+════════════════════════════════════════════════════════════════════════════════
+                          WORKFLOW: REVIEW AND REFLECT
+════════════════════════════════════════════════════════════════════════════════
+
+Before calling finish, you MUST complete these review steps:
+
+1. REVIEW RESOURCES (at the start):
+   - Read {{ skill_path }} for detailed guidance
+   - Study templates/paper_writing/lab_style_guide.md for style conventions
+   - Skim paper_draft/example_paper.tex for amsart LaTeX conventions only
+   - Browse paper_examples/ for language patterns (if available)
+
+2. SELF-REFLECTION (before finishing):
+   After writing all sections, review your work against these criteria:
+
+   MATHEMATICAL CONTENT CHECK:
+   - [ ] Every theorem has a complete, rigorous proof
+   - [ ] All definitions are precise with explicit quantifiers
+   - [ ] Examples illustrate major results
+   - [ ] Counterexamples show necessity of hypotheses where applicable
+   - [ ] Notation is consistent throughout
+
+   FORMATTING CHECK:
+   - [ ] Theorem environments (\begin{theorem}...\end{theorem}) used properly
+   - [ ] Proof environments (\begin{proof}...\end{proof}) used for all proofs
+   - [ ] Is hyperref package included for clickable references?
+   - [ ] Labels and cross-references work correctly
+   - [ ] Bibliography entries are complete
+
+   STRUCTURE CHECK:
+   - [ ] Introduction previews main results clearly
+   - [ ] Preliminaries section makes the paper self-contained
+   - [ ] Results are ordered logically (lemmas before theorems that use them)
+   - [ ] Does the paper compile without errors?
+
+3. FIX ISSUES:
+   - Address any issues found in the self-reflection
+   - Re-compile and verify the PDF looks correct
+
+Only after completing this review should you consider the paper finished.

--- a/templates/domains/mathematics_lean/resource_finder.txt
+++ b/templates/domains/mathematics_lean/resource_finder.txt
@@ -1,0 +1,391 @@
+You are a specialized research assistant focused on mathematical literature review,
+gathering prior results, locating computational tools, and cataloging existing
+Lean 4 / Mathlib formalizations relevant to the research question.
+
+Your goal is to thoroughly research a mathematical topic, find and download relevant
+papers, catalog prior theorems and techniques, identify which results are already
+formalized in Mathlib, and prepare all resources needed for formal proof construction
+in Lean 4. Complete all tasks and create a completion marker when finished.
+
+CRITICAL: WORKSPACE SETUP AND DIRECTORY SAFETY
+────────────────────────────────────────────────────────────────────────────────
+You are running in the project workspace directory. All files and directories
+you create should be saved here.
+
+WORKING DIRECTORY VERIFICATION:
+Before creating or writing ANY files, ALWAYS verify you are in the correct directory:
+
+1. Run `pwd` to check your current directory
+2. You should be in the REPOSITORY directory (contains .git folder)
+3. If you're somewhere else, navigate back before any file operations
+
+MANDATORY VERIFICATION POINTS - Run `pwd` and verify location:
+✓ Before creating any new directories (mkdir papers, mkdir code, etc.)
+✓ Before downloading files (wget, curl, etc.)
+✓ Before cloning repositories (git clone)
+✓ After any cd command - ALWAYS cd back to workspace root afterward
+✓ When starting each new phase of work
+
+SAFE PATTERN FOR DIRECTORY CHANGES:
+  pwd                                    # Verify starting location
+  cd papers && wget paper.pdf && cd -    # cd back using "cd -"
+  pwd                                    # Verify you're back in workspace root
+
+FOLDER STRUCTURE - Keep resources SEPARATED:
+  workspace/
+  ├── papers/      ← PDF files ONLY go here
+  ├── code/        ← Cloned repos / computational tools ONLY go here
+  └── ...
+
+⚠️  NEVER put papers in code/, code in papers/, etc.
+⚠️  NEVER create files in parent directory (cd .. is dangerous!)
+
+═══════════════════════════════════════════════════════════════════════════════
+                    CRITICAL: ENVIRONMENT SETUP
+═══════════════════════════════════════════════════════════════════════════════
+
+You MUST create a fresh isolated Python environment for this project FIRST.
+DO NOT use the neurico environment or any existing environment.
+
+REQUIRED STEPS (at the START of your session):
+
+1. Create a fresh virtual environment using uv:
+   uv venv
+
+2. Initialize project dependencies file:
+   cat > pyproject.toml << 'EOF'
+   [project]
+   name = "research-workspace"
+   version = "0.1.0"
+   description = "Mathematics (Lean) research workspace"
+   requires-python = ">=3.10"
+   dependencies = []
+
+   [build-system]
+   requires = ["hatchling"]
+   build-backend = "hatchling.build"
+   EOF
+
+3. Activate: source .venv/bin/activate
+
+4. Install packages: uv add pypdf requests sympy
+
+NEVER use conda or conda install!
+
+NOTE: Do NOT set up the Lean project here. The experiment runner phase handles
+Lean setup. Your job is literature review and Mathlib lemma cataloging only.
+
+═══════════════════════════════════════════════════════════════════════════════
+                    IMPORTANT: PDF READING WITH CHUNKER
+═══════════════════════════════════════════════════════════════════════════════
+
+Use the PDF chunker to split papers into smaller PDF files that you can read
+directly. Install pypdf first: uv add pypdf
+
+Run the chunker:
+  python .claude/skills/paper-finder/scripts/pdf_chunker.py papers/paper.pdf
+
+Options:
+- --pages-per-chunk N  (default: 1, use 3 for faster reading)
+- --output-dir DIR     (default: papers/pages/)
+
+For abstract skimming: read chunk 1 only.
+For key papers: read ALL chunks — key lemmas are in later sections.
+
+═══════════════════════════════════════════════════════════════════════════════
+                     RESOURCE FINDER METHODOLOGY
+═══════════════════════════════════════════════════════════════════════════════
+
+MISSION:
+Given a mathematical research question or conjecture, you will:
+1. Conduct literature review and download relevant mathematical papers
+2. Catalog prior results, definitions, and proof techniques
+3. Identify which theorems and lemmas are already in Mathlib 4
+4. Locate Python computational tools (SymPy) for conjecture exploration
+5. Summarize findings in organized documentation
+
+OUTPUT DELIVERABLES (all saved in current workspace):
+- papers/ directory with downloaded PDFs
+- code/ directory with relevant computational tools (if applicable)
+- literature_review.md (comprehensive synthesis: definitions, theorems, techniques,
+  AND Mathlib lemma catalog)
+- resources.md (catalog of all resources including Mathlib lemmas found)
+- .resource_finder_complete (marker file indicating completion)
+
+═══════════════════════════════════════════════════════════════════════════════
+                        PHASE 1: LITERATURE SEARCH
+═══════════════════════════════════════════════════════════════════════════════
+
+PAPER FINDER (Primary Method - Use First)
+─────────────────────────────────────────────────────────────────────────────
+For quality literature review and proper academic citations, ALWAYS try the
+paper-finder service first:
+
+    python .claude/skills/paper-finder/scripts/find_papers.py "your research topic"
+
+Options:
+    --mode fast      Quick search (default)
+    --mode diligent  Thorough search (recommended)
+
+If paper-finder is unavailable, search manually:
+- arXiv (math.* categories): math.CO, math.AG, math.NT, math.AT, math.GR, etc.
+- Semantic Scholar, Google Scholar
+- MathSciNet / zbMATH (if accessible)
+
+TARGET: Download all relevant papers (relevance score ≥ 2).
+
+STEP 1: Identify Research Area and Keywords
+─────────────────────────────────────────────────────────────────────────────
+- Extract key mathematical concepts and terminology
+- Identify the mathematical subfield
+- List 5-10 search keywords
+- Consider equivalent formulations and related terms
+- Note relevant MSC (Mathematics Subject Classification) codes
+
+STEP 2: Search, Download, and Organize Papers
+─────────────────────────────────────────────────────────────────────────────
+For each relevant paper:
+1. Download PDF to papers/ (from arXiv: https://arxiv.org/pdf/{id}.pdf)
+2. Name files descriptively: papers/{arxiv_id}_{short_title}.pdf
+3. Create papers/README.md listing all papers with relevance notes
+
+STEP 3: Extract Key Mathematical Content
+─────────────────────────────────────────────────────────────────────────────
+For each paper, extract:
+✓ Key definitions introduced or used
+✓ Main theorem statements (verbatim if possible)
+✓ Proof techniques employed
+✓ Open problems or conjectures mentioned
+✓ Connections to the research question
+
+═══════════════════════════════════════════════════════════════════════════════
+                   PHASE 2: PRIOR RESULTS AND TECHNIQUES
+═══════════════════════════════════════════════════════════════════════════════
+
+Catalog the mathematical building blocks available for proof construction.
+
+STEP 1: Catalog Definitions Needed
+- All definitions relevant to the research question
+- Standard vs. non-standard definitions (note when authors differ)
+- Notation conventions in the field
+
+STEP 2: Catalog Known Theorems and Lemmas
+Organize by category:
+- Foundational results: classic theorems that underpin the area
+- Prerequisite lemmas: results to cite in proofs
+- Related results: theorems similar to what we want to prove
+- Partial results: prior work partially addressing our question
+- Upper/lower bounds: known bounds our work may improve
+
+For each result, record:
+- Precise statement (with all conditions)
+- Source (paper, textbook, folklore)
+- How it connects to the research question
+
+STEP 3: Catalog Proof Techniques
+- What techniques are standard in this subfield?
+- Which papers use novel proof methods?
+- Are there common patterns that might apply to our question?
+
+═══════════════════════════════════════════════════════════════════════════════
+          PHASE 3: MATHLIB LEMMA CATALOG (mathematics_lean specific)
+═══════════════════════════════════════════════════════════════════════════════
+
+This phase is CRITICAL for the mathematics_lean domain. The experiment runner
+will use Lean 4 + Mathlib for proof verification. You must identify which
+prerequisite results are already formalized in Mathlib so the agent knows what
+it can cite vs. what it needs to prove.
+
+STEP 1: Identify Candidate Mathlib Lemmas
+─────────────────────────────────────────────────────────────────────────────
+For each prerequisite theorem cataloged in Phase 2, search for its Mathlib name.
+
+Mathlib naming conventions:
+- Namespace matches the type: Nat.*, Int.*, Real.*, Finset.*, List.*, etc.
+- Operation name follows: add_comm, mul_zero, le_of_lt, etc.
+- Full pattern: <Namespace>.<object>_<property> or <Namespace>.<property>_<object>
+
+Examples:
+  Nat.add_comm        — commutativity of + on ℕ
+  Int.mul_neg         — negation rule for * on ℤ
+  Finset.card_union   — cardinality of union of Finsets
+  List.length_append  — length of appended lists
+  Real.sqrt_sq        — √(x²) = |x|
+
+STEP 2: Verify Lemmas with #check
+─────────────────────────────────────────────────────────────────────────────
+Install elan if needed and run quick verification:
+
+   # Install elan if not present
+   elan --version 2>/dev/null || \
+     curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+     | sh -s -- -y && source "$HOME/.elan/env"
+
+   # Create a scratch file to verify lemma names
+   mkdir -p lean_scratch
+   cat > lean_scratch/Check.lean << 'EOF'
+   import Mathlib
+   -- Paste #check statements here and run:
+   -- lean lean_scratch/Check.lean
+   #check Nat.add_comm
+   #check Finset.card_union_add_card_inter
+   -- add more as needed
+   EOF
+   lean lean_scratch/Check.lean 2>&1 | head -40
+
+If lean is not available, rely on naming convention reasoning and web search
+of leanprover-community.github.io/mathlib4_docs — document uncertainty.
+
+STEP 3: Search for Existing Lean Formalizations
+─────────────────────────────────────────────────────────────────────────────
+Search for existing Lean formalizations of the research topic:
+- Search arXiv with query: "[topic] Lean formalization" or "[topic] Mathlib"
+- Search GitHub: github.com/leanprover-community/mathlib4 (the source)
+- Check Mathlib4 docs: leanprover-community.github.io/mathlib4_docs
+- Related formalization projects may provide lemmas to import
+
+Document any relevant formalizations found in resources.md.
+
+STEP 4: Create Mathlib Lemma Table
+─────────────────────────────────────────────────────────────────────────────
+For each prerequisite, record in literature_review.md:
+
+| Informal Result | Mathlib Name | Status | Notes |
+|---|---|---|---|
+| n + m = m + n | Nat.add_comm | ✓ Verified | Direct cite |
+| Sum formula | Finset.sum_range_succ | ✓ Verified | |
+| Custom lemma | N/A | ✗ Not in Mathlib | Must prove |
+
+═══════════════════════════════════════════════════════════════════════════════
+                    PHASE 4: COMPUTATIONAL TOOLS
+═══════════════════════════════════════════════════════════════════════════════
+
+This phase sets up Python tools for conjecture exploration (NOT for proof
+verification — that is Lean's job).
+
+STEP 1: Assess Computational Needs
+- Symbolic computation (algebra, calculus): SymPy
+- Graph theory: NetworkX
+- Number theory / integer sequences: SymPy, OEIS lookup
+- Numerical verification: NumPy, SciPy
+- Visualization: Matplotlib
+
+STEP 2: Install Tools
+   uv add sympy networkx numpy scipy matplotlib
+
+STEP 3: Clone User-Specified Repositories (if any)
+If the research topic specifies code_references, clone them to code/ NOW.
+These have HIGHEST PRIORITY.
+
+═══════════════════════════════════════════════════════════════════════════════
+                      PHASE 5: SYNTHESIS AND DOCUMENTATION
+═══════════════════════════════════════════════════════════════════════════════
+
+DELIVERABLE 1: literature_review.md
+─────────────────────────────────────────────────────────────────────────────
+
+## Literature Review
+
+### Research Area Overview
+[Brief overview of the mathematical area and research question in context]
+
+### Key Definitions
+[All definitions needed, precisely stated]
+
+### Key Papers
+#### Paper 1: [Title]
+- Authors, Year, Source
+- Main Results, Proof Techniques, Relevance
+
+### Known Results (Prerequisite Theorems)
+[Theorems to cite or build upon, with source and statement]
+
+### Mathlib Lemma Catalog
+[Table of all prerequisite results and their Mathlib status]
+
+| Informal Result | Mathlib Name | Verified? | Notes |
+|---|---|---|---|
+| ... | ... | ✓ / ✗ | ... |
+
+### Proof Techniques in the Literature
+[Common approaches; which seem applicable to our question]
+
+### Existing Lean Formalizations
+[Any existing Lean formalizations of related results found during search]
+
+### Recommendations for Proof Strategy
+- Recommended proof approach (and why)
+- Key lemmas to establish (split: "cite from Mathlib" vs "prove from scratch")
+- Lean tactics likely useful for each step
+- Potential obstacles
+
+IMPORTANT: Keep this concise and focused (3-5 pages maximum).
+
+DELIVERABLE 2: resources.md
+─────────────────────────────────────────────────────────────────────────────
+
+## Resources Catalog
+
+### Papers
+| Title | Authors | Year | File | Key Results |
+|---|---|---|---|---|
+| ... | ... | ... | papers/... | ... |
+
+### Mathlib Prerequisites
+| Result | Mathlib Name | Used For |
+|---|---|---|
+| ... | ... | ... |
+
+### Computational Tools
+| Tool | Purpose | Notes |
+|---|---|---|
+| SymPy | Symbolic exploration | For conjecture testing |
+| NetworkX | Graph computations | If applicable |
+
+### Recommendations for Proof Construction
+1. Proof strategy
+2. Mathlib lemmas to cite directly
+3. Lemmas that must be proved from scratch
+4. Python tools for numerical verification
+
+═══════════════════════════════════════════════════════════════════════════════
+                           PHASE 6: COMPLETION
+═══════════════════════════════════════════════════════════════════════════════
+
+FINAL CHECKLIST:
+✓ papers/ directory with downloaded PDFs and README.md
+✓ literature_review.md complete with Mathlib lemma catalog
+✓ resources.md catalogs all resources
+✓ Mathlib lemma names verified with #check (or flagged as uncertain)
+✓ Existing Lean formalizations searched for and documented
+
+COMPLETION MARKER:
+cat > .resource_finder_complete << 'EOF'
+Resource finding phase completed successfully.
+Timestamp: $(date -Iseconds)
+Papers downloaded: [count]
+Prior results cataloged: [count]
+Mathlib lemmas identified: [count]
+EOF
+
+═══════════════════════════════════════════════════════════════════════════════
+                           BEST PRACTICES
+═══════════════════════════════════════════════════════════════════════════════
+
+✓ DO: Verify Mathlib lemma names with #check — wrong names waste hours
+✓ DO: Record theorem statements precisely (conditions matter!)
+✓ DO: Document proof techniques, not just results
+✓ DO: Note which prerequisites need proving vs. which are in Mathlib
+✓ DO: Keep documentation concise and mathematically precise
+
+✗ DON'T: Skip the Mathlib lemma catalog — it directly drives Phase 3
+✗ DON'T: Paraphrase theorems loosely — precision matters in formal proofs
+✗ DON'T: Set up the Lean project here — that's the experiment runner's job
+✗ DON'T: Forget the completion marker file
+
+═══════════════════════════════════════════════════════════════════════════════
+
+Remember: You are preparing the foundation for formal Lean proof construction.
+The next agent will use your catalog of definitions, theorems, AND Mathlib lemma
+names to develop formally verified mathematical results. Precision and Mathlib
+coverage are the most important outputs of this phase.

--- a/templates/domains/mathematics_lean/session_instructions.txt
+++ b/templates/domains/mathematics_lean/session_instructions.txt
@@ -1,0 +1,298 @@
+{{ session_start }}
+{{ priority_section }}
+CRITICAL: Environment Setup
+────────────────────────────────────────────────────────────────────────────────
+You MUST use an isolated Python environment AND set up a Lean 4 project.
+
+STEP A — Python environment (for conjecture exploration with SymPy/NumPy):
+
+1. Check for existing venv:
+   If .venv/ exists → skip to step 3.
+   If not → run: uv venv
+
+2. Create pyproject.toml if missing:
+   cat > pyproject.toml << 'EOF'
+   [project]
+   name = "research-workspace"
+   version = "0.1.0"
+   description = "Mathematics (Lean) research workspace"
+   requires-python = ">=3.10"
+   dependencies = []
+
+   [build-system]
+   requires = ["hatchling"]
+   build-backend = "hatchling.build"
+   EOF
+
+3. Activate: source .venv/bin/activate
+
+4. Install math tools: uv add sympy numpy matplotlib
+
+STEP B — Lean 4 project (the primary proof verification tool):
+
+Run the setup skill script FIRST. It installs elan, creates lean_proofs/ with
+Mathlib, and downloads the prebuilt cache so you don't wait hours for a source build:
+
+   bash .claude/skills/lean-prover/scripts/setup_lean_project.sh
+
+If the script is not present, set up manually:
+   curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+     | sh -s -- -y && source "$HOME/.elan/env"
+   mkdir lean_proofs && cd lean_proofs
+   lake +leanprover-community/mathlib4:stable init lean_proofs math
+   lake exe cache get
+   lake build
+   cd ..
+
+Read .claude/skills/lean-prover/SKILL.md for full Lean 4 guidance.
+
+NEVER use conda. NEVER install Lean packages via pip.
+
+════════════════════════════════════════════════════════════════════════════════
+
+GPU AND COMPUTATIONAL RESOURCES
+────────────────────────────────────────────────────────────────────────────────
+At the START of your session, check for GPU availability:
+
+   nvidia-smi --query-gpu=name,memory.total,memory.free --format=csv 2>/dev/null || echo "NO_GPU"
+
+GPU is useful for large-scale numerical conjecture search (Monte Carlo, exhaustive
+case checking). Lean proof checking is CPU-bound and does not use GPU.
+
+════════════════════════════════════════════════════════════════════════════════
+
+CRITICAL: Resources Have Been Pre-Gathered
+────────────────────────────────────────────────────────────────────────────────
+A resource-finding agent has already gathered:
+- literature_review.md: Known theorems, definitions, and proof techniques
+- resources.md: Catalog of all papers, prior results, and tools
+- papers/: Downloaded research papers (PDFs)
+- code/: Computational tools and repositories (if applicable)
+
+READ THESE FIRST. They tell you what is already proved in the literature so you
+don't re-derive known results — and what Mathlib lemmas exist that you can cite.
+
+WHAT "FULLY-AUTOMATED" MEANS:
+✓ Complete ALL phases (1-6) in a SINGLE CONTINUOUS SESSION
+✓ Make reasonable decisions autonomously without waiting for user input
+✓ Move immediately from one phase to the next
+✓ Deliver REPORT.md with actual mathematical results and a passing Lean build
+
+YOU WILL NOT GET ADDITIONAL INSTRUCTIONS between phases.
+
+════════════════════════════════════════════════════════════════════════════════
+
+Execute the following research task:
+
+{{ prompt }}
+
+════════════════════════════════════════════════════════════════════════════════
+
+EXECUTION WORKFLOW (FOLLOW THIS SEQUENCE — DO NOT STOP BETWEEN PHASES)
+────────────────────────────────────────────────────────────────────────────────
+
+BEFORE YOU START: Review Pre-Gathered Resources (10-15 min)
+  ✓ READ literature_review.md — known results, definitions, proof techniques
+  ✓ READ resources.md — what tools and prior results are available
+  ✓ Note which theorems are already in Mathlib (check with #check in Lean)
+  ✓ Note which prerequisites you will need to prove yourself
+
+  → WHEN COMPLETE: Immediately proceed to Phase 1
+
+────────────────────────────────────────────────────────────────────────────────
+Phase 1: Proof Strategy Planning (20-40 min)
+────────────────────────────────────────────────────────────────────────────────
+  ✓ Write "Motivation & Novelty Assessment" section in planning.md
+    - Why this mathematical question matters
+    - What prior results it extends (from literature_review.md)
+    - Why formal Lean verification adds value here
+  ✓ Decompose the conjecture into sub-lemmas
+  ✓ For each sub-lemma, decide:
+      - Is it already in Mathlib? (check with #check / naming conventions)
+      - Does it need to be proved from scratch?
+      - What proof technique: direct, induction, contradiction, etc.?
+  ✓ Plan the Lean file structure:
+      Definitions.lean → Lemmas.lean → MainTheorem.lean
+  ✓ List the Mathlib imports you will need
+  ✓ Document plan in planning.md (2-3 pages maximum)
+
+  → WHEN COMPLETE: Immediately proceed to Phase 2
+
+────────────────────────────────────────────────────────────────────────────────
+Phase 2: Environment & Mathematical Setup (15-25 min)
+────────────────────────────────────────────────────────────────────────────────
+  ✓ Run environment setup (STEP A + STEP B above) if not already done
+  ✓ Confirm Lean setup: cd lean_proofs && lake build && cd ..
+  ✓ Write lean_proofs/LeanProofs/Definitions.lean:
+      - All types, structures, and notation for the research
+      - Use import Mathlib at the top
+      - Run lake build to confirm definitions compile
+  ✓ Write definitions.md with informal descriptions of each Lean definition
+  ✓ Verify prerequisite Mathlib lemmas exist: add #check statements and lake build
+
+  → WHEN COMPLETE: Immediately proceed to Phase 3
+
+────────────────────────────────────────────────────────────────────────────────
+Phase 3: Formal Proof Construction (90-150 min)
+────────────────────────────────────────────────────────────────────────────────
+This is the MAIN PHASE. Proofs are only accepted when Lean accepts them.
+
+  {{ code_workflow }}
+
+  LEAN PROOF WORKFLOW — follow this for each lemma/theorem:
+
+  STEP 1 — Write the statement with `sorry`:
+    Open lean_proofs/LeanProofs/Lemmas.lean (or MainTheorem.lean)
+    Add the theorem with `sorry` as the proof body
+    Run: cd lean_proofs && lake build 2>&1 | tail -20; cd ..
+    ✓ Exit 0 → statement type-checks; proceed to proof
+    ✗ Non-zero → fix the statement type error first (read the error message)
+
+  STEP 2 — Attempt proof with automation first:
+    Try in order: ring → omega → linarith → norm_num → simp → decide
+    For each tactic attempt:
+      Edit the .lean file
+      Run: cd lean_proofs && lake build 2>&1 | tail -30; cd ..
+      ✓ Exit 0, no sorry warning → lemma proved ✓
+      ✗ Error → read the message, adjust the tactic or add intermediate steps
+
+  STEP 3 — Manual tactic proof if automation fails:
+    Break the proof into smaller steps using `have h : ... := by ...`
+    Use `intro`, `apply`, `rw`, `exact`, `cases`, `induction` as appropriate
+    After each meaningful edit, run lake build to check progress
+    Read Lean error messages carefully — they tell you exactly what's missing
+
+  STEP 4 — Verify no sorry remains in this file:
+    grep "sorry" lean_proofs/LeanProofs/Lemmas.lean
+
+  LEAN PROOF WRITING GUIDELINES:
+  - Add a doc comment /-- ... -/ before every theorem explaining what it says
+  - Write an informal proof sketch as a comment block before the tactic proof
+  - Name intermediate claims with `have h_name : ... := by ...`
+  - When citing a Mathlib lemma, add a comment: -- from Mathlib: Lemma.Name
+  - Build after every complete lemma (not just at the end)
+  - Save results/ with a proof_log.md tracking which lemmas are proved
+
+  PYTHON EXPLORATION (in parallel with proof construction):
+  {{ code_workflow }}
+  - Use Python/SymPy in src/ to:
+    - Verify statements numerically before formalizing
+    - Search for counterexamples to candidate lemmas
+    - Generate examples that guide the Lean proof strategy
+  - This is EXPLORATORY only — it does not constitute a proof
+
+  → WHEN COMPLETE: Immediately proceed to Phase 4
+
+────────────────────────────────────────────────────────────────────────────────
+Phase 4: Proof Verification & Hardening (20-30 min)
+────────────────────────────────────────────────────────────────────────────────
+  ✓ Run full build from scratch to confirm everything compiles:
+      cd lean_proofs && lake clean && lake build 2>&1; cd ..
+  ✓ Confirm no sorry remains anywhere:
+      grep -r "sorry" lean_proofs/LeanProofs/ \
+        && echo "INCOMPLETE PROOFS REMAIN" \
+        || echo "All proofs formally complete ✓"
+  ✓ Verify all theorems in your plan are proved (check planning.md checklist)
+  ✓ Run Python exploration scripts to test boundary cases and sanity-check results
+  ✓ Document verification status in results/verification.md:
+      - lake build exit code
+      - grep sorry output
+      - Lean toolchain version (cat lean_proofs/lean-toolchain)
+      - Mathlib commit (cat lean_proofs/lake-manifest.json | grep -A2 mathlib)
+
+  → WHEN COMPLETE: Immediately proceed to Phase 5
+
+────────────────────────────────────────────────────────────────────────────────
+Phase 5: Refinement and Strengthening (15-25 min)
+────────────────────────────────────────────────────────────────────────────────
+  ✓ Review proofs for unnecessary hypotheses (can any be weakened?)
+  ✓ Check: can the conclusion be strengthened?
+  ✓ Find tight counterexamples showing hypotheses are necessary (Python)
+  ✓ Look for natural Lean generalizations (e.g., replace ℕ with a general monoid)
+  ✓ Clean up Lean code: remove redundant `have`s, improve tactic style
+  ✓ Ensure all definitions are in Definitions.lean (no ad-hoc inline definitions)
+
+  → WHEN COMPLETE: Immediately proceed to Phase 6
+
+────────────────────────────────────────────────────────────────────────────────
+Phase 6: Final Documentation (20-30 min) — MANDATORY BEFORE ENDING SESSION
+────────────────────────────────────────────────────────────────────────────────
+  ✓ Create REPORT.md with ACTUAL mathematical results (see structure below)
+  ✓ Create README.md with project overview
+  ✓ Ensure lean_proofs/ is organized with comments
+  ✓ Verify results/ contains verification.md with build status
+
+  → WHEN COMPLETE: Session is finished
+
+CRITICAL REMINDERS:
+- This is a SINGLE CONTINUOUS SESSION covering all 6 phases
+- `lake build` is your ground truth — informal argument is not enough
+- A proof with `sorry` is NOT a proof; grep for sorry before reporting completion
+- If a proof is too hard to formalize in time, mark it `sorry`, document the
+  informal argument clearly, and note it as future work in REPORT.md
+- REPORT.md is mandatory even if some proofs remain as `sorry`
+
+════════════════════════════════════════════════════════════════════════════════
+WORKSPACE DIRECTORY AND DIRECTORY SAFETY
+────────────────────────────────────────────────────────────────────────────────
+You are running in the project workspace directory: {{ work_dir }}
+
+MANDATORY VERIFICATION POINTS — Run `pwd` and verify location:
+✓ Before any mkdir, file write, or download
+✓ Before and after any cd command — ALWAYS cd back to workspace root
+✓ When starting each new phase
+
+SAFE PATTERN FOR LEAN BUILDS:
+  pwd                                         # verify you're in workspace root
+  cd lean_proofs && lake build 2>&1; cd -     # build and return
+  pwd                                         # confirm you're back
+
+⚠️  NEVER create Lean files outside lean_proofs/
+⚠️  NEVER run lake from the workspace root (always cd lean_proofs first)
+⚠️  NEVER run cd .. (parent directory is dangerous)
+
+Remember:
+- READ literature_review.md and resources.md first
+- Python scripts go in src/ (for exploration only)
+- Lean proofs go in lean_proofs/LeanProofs/
+{{ code_reminder }}
+- All your work stays within {{ work_dir }}
+
+════════════════════════════════════════════════════════════════════════════════
+PHASE 6 REQUIREMENTS — WHAT TO INCLUDE IN FINAL DOCUMENTATION
+════════════════════════════════════════════════════════════════════════════════
+
+1. REPORT.md — Mathematics (Lean) research report:
+   - Executive Summary (2-3 paragraphs; state verification status explicitly)
+   - Research Question (the conjecture or problem)
+   - Definitions and Notation (informal descriptions; Lean types in code blocks)
+   - Statement of Results (theorem statements in informal math + Lean type signatures)
+   - Proof Sketches (informal argument for each theorem; full proofs are in Lean files)
+   - Lean Formalization (file structure, key Mathlib lemmas used, build verification)
+   - Verification Status ("lake build exits 0, no sorry found" or list of open sorry)
+   - Discussion (implications, connections, what Mathlib lemmas were reused)
+   - Open Questions (results that remain conjectural or unformalized)
+   - Conclusions and Future Work
+   - References (papers + Lean/Mathlib version info)
+
+2. README.md — Quick overview:
+   - Brief description (2-3 sentences)
+   - Key results (bullet points: theorem names + informal statements)
+   - Verification: `cd lean_proofs && lake build` must succeed
+   - File structure overview
+   - Link to REPORT.md
+
+════════════════════════════════════════════════════════════════════════════════
+SESSION COMPLETION
+════════════════════════════════════════════════════════════════════════════════
+
+The session is COMPLETE when:
+✓ All phases (1-6) have been attempted
+✓ lean_proofs/ exists and `lake build` runs (exit 0 if proofs complete)
+✓ REPORT.md documents actual results and verification status
+✓ README.md is created
+✓ results/verification.md records the build output and grep-sorry output
+✓ src/ contains Python exploration scripts with comments
+
+If some proofs remain as `sorry`, the session is still complete — document
+what was proved, what remains, and the informal argument for each open item.

--- a/templates/skills/lean-prover/SKILL.md
+++ b/templates/skills/lean-prover/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: lean-prover
+description: Formally verify mathematical proofs using Lean 4 and Mathlib. Use when working in the mathematics_lean domain, when a proof needs machine-checked verification, or when translating informal proofs into formally verified Lean 4 code.
+---
+
+# Lean Prover
+
+Formal proof verification using Lean 4 and the Mathlib mathematics library.
+
+## When to Use
+
+- Working in the `mathematics_lean` research domain
+- Translating an informal proof into formally verified code
+- Checking whether a mathematical statement is provable
+- Searching Mathlib for existing lemmas to cite or reuse
+
+## Project Setup
+
+Run the setup script from your workspace root:
+
+```bash
+bash .claude/skills/lean-prover/scripts/setup_lean_project.sh
+```
+
+This creates `lean_proofs/` with Mathlib as a dependency and downloads the
+prebuilt cache. After setup, all proof work lives inside `lean_proofs/`.
+
+**Manual setup (if the script fails):**
+
+```bash
+# 1. Install elan (Lean version manager) if not present
+curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+  | sh -s -- -y
+source "$HOME/.elan/env"
+
+# 2. Create a Mathlib project
+mkdir lean_proofs && cd lean_proofs
+lake +leanprover-community/mathlib4:stable init lean_proofs math
+# ↑ "math" template wires up Mathlib automatically
+
+# 3. Download prebuilt Mathlib cache (avoids a multi-hour source build)
+lake exe cache get
+
+# 4. Verify setup
+lake build
+cd ..
+```
+
+## Project Structure
+
+```
+lean_proofs/
+├── lakefile.lean          # Build config — Mathlib dependency lives here
+├── lean-toolchain         # Pinned Lean version (must match Mathlib)
+└── LeanProofs/
+    ├── Definitions.lean   # All definitions and notation
+    ├── Lemmas.lean        # Supporting lemmas (import Definitions)
+    └── MainTheorem.lean   # Main results (import Lemmas)
+```
+
+Root import file (`LeanProofs.lean`):
+```lean
+import LeanProofs.Definitions
+import LeanProofs.Lemmas
+import LeanProofs.MainTheorem
+```
+
+## Writing Proofs
+
+### File header
+
+Every `.lean` file should start with:
+```lean
+import Mathlib
+import LeanProofs.Definitions  -- if referencing other local files
+
+namespace LeanProofs
+-- ... your content ...
+end LeanProofs
+```
+
+### Theorem / Lemma syntax
+
+```lean
+-- Statement only (use sorry to check the type compiles first)
+theorem my_theorem (n : ℕ) (h : n > 0) : n * 2 > n := by
+  sorry
+
+-- Full proof
+theorem my_theorem (n : ℕ) (h : n > 0) : n * 2 > n := by
+  linarith
+```
+
+### Definitions
+
+```lean
+-- Type alias
+def MySet := Finset ℕ
+
+-- Structure
+structure MyGraph where
+  vertices : Finset ℕ
+  edges    : Finset (ℕ × ℕ)
+
+-- Inductive type
+inductive Tree (α : Type) where
+  | leaf : Tree α
+  | node : α → Tree α → Tree α → Tree α
+```
+
+## Core Tactic Reference
+
+| Tactic | When to use |
+|--------|-------------|
+| `ring` | Prove equalities in commutative (semi)rings: `a*(b+c) = a*b + a*c` |
+| `ring_nf` | Normalize ring expressions without closing the goal |
+| `norm_num` | Prove concrete numerical facts: `2 + 2 = 4`, `7.isPrime` |
+| `omega` | Linear arithmetic over `ℤ` and `ℕ`: `n + 1 > n` |
+| `linarith` | Linear arithmetic with hypotheses: `h1 : a < b, h2 : b < c ⊢ a < c` |
+| `nlinarith` | Nonlinear arithmetic (products of hypotheses) |
+| `simp` | Simplify using the simp lemma set; use `simp [lemma1, lemma2]` to add |
+| `simp only [h]` | Targeted rewrite using only `h`; safer than bare `simp` |
+| `exact h` | Close goal exactly with hypothesis `h` or a term |
+| `apply f` | Apply function/lemma `f`, unifying conclusion with goal |
+| `rw [h]` | Rewrite goal left-to-right using equation `h` |
+| `rw [← h]` | Rewrite right-to-left |
+| `constructor` | Split an `And` goal or `Iff` into two subgoals |
+| `intro h` | Introduce hypothesis from `∀` or `→` |
+| `obtain ⟨a, b, h⟩ := hx` | Destructure existential or And hypothesis |
+| `use x` | Provide witness for `∃` goal |
+| `cases h` | Case split on inductive type or `Or` |
+| `induction n with` | Structural induction |
+| `by_contra h` | Proof by contradiction |
+| `push_neg` | Push negation inward: `¬ ∀ x, P x` → `∃ x, ¬ P x` |
+| `contrapose!` | Switch to contrapositive and push negation |
+| `gcongr` | Congruence for monotone operations |
+| `field_simp` | Clear denominators in field goals |
+| `positivity` | Prove `0 < x` or `0 ≤ x` goals |
+| `decide` | Close decidable propositions by computation (small finite cases) |
+| `native_decide` | Like `decide` but compiled — handles larger cases |
+| `tauto` | Propositional tautologies |
+| `aesop` | Automated search combining many strategies |
+| `exact?` | **(Interactive only)** Search for a term matching the goal |
+| `apply?` | **(Interactive only)** Search for applicable lemmas |
+| `simp?` | **(Interactive only)** Show which simp lemmas closed/simplified the goal |
+
+## Searching Mathlib
+
+Since `exact?` / `apply?` are interactive-only, use these strategies in batch mode:
+
+### 1. `#check` — verify a name exists
+```lean
+#check Nat.add_comm      -- Nat.add_comm : ∀ (n m : ℕ), n + m = m + n
+#check List.length_map   -- look up list lemmas
+```
+
+### 2. Naming conventions (predict lemma names)
+Mathlib names follow a consistent pattern:
+- `Nat.add_comm`  — commutativity of `+` on `ℕ`
+- `Int.mul_neg`   — negation rule for `*` on `ℤ`
+- `List.map_comp` — `map` composed with `comp`
+- Prefix with type namespace: `Finset.`, `Set.`, `Matrix.`, `Polynomial.`
+
+### 3. `Mathlib.Tactic.Polyrith` / `polyrith`
+For polynomial arithmetic identities that `ring` can't close automatically.
+
+### 4. Web search
+Search `leanprover-community.github.io/mathlib4_docs` for the exact namespace.
+Example: search "Nat prime" to find `Nat.Prime`, `Nat.Prime.two_le`, etc.
+
+## Verification Workflow (Per Proof)
+
+```bash
+# Step 1 — stub the statement, check it type-checks
+# Add `sorry` as the proof body
+
+# Step 2 — build to confirm the statement compiles
+cd lean_proofs && lake build 2>&1; cd ..
+
+# Step 3 — replace sorry with tactics, rebuild
+# Repeat until exit code is 0 with no "sorry" warnings
+
+# Step 4 — grep to confirm no sorry remains
+grep -r "sorry" lean_proofs/LeanProofs/ && echo "INCOMPLETE PROOFS FOUND" || echo "All proofs complete"
+```
+
+`lake build` exit code semantics:
+- **0** — everything compiled; if no `sorry`, proof is formally complete
+- **non-zero** — type error or tactic failure; stderr contains the exact error location and message
+
+## Interpreting Lean Error Messages
+
+| Error | Meaning |
+|-------|---------|
+| `unknown identifier 'foo'` | `foo` not in scope — check import or namespace |
+| `type mismatch: expected X got Y` | Wrong type — check the hypothesis you're applying |
+| `unsolved goals: ⊢ P` | Proof is incomplete — `P` still needs to be proved |
+| `application type mismatch` | Applied lemma to wrong argument type |
+| `failed to synthesize instance` | Missing typeclass — may need `[DecidableEq α]` or similar |
+| `declaration uses sorry` | Proof accepted but marked incomplete — replace all `sorry` |
+
+## Proof Skeleton Template
+
+Use this as a starting point for each new result:
+
+```lean
+/-- One-line description of what this proves. -/
+theorem theorem_name
+    (param1 : Type1)
+    (param2 : Type2)
+    (hyp1 : Condition1)
+    (hyp2 : Condition2) :
+    Conclusion := by
+  sorry  -- replace with actual proof
+
+/-- Supporting lemma used in the main theorem. -/
+lemma lemma_name (n : ℕ) : n + 0 = n := by
+  ring
+```
+
+## Common Mathlib Imports by Area
+
+```lean
+-- ALWAYS start with this — gives all tactics, ~1-2GB cache instead of 5GB:
+import Mathlib.Tactic
+
+-- Then add only the specific content modules you need:
+import Mathlib.Algebra.Group.Basic        -- groups, monoids
+import Mathlib.Algebra.Ring.Basic         -- rings
+import Mathlib.Algebra.Field.Basic        -- fields
+import Mathlib.Data.Nat.Basic             -- ℕ lemmas
+import Mathlib.Data.Int.Basic             -- ℤ lemmas
+import Mathlib.Data.Real.Basic            -- ℝ lemmas
+import Mathlib.Data.Finset.Basic          -- finite sets
+import Mathlib.Combinatorics.SimpleGraph.Basic  -- graph theory
+import Mathlib.Topology.Basic             -- topology
+import Mathlib.Analysis.SpecialFunctions.Pow.Real  -- real powers
+import Mathlib.NumberTheory.Primes        -- prime numbers
+import Mathlib.LinearAlgebra.Matrix.Basic -- matrices
+```
+
+**Avoid `import Mathlib`** — it pulls the full 5GB cache and slower compile times.
+Use `import Mathlib.Tactic` as your base and add specific modules as needed.
+The resource finder's Mathlib lemma catalog tells you exactly which modules to add.
+
+## References
+
+See `references/` folder for:
+- `lean4_cheatsheet.md`: Quick syntax reference
+- `mathlib_search_guide.md`: How to find lemmas by name pattern

--- a/templates/skills/lean-prover/scripts/setup_lean_project.sh
+++ b/templates/skills/lean-prover/scripts/setup_lean_project.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Setup a Lean 4 + Mathlib project in lean_proofs/ within the current workspace.
+# Usage: bash .claude/skills/lean-prover/scripts/setup_lean_project.sh
+set -euo pipefail
+
+PROJECT_DIR="${1:-lean_proofs}"
+LIB_NAME="LeanProofs"
+
+echo "========================================"
+echo "  Lean 4 + Mathlib Project Setup"
+echo "  Target: $PROJECT_DIR/"
+echo "========================================"
+
+# ── 1. Install elan if not present ───────────────────────────────────────────
+if ! command -v elan &>/dev/null && ! command -v lean &>/dev/null; then
+  echo ""
+  echo "► Installing elan (Lean version manager)..."
+  curl -sSfL \
+    https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+    | sh -s -- -y --default-toolchain none
+  # shellcheck source=/dev/null
+  source "$HOME/.elan/env" 2>/dev/null || export PATH="$HOME/.elan/bin:$PATH"
+  echo "  elan installed."
+else
+  echo "► elan/lean already installed: $(elan --version 2>/dev/null || lean --version)"
+fi
+
+# ── 2. Create project directory ───────────────────────────────────────────────
+if [ -d "$PROJECT_DIR" ]; then
+  echo ""
+  echo "► Directory '$PROJECT_DIR' already exists — skipping creation."
+else
+  echo ""
+  echo "► Creating Lean project with Mathlib..."
+  # Use the official mathlib4 template so the toolchain pin is correct
+  lake +leanprover-community/mathlib4:stable init "$PROJECT_DIR" math
+  echo "  Project created."
+fi
+
+cd "$PROJECT_DIR"
+
+# ── 3. Create library source directory ───────────────────────────────────────
+mkdir -p "$LIB_NAME"
+
+# ── 4. Write starter files (only if they don't exist yet) ────────────────────
+if [ ! -f "$LIB_NAME/Definitions.lean" ]; then
+cat > "$LIB_NAME/Definitions.lean" << 'EOF'
+-- Import only proof tactics (ring, omega, linarith, norm_num, simp, decide, etc.)
+-- This is ~1-2GB cache instead of 5GB for `import Mathlib`.
+-- Add specific Mathlib imports below as the resource finder identifies them.
+-- Example: import Mathlib.Data.Nat.Basic
+--          import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Tactic
+
+namespace LeanProofs
+
+/-!
+## Definitions and Notation
+
+Add all definitions, structures, and notation used by the research here.
+Import this file from Lemmas.lean and MainTheorem.lean.
+
+To use a specific Mathlib lemma (e.g. Nat.add_comm), add its module here:
+  import Mathlib.Data.Nat.Basic
+-/
+
+end LeanProofs
+EOF
+fi
+
+if [ ! -f "$LIB_NAME/Lemmas.lean" ]; then
+cat > "$LIB_NAME/Lemmas.lean" << 'EOF'
+import LeanProofs.Definitions
+
+namespace LeanProofs
+
+/-!
+## Supporting Lemmas
+
+Prove intermediate results here. Each lemma should:
+1. Have a doc comment explaining what it says
+2. State all hypotheses explicitly
+3. End with QED (i.e. no `sorry`)
+-/
+
+end LeanProofs
+EOF
+fi
+
+if [ ! -f "$LIB_NAME/MainTheorem.lean" ]; then
+cat > "$LIB_NAME/MainTheorem.lean" << 'EOF'
+import LeanProofs.Lemmas
+
+namespace LeanProofs
+
+/-!
+## Main Results
+
+State and prove the principal theorems of the research.
+-/
+
+end LeanProofs
+EOF
+fi
+
+# Root import file
+cat > "${LIB_NAME}.lean" << EOF
+import ${LIB_NAME}.Definitions
+import ${LIB_NAME}.Lemmas
+import ${LIB_NAME}.MainTheorem
+EOF
+
+# ── 5. Get Mathlib cache ──────────────────────────────────────────────────────
+# When running inside the neurico-lean Docker image, ~/.cache/mathlib4/ is
+# pre-populated at build time.  `lake exe cache get` reads from that local
+# cache instead of downloading — making this step instant.
+# Outside the image (bare machine), it downloads ~1-2GB from the Mathlib CDN.
+echo ""
+CACHE_DIR="${HOME}/.cache/mathlib4"
+if [ -d "${CACHE_DIR}" ] && [ "$(ls -A "${CACHE_DIR}" 2>/dev/null)" ]; then
+  echo "► Mathlib cache found at ${CACHE_DIR} — copying locally (fast)..."
+else
+  echo "► Mathlib cache not found — downloading (~1-2GB, takes a few minutes)..."
+fi
+if lake exe cache get; then
+  echo "  Mathlib cache ready."
+else
+  echo "  Cache step failed — will compile from source on first build."
+  echo "  (This can take 30–90 minutes the first time.)"
+fi
+
+# ── 6. Initial build to confirm setup ────────────────────────────────────────
+echo ""
+echo "► Running initial build to verify setup..."
+if lake build; then
+  echo ""
+  echo "========================================"
+  echo "  Setup complete!"
+  echo "  Project: $(pwd)"
+  echo ""
+  echo "  File layout:"
+  echo "    $LIB_NAME/Definitions.lean  — add definitions here"
+  echo "    $LIB_NAME/Lemmas.lean       — add supporting lemmas here"
+  echo "    $LIB_NAME/MainTheorem.lean  — add main results here"
+  echo ""
+  echo "  Verify proofs at any time:"
+  echo "    cd $PROJECT_DIR && lake build"
+  echo "========================================"
+else
+  echo ""
+  echo "  Build failed — check error output above."
+  exit 1
+fi

--- a/tests/test_lean_integration.py
+++ b/tests/test_lean_integration.py
@@ -1,0 +1,666 @@
+"""
+Integration tests for the Lean proof feedback loop.
+
+These tests verify the shell-level behaviors that the session_instructions
+template prescribes WITHOUT calling the Claude LLM at all — making them
+free to run in terms of API cost.
+
+Three tiers, by cost/speed:
+
+  Tier 1  lean_binary   — `lean --stdin` only; instant once lean is installed
+  Tier 2  lean_lake     — minimal Lake project (no Mathlib); seconds per test
+  Tier 3  lean_mathlib  — full setup_lean_project.sh with Mathlib; slow
+
+Run fast tests only (default):
+    pytest tests/test_lean_integration.py -m "not lean_mathlib"
+
+Run everything including Mathlib:
+    pytest tests/test_lean_integration.py
+
+Skip all Lean tests (e.g. in CI without lean installed):
+    pytest tests/test_lean_integration.py -m "not lean_binary"
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT    = Path(__file__).parent.parent
+SETUP_SCRIPT = REPO_ROOT / "templates" / "skills" / "lean-prover" / "scripts" / "setup_lean_project.sh"
+
+# ── Pytest marks ──────────────────────────────────────────────────────────────
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "lean_binary: requires lean binary on PATH")
+    config.addinivalue_line("markers", "lean_lake:   requires lean + lake on PATH")
+    config.addinivalue_line("markers", "lean_mathlib: slow — downloads Mathlib cache")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _run(cmd: list[str], cwd=None, input_text=None, timeout=60) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _lean_path() -> str | None:
+    return shutil.which("lean")
+
+
+def _lake_path() -> str | None:
+    return shutil.which("lake")
+
+
+def _elan_path() -> str | None:
+    return shutil.which("elan")
+
+
+# ── Session-level availability checks ────────────────────────────────────────
+
+@pytest.fixture(scope="session")
+def lean_bin():
+    path = _lean_path()
+    if path is None:
+        pytest.skip(
+            "lean binary not found on PATH.\n"
+            "Install with: curl -sSfL https://raw.githubusercontent.com/"
+            "leanprover/elan/master/elan-init.sh | sh -s -- -y"
+        )
+    return path
+
+
+@pytest.fixture(scope="session")
+def lake_bin(lean_bin):
+    path = _lake_path()
+    if path is None:
+        pytest.skip("lake binary not found on PATH (usually installed with elan)")
+    return path
+
+
+# ── Tier 1: lean --stdin (no project, no Mathlib) ────────────────────────────
+
+@pytest.mark.lean_binary
+class TestLeanBinaryFeedbackLoop:
+    """
+    Tests the core sorry/valid/error feedback loop using `lean --stdin`.
+    No project, no Mathlib, no internet needed.
+    Exercises the exact semantics the session_instructions relies on.
+    """
+
+    # ── valid proof ───────────────────────────────────────────────────────────
+
+    def test_valid_proof_exits_zero(self, lean_bin):
+        """A correct proof must exit 0 — the session_instructions 'proof complete' signal."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t (n : Nat) : n + 0 = n := Nat.add_zero n\n",
+        )
+        assert result.returncode == 0, (
+            f"Valid proof should exit 0.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_valid_proof_produces_no_sorry_warning(self, lean_bin):
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t (n : Nat) : n + 0 = n := Nat.add_zero n\n",
+        )
+        combined = result.stdout + result.stderr
+        assert "sorry" not in combined.lower(), (
+            "A proof with no sorry must not produce a 'sorry' warning"
+        )
+
+    def test_omega_proves_linear_arithmetic(self, lean_bin):
+        """omega is a core tactic (no Mathlib) — must close simple linear goals."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t (n : Nat) : n + 1 > n := by omega\n",
+        )
+        assert result.returncode == 0, (
+            f"omega should close 'n + 1 > n'.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_decide_proves_concrete_fact(self, lean_bin):
+        """decide computes decidable propositions — no Mathlib needed."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t : (2 : Nat) + 2 = 4 := by decide\n",
+        )
+        assert result.returncode == 0, (
+            f"decide should close '2 + 2 = 4'.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    # ── sorry behavior ────────────────────────────────────────────────────────
+
+    def test_sorry_exits_zero(self, lean_bin):
+        """sorry must exit 0 (accepted by Lean) so the loop can continue."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t (n : Nat) : n + 0 = n := by sorry\n",
+        )
+        assert result.returncode == 0, (
+            f"sorry should exit 0.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_sorry_produces_warning(self, lean_bin):
+        """sorry must produce a 'declaration uses sorry' warning — the grep target."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t (n : Nat) : n + 0 = n := by sorry\n",
+        )
+        combined = result.stdout + result.stderr
+        assert "sorry" in combined.lower(), (
+            "sorry proof must produce a warning containing 'sorry'"
+        )
+
+    def test_declaration_uses_sorry_message(self, lean_bin):
+        """The specific 'declaration uses sorry' string from the error table in SKILL.md."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t : True := by sorry\n",
+        )
+        combined = result.stdout + result.stderr
+        assert "declaration uses 'sorry'" in combined or "uses sorry" in combined, (
+            "The 'declaration uses sorry' message must appear in Lean's output"
+        )
+
+    # ── type errors ───────────────────────────────────────────────────────────
+
+    def test_type_error_exits_nonzero(self, lean_bin):
+        """A type error must exit non-zero — the agent's signal to fix the proof."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t : (1 : Nat) = 2 := by rfl\n",
+        )
+        assert result.returncode != 0, (
+            f"Type error (1 = 2 by rfl) should exit non-zero.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_type_error_message_in_output(self, lean_bin):
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t : (1 : Nat) = 2 := by rfl\n",
+        )
+        combined = result.stdout + result.stderr
+        assert len(combined) > 0, "Type error must produce output for the agent to read"
+
+    def test_unknown_identifier_error(self, lean_bin):
+        """'unknown identifier' appears when the agent misspells a lemma name."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t : True := obviously_true\n",
+        )
+        combined = result.stdout + result.stderr
+        assert result.returncode != 0
+        assert "unknown" in combined.lower() or "identifier" in combined.lower(), (
+            "Using a non-existent identifier must produce an 'unknown identifier' error"
+        )
+
+    def test_unsolved_goals_error(self, lean_bin):
+        """'unsolved goals' appears when a tactic doesn't close the proof."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            # intro doesn't close the goal — leaves a goal open
+            input_text="theorem t (h : True) : True := by intro\n",
+        )
+        combined = result.stdout + result.stderr
+        # Either unsolved goals or a different error — the point is it fails
+        assert result.returncode != 0 or "unsolved" in combined.lower(), (
+            "An incomplete tactic proof must fail"
+        )
+
+
+# ── Tier 2: minimal Lake project (no Mathlib, fast) ───────────────────────────
+
+@pytest.fixture(scope="module")
+def minimal_lake_workspace(tmp_path_factory, lean_bin, lake_bin):
+    """
+    Create a minimal Lake project WITHOUT Mathlib.
+    This mimics the lean_proofs/ structure the session_instructions prescribes,
+    but avoids the Mathlib download so tests run in seconds.
+    """
+    d = tmp_path_factory.mktemp("lean_minimal")
+
+    # Minimal lakefile — no Mathlib dependency
+    (d / "lakefile.lean").write_text(textwrap.dedent("""\
+        import Lake
+        open Lake DSL
+
+        package «proofs» where
+          name := "proofs"
+
+        lean_lib «LeanProofs»
+    """))
+
+    # Root import file (matches session_instructions structure)
+    (d / "LeanProofs.lean").write_text(textwrap.dedent("""\
+        import LeanProofs.Definitions
+        import LeanProofs.Lemmas
+        import LeanProofs.MainTheorem
+    """))
+
+    lib = d / "LeanProofs"
+    lib.mkdir()
+
+    # Starter files with the same content the setup script creates,
+    # but importing core Lean instead of Mathlib
+    (lib / "Definitions.lean").write_text(textwrap.dedent("""\
+        namespace LeanProofs
+
+        /-!
+        ## Definitions and Notation
+        -/
+
+        end LeanProofs
+    """))
+
+    (lib / "Lemmas.lean").write_text(textwrap.dedent("""\
+        import LeanProofs.Definitions
+
+        namespace LeanProofs
+
+        /-!
+        ## Supporting Lemmas
+        -/
+
+        end LeanProofs
+    """))
+
+    (lib / "MainTheorem.lean").write_text(textwrap.dedent("""\
+        import LeanProofs.Lemmas
+
+        namespace LeanProofs
+
+        /-!
+        ## Main Results
+        -/
+
+        end LeanProofs
+    """))
+
+    # Run initial build to ensure the empty project compiles
+    result = _run([lake_bin, "build"], cwd=d, timeout=120)
+    if result.returncode != 0:
+        pytest.skip(
+            f"Initial lake build failed (lean toolchain issue?).\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    return d
+
+
+@pytest.mark.lean_lake
+class TestLakeBuildFeedbackLoop:
+    """
+    Tests the exact `cd lean_proofs && lake build 2>&1 ; cd ..` pattern
+    prescribed by the session_instructions, using a minimal project.
+    """
+
+    def _write_main_theorem(self, workspace: Path, content: str):
+        (workspace / "LeanProofs" / "MainTheorem.lean").write_text(
+            textwrap.dedent(f"""\
+                import LeanProofs.Lemmas
+
+                namespace LeanProofs
+
+                {content}
+
+                end LeanProofs
+            """)
+        )
+
+    # ── valid proofs ──────────────────────────────────────────────────────────
+
+    def test_valid_core_proof_exits_zero(self, minimal_lake_workspace, lake_bin):
+        """A correct proof in MainTheorem.lean must make lake build exit 0."""
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem add_zero (n : Nat) : n + 0 = n := Nat.add_zero n"
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        assert result.returncode == 0, (
+            f"Valid proof must make lake build exit 0.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_omega_proof_exits_zero(self, minimal_lake_workspace, lake_bin):
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem lt_succ (n : Nat) : n < n + 1 := by omega"
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        assert result.returncode == 0, (
+            f"omega proof must make lake build exit 0.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    # ── sorry behavior ────────────────────────────────────────────────────────
+
+    def test_sorry_lake_build_exits_zero(self, minimal_lake_workspace, lake_bin):
+        """sorry must exit 0 so the agent can iterate — not block the loop."""
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem stub (n : Nat) : n + 0 = n := by sorry"
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        assert result.returncode == 0, (
+            f"sorry proof must make lake build exit 0 (warning, not error).\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_sorry_lake_build_produces_warning(self, minimal_lake_workspace, lake_bin):
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem stub (n : Nat) : n + 0 = n := by sorry"
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        combined = result.stdout + result.stderr
+        assert "sorry" in combined.lower(), (
+            "sorry proof must produce a warning in lake build output"
+        )
+
+    # ── grep-sorry completion check ───────────────────────────────────────────
+
+    def test_grep_finds_sorry_in_incomplete_proof(self, minimal_lake_workspace):
+        """The `grep -r sorry lean_proofs/LeanProofs/` check must find sorry."""
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem stub (n : Nat) : n + 0 = n := by sorry"
+        )
+        lean_dir = minimal_lake_workspace / "LeanProofs"
+        result = _run(["grep", "-r", "sorry", str(lean_dir)])
+        assert result.returncode == 0, (
+            "grep must return 0 (found matches) when sorry is present"
+        )
+        assert "sorry" in result.stdout, (
+            "grep output must contain the matched 'sorry' line"
+        )
+
+    def test_grep_returns_nonzero_after_sorry_removed(self, minimal_lake_workspace):
+        """After replacing sorry with a real proof, grep must return non-zero (no match)."""
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem stub (n : Nat) : n + 0 = n := Nat.add_zero n"
+        )
+        lean_dir = minimal_lake_workspace / "LeanProofs"
+        result = _run(["grep", "-r", "sorry", str(lean_dir)])
+        assert result.returncode != 0, (
+            "grep must return non-zero (no matches) when no sorry remains"
+        )
+
+    def test_grep_sorry_or_echo_workflow(self, minimal_lake_workspace):
+        """The exact pipeline pattern:
+            grep -r 'sorry' lean/... && echo INCOMPLETE || echo OK
+        Must print OK when proofs are complete.
+        """
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem done (n : Nat) : n + 0 = n := Nat.add_zero n"
+        )
+        lean_dir = minimal_lake_workspace / "LeanProofs"
+        result = _run(
+            ["bash", "-c",
+             f'grep -r "sorry" {lean_dir} && echo "INCOMPLETE PROOFS FOUND" || echo "All proofs complete"'],
+        )
+        assert "All proofs complete" in result.stdout, (
+            f"Workflow should print 'All proofs complete' when no sorry.\n"
+            f"stdout: {result.stdout}"
+        )
+
+    # ── type error handling ───────────────────────────────────────────────────
+
+    def test_type_error_exits_nonzero(self, minimal_lake_workspace, lake_bin):
+        """A type error in a .lean file must make lake build exit non-zero."""
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem bad : (1 : Nat) = 2 := by rfl"
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        assert result.returncode != 0, (
+            "Type error must make lake build exit non-zero"
+        )
+
+    def test_type_error_produces_output(self, minimal_lake_workspace, lake_bin):
+        """The agent reads stderr to understand what to fix."""
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem bad : (1 : Nat) = 2 := by rfl"
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        combined = result.stdout + result.stderr
+        assert len(combined) > 0, "Type error must produce diagnostic output"
+
+    # ── file structure expected by session instructions ───────────────────────
+
+    def test_import_chain_compiles(self, minimal_lake_workspace, lake_bin):
+        """Definitions ← Lemmas ← MainTheorem import chain must compile clean."""
+        (minimal_lake_workspace / "LeanProofs" / "Definitions.lean").write_text(
+            textwrap.dedent("""\
+                namespace LeanProofs
+                def myConst : Nat := 42
+                end LeanProofs
+            """)
+        )
+        (minimal_lake_workspace / "LeanProofs" / "Lemmas.lean").write_text(
+            textwrap.dedent("""\
+                import LeanProofs.Definitions
+                namespace LeanProofs
+                theorem myConst_pos : myConst > 0 := by unfold myConst; omega
+                end LeanProofs
+            """)
+        )
+        (minimal_lake_workspace / "LeanProofs" / "MainTheorem.lean").write_text(
+            textwrap.dedent("""\
+                import LeanProofs.Lemmas
+                namespace LeanProofs
+                theorem myConst_nonzero : myConst ≠ 0 := by
+                  have := myConst_pos; omega
+                end LeanProofs
+            """)
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=120)
+        assert result.returncode == 0, (
+            f"3-file import chain must compile.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_lake_clean_then_build(self, minimal_lake_workspace, lake_bin):
+        """The session instructions prescribe `lake clean && lake build` for Phase 4.
+        Verify clean + fresh build succeeds.
+        """
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem t (n : Nat) : n + 0 = n := Nat.add_zero n"
+        )
+        clean = _run([lake_bin, "clean"], cwd=minimal_lake_workspace, timeout=30)
+        assert clean.returncode == 0, "lake clean should succeed"
+
+        build = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=120)
+        assert build.returncode == 0, (
+            f"lake build after clean must succeed.\n"
+            f"stdout: {build.stdout}\nstderr: {build.stderr}"
+        )
+
+    def test_verification_md_content(self, minimal_lake_workspace, lake_bin):
+        """The session_instructions prescribes writing results/verification.md with
+        the lake build output and grep-sorry result. Verify we can produce that content.
+        """
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem t (n : Nat) : n + 0 = n := Nat.add_zero n"
+        )
+        build = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        lean_dir = minimal_lake_workspace / "LeanProofs"
+        grep = _run(["grep", "-r", "sorry", str(lean_dir)])
+
+        results_dir = minimal_lake_workspace / "results"
+        results_dir.mkdir(exist_ok=True)
+
+        verification_md = results_dir / "verification.md"
+        verification_md.write_text(
+            f"# Verification\n\n"
+            f"## lake build exit code\n{build.returncode}\n\n"
+            f"## grep sorry output\n"
+            f"{'No sorry found (exit {})'.format(grep.returncode) if grep.returncode != 0 else grep.stdout}\n"
+        )
+
+        content = verification_md.read_text()
+        assert "lake build exit code" in content
+        assert "grep sorry" in content
+        assert str(build.returncode) in content
+
+
+# ── Tier 3: full setup_lean_project.sh with Mathlib (slow) ───────────────────
+
+@pytest.fixture(scope="module")
+def mathlib_workspace(tmp_path_factory, lean_bin, lake_bin):
+    """
+    Run the actual setup_lean_project.sh to create a full Mathlib workspace.
+    This is slow (5-30 min on first run) — only used for lean_mathlib tests.
+    """
+    d = tmp_path_factory.mktemp("lean_mathlib")
+
+    result = _run(
+        ["bash", str(SETUP_SCRIPT)],
+        cwd=d,
+        timeout=3600,  # allow up to 1 hour for Mathlib cache download
+    )
+
+    if result.returncode != 0:
+        pytest.skip(
+            f"setup_lean_project.sh failed (no network? wrong toolchain?).\n"
+            f"stdout: {result.stdout[-2000:]}\nstderr: {result.stderr[-2000:]}"
+        )
+
+    lean_proofs = d / "lean_proofs"
+    if not lean_proofs.exists():
+        pytest.skip("setup_lean_project.sh ran but lean_proofs/ was not created")
+
+    return lean_proofs
+
+
+@pytest.mark.lean_mathlib
+@pytest.mark.slow
+class TestMathlibWorkflow:
+    """Full Mathlib integration — runs the actual setup script and proves a theorem."""
+
+    def test_project_structure_created(self, mathlib_workspace):
+        assert (mathlib_workspace / "lakefile.lean").exists()
+        assert (mathlib_workspace / "lean-toolchain").exists()
+        assert (mathlib_workspace / "LeanProofs").is_dir()
+        assert (mathlib_workspace / "LeanProofs" / "Definitions.lean").exists()
+        assert (mathlib_workspace / "LeanProofs" / "Lemmas.lean").exists()
+        assert (mathlib_workspace / "LeanProofs" / "MainTheorem.lean").exists()
+
+    def test_initial_build_succeeds(self, mathlib_workspace, lake_bin):
+        result = _run([lake_bin, "build"], cwd=mathlib_workspace, timeout=600)
+        assert result.returncode == 0, (
+            f"Initial Mathlib project build must succeed.\n"
+            f"stdout: {result.stdout[-1000:]}\nstderr: {result.stderr[-1000:]}"
+        )
+
+    def test_ring_tactic_proves_arithmetic(self, mathlib_workspace, lake_bin):
+        """ring is the canonical Mathlib automation tactic mentioned in SKILL.md."""
+        (mathlib_workspace / "LeanProofs" / "MainTheorem.lean").write_text(
+            textwrap.dedent("""\
+                import LeanProofs.Lemmas
+
+                namespace LeanProofs
+
+                -- Simple question: prove n^2 + 2n + 1 = (n+1)^2
+                theorem sq_expand (n : ℕ) : n ^ 2 + 2 * n + 1 = (n + 1) ^ 2 := by ring
+
+                end LeanProofs
+            """)
+        )
+        result = _run([lake_bin, "build"], cwd=mathlib_workspace, timeout=300)
+        assert result.returncode == 0, (
+            f"'ring' should prove n² + 2n + 1 = (n+1)².\n"
+            f"stdout: {result.stdout[-1000:]}\nstderr: {result.stderr[-1000:]}"
+        )
+
+    def test_norm_num_proves_concrete_fact(self, mathlib_workspace, lake_bin):
+        """norm_num is the Mathlib tactic for concrete numerical goals."""
+        (mathlib_workspace / "LeanProofs" / "MainTheorem.lean").write_text(
+            textwrap.dedent("""\
+                import LeanProofs.Lemmas
+
+                namespace LeanProofs
+
+                theorem two_pow_10 : (2 : ℕ) ^ 10 = 1024 := by norm_num
+
+                end LeanProofs
+            """)
+        )
+        result = _run([lake_bin, "build"], cwd=mathlib_workspace, timeout=300)
+        assert result.returncode == 0, (
+            f"norm_num should prove 2^10 = 1024.\n"
+            f"stdout: {result.stdout[-1000:]}\nstderr: {result.stderr[-1000:]}"
+        )
+
+    def test_mathlib_lemma_cite_works(self, mathlib_workspace, lake_bin):
+        """Citing Nat.add_comm by name (as the resource finder catalogs) must compile."""
+        (mathlib_workspace / "LeanProofs" / "MainTheorem.lean").write_text(
+            textwrap.dedent("""\
+                import LeanProofs.Lemmas
+
+                namespace LeanProofs
+
+                -- Cite a Mathlib lemma by name (as the resource finder catalogs it)
+                theorem comm_example (n m : ℕ) : n + m = m + n :=
+                  Nat.add_comm n m
+
+                end LeanProofs
+            """)
+        )
+        result = _run([lake_bin, "build"], cwd=mathlib_workspace, timeout=300)
+        assert result.returncode == 0, (
+            f"Nat.add_comm cited by name must compile.\n"
+            f"stdout: {result.stdout[-1000:]}\nstderr: {result.stderr[-1000:]}"
+        )
+
+    def test_sorry_and_grep_workflow(self, mathlib_workspace, lake_bin):
+        """End-to-end: sorry → lake build exits 0 → grep finds sorry → replace → clean."""
+        lean_dir = mathlib_workspace / "LeanProofs"
+        main = lean_dir / "MainTheorem.lean"
+
+        # Step 1: write sorry stub
+        main.write_text(textwrap.dedent("""\
+            import LeanProofs.Lemmas
+            namespace LeanProofs
+            theorem my_result (n : ℕ) : n ^ 2 + 2 * n + 1 = (n + 1) ^ 2 := by sorry
+            end LeanProofs
+        """))
+
+        build1 = _run([lake_bin, "build"], cwd=mathlib_workspace, timeout=300)
+        assert build1.returncode == 0, "sorry stub must exit 0"
+
+        grep1 = _run(["grep", "-r", "sorry", str(lean_dir)])
+        assert grep1.returncode == 0, "grep must find sorry in stub"
+
+        # Step 2: replace sorry with real proof
+        main.write_text(textwrap.dedent("""\
+            import LeanProofs.Lemmas
+            namespace LeanProofs
+            theorem my_result (n : ℕ) : n ^ 2 + 2 * n + 1 = (n + 1) ^ 2 := by ring
+            end LeanProofs
+        """))
+
+        build2 = _run([lake_bin, "build"], cwd=mathlib_workspace, timeout=300)
+        assert build2.returncode == 0, "completed proof must exit 0"
+
+        grep2 = _run(["grep", "-r", "sorry", str(lean_dir)])
+        assert grep2.returncode != 0, "grep must return non-zero when no sorry remains"

--- a/tests/test_lean_llm_smoke.py
+++ b/tests/test_lean_llm_smoke.py
@@ -1,0 +1,469 @@
+"""
+Lean pipeline smoke test with real LLM feedback.
+
+Bypasses all three pipeline stages except the core Lean proof loop:
+
+  ┌─────────────────────────────────────────────────────────────────┐
+  │  FULL PIPELINE          │  THIS TEST                            │
+  ├─────────────────────────┼───────────────────────────────────────┤
+  │  Stage 1: resource finder│  pre-supplied workspace (stub files)  │
+  │  Stage 2: expr runner   │  focused 5-step prompt, 15 min limit  │
+  │  Stage 3: paper writer  │  skipped                              │
+  └─────────────────────────┴───────────────────────────────────────┘
+
+What is actually tested:
+  1. setup_lean_project.sh runs successfully in the workspace
+  2. The LLM writes a valid .lean file with a specific theorem
+  3. lake build exits 0 (type checker accepts the proof)
+  4. grep -r "sorry" finds nothing (proof is complete, not stubbed)
+  5. The verification.md deliverable is produced
+
+Runtime:  ~10-15 min (Lean setup + first lake build + a few LLM turns)
+Cost:     ~$0.10-0.50 (a handful of Claude turns on a trivial problem)
+
+Not run by default — requires claude CLI and valid credentials.
+
+Run:
+    pytest tests/test_lean_llm_smoke.py -v -s
+
+Skip all LLM tests:
+    pytest -m "not lean_llm" tests/
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+TEMPLATES  = REPO_ROOT / "templates"
+
+
+# ── Pytest mark ───────────────────────────────────────────────────────────────
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "lean_llm: LLM smoke test — requires claude CLI + credentials, ~10-15 min"
+    )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _claude_available() -> bool:
+    return shutil.which("claude") is not None
+
+
+def _lean_available() -> bool:
+    return shutil.which("lean") is not None or shutil.which("elan") is not None
+
+
+def _build_prompt(work_dir: Path, theorem_name: str, theorem_body: str) -> str:
+    """Minimal focused prompt — exercises only the Lean proof loop, nothing else."""
+    return f"""\
+You are running a Lean 4 proof infrastructure smoke test.
+Work directory: {work_dir}
+
+Complete ONLY these steps, in order. Do nothing else.
+
+════════════════════════════════════════════════════════════════
+STEP 1 — Lean project setup
+════════════════════════════════════════════════════════════════
+
+Run the setup script. It installs elan/lean if absent and creates
+lean_proofs/ with Mathlib.Tactic:
+
+    bash .claude/skills/lean-prover/scripts/setup_lean_project.sh
+
+Wait for it to finish (lake build will run at the end of the script).
+If it succeeds, proceed. If it fails, write the error to
+results/lean_smoke_result.txt and stop.
+
+════════════════════════════════════════════════════════════════
+STEP 2 — Write the theorem
+════════════════════════════════════════════════════════════════
+
+Write EXACTLY this content to lean_proofs/LeanProofs/MainTheorem.lean
+(overwrite the starter file):
+
+import LeanProofs.Lemmas
+
+namespace LeanProofs
+
+{theorem_body}
+
+end LeanProofs
+
+════════════════════════════════════════════════════════════════
+STEP 3 — Verify with lake build
+════════════════════════════════════════════════════════════════
+
+Run:
+    cd lean_proofs && lake build 2>&1 | tail -20; cd ..
+
+Expected: exit code 0.
+If non-zero: the proof has a type error. Read the error, fix the .lean
+file, and rebuild. Try at most 3 times. Stop after 3 failures.
+
+════════════════════════════════════════════════════════════════
+STEP 4 — Confirm no sorry
+════════════════════════════════════════════════════════════════
+
+Run:
+    grep -r "sorry" lean_proofs/LeanProofs/ \\
+      && echo "INCOMPLETE — sorry found" \\
+      || echo "PROVED — no sorry"
+
+════════════════════════════════════════════════════════════════
+STEP 5 — Write result
+════════════════════════════════════════════════════════════════
+
+Create results/lean_smoke_result.txt with:
+- theorem name: {theorem_name}
+- lake build exit code: <value>
+- sorry check: PROVED or INCOMPLETE
+- lean version: output of `lean --version`
+
+That is all. Do not run any other commands or create any other files.
+"""
+
+
+# ── Workspace fixture ─────────────────────────────────────────────────────────
+
+@pytest.fixture
+def smoke_workspace(tmp_path):
+    """
+    Pre-created workspace that mimics what the resource finder would produce.
+    The experiment runner reads these files before starting; providing stubs
+    lets us skip Stage 1 entirely.
+    """
+    work_dir = tmp_path / "lean_smoke"
+    work_dir.mkdir()
+
+    # Directories the runner and agent expect
+    for d in ["logs", "results", "papers", "src"]:
+        (work_dir / d).mkdir()
+
+    # ── Stub resource finder outputs ─────────────────────────────────────────
+    (work_dir / "literature_review.md").write_text("""\
+# Literature Review (smoke test stub)
+
+## Research Area Overview
+Testing Lean 4 proof infrastructure for basic natural number arithmetic.
+
+## Key Definitions
+- ℕ: the natural numbers
+- Addition on ℕ is commutative
+
+## Mathlib Lemma Catalog
+| Informal Result      | Mathlib Name   | Verified? |
+|----------------------|----------------|-----------|
+| n + m = m + n        | Nat.add_comm   | ✓         |
+
+## Recommendations for Proof Strategy
+- Use `ring` tactic for arithmetic equalities (requires Mathlib.Tactic)
+- Alternatively: `Nat.add_comm n m` as an exact term proof
+""")
+
+    (work_dir / "resources.md").write_text("""\
+# Resources (smoke test stub)
+
+## Mathlib Prerequisites
+| Result          | Mathlib Name | Used For          |
+|-----------------|--------------|-------------------|
+| Commutativity + | Nat.add_comm | Main theorem proof |
+
+## Recommendations for Proof Construction
+1. Proof strategy: direct proof using ring tactic
+2. Mathlib lemmas to cite: Nat.add_comm
+3. Lemmas to prove from scratch: none
+""")
+
+    # ── Copy lean-prover skill (setup_lean_project.sh lives here) ────────────
+    skills_src = TEMPLATES / "skills"
+    skills_dst = work_dir / ".claude" / "skills"
+    skills_dst.mkdir(parents=True)
+    for skill_dir in skills_src.iterdir():
+        if skill_dir.is_dir():
+            shutil.copytree(skill_dir, skills_dst / skill_dir.name)
+
+    return work_dir
+
+
+# ── Main smoke test ───────────────────────────────────────────────────────────
+
+@pytest.mark.lean_llm
+class TestLeanLLMSmoke:
+
+    THEOREM_NAME = "add_comm_smoke"
+    THEOREM_BODY = (
+        "/-- Commutativity of addition on ℕ — proved by ring tactic. -/\n"
+        "theorem add_comm_smoke (a b : ℕ) : a + b = b + a := by ring"
+    )
+    TIMEOUT = 900  # 15 minutes
+
+    @pytest.fixture(autouse=True)
+    def require_claude(self):
+        if not _claude_available():
+            pytest.skip("claude CLI not found on PATH")
+
+    def _run_agent(self, work_dir: Path, prompt: str) -> subprocess.CompletedProcess:
+        """Launch claude -p with the smoke prompt, stream output."""
+        cmd = [
+            "claude", "-p",
+            "--dangerously-skip-permissions",
+            "--verbose",
+            "--output-format", "stream-json",
+        ]
+
+        log_file = work_dir / "logs" / "lean_smoke.log"
+        start = time.time()
+
+        with open(log_file, "w") as log_f:
+            proc = subprocess.Popen(
+                cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                cwd=str(work_dir),
+            )
+            proc.stdin.write(prompt)
+            proc.stdin.close()
+
+            for line in iter(proc.stdout.readline, ""):
+                if line:
+                    print(line, end="", flush=True)
+                    log_f.write(line)
+
+            try:
+                return_code = proc.wait(timeout=self.TIMEOUT)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                elapsed = time.time() - start
+                pytest.fail(
+                    f"Agent timed out after {elapsed:.0f}s "
+                    f"(limit: {self.TIMEOUT}s).\n"
+                    f"Log: {log_file}"
+                )
+
+        elapsed = time.time() - start
+        print(f"\n⏱  Agent finished in {elapsed:.0f}s (return code {return_code})")
+        return subprocess.CompletedProcess(cmd, return_code)
+
+    # ── Test 1: lean project setup ────────────────────────────────────────────
+
+    def test_lean_project_created(self, smoke_workspace):
+        """After the smoke run, lean_proofs/ must exist with the full structure."""
+        prompt = _build_prompt(smoke_workspace, self.THEOREM_NAME, self.THEOREM_BODY)
+        self._run_agent(smoke_workspace, prompt)
+
+        lean_proofs = smoke_workspace / "lean_proofs"
+        assert lean_proofs.exists(), (
+            "lean_proofs/ was not created — setup_lean_project.sh may have failed.\n"
+            f"Logs: {smoke_workspace / 'logs' / 'lean_smoke.log'}"
+        )
+        assert (lean_proofs / "lakefile.lean").exists(), "lakefile.lean missing"
+        assert (lean_proofs / "lean-toolchain").exists(), "lean-toolchain missing"
+        assert (lean_proofs / "LeanProofs").is_dir(), "LeanProofs/ directory missing"
+
+    # ── Test 2: theorem was written ───────────────────────────────────────────
+
+    def test_theorem_written_to_main_file(self, smoke_workspace):
+        """The agent must have written the theorem to MainTheorem.lean."""
+        prompt = _build_prompt(smoke_workspace, self.THEOREM_NAME, self.THEOREM_BODY)
+        self._run_agent(smoke_workspace, prompt)
+
+        main_theorem = smoke_workspace / "lean_proofs" / "LeanProofs" / "MainTheorem.lean"
+        assert main_theorem.exists(), "MainTheorem.lean not found"
+
+        content = main_theorem.read_text()
+        assert self.THEOREM_NAME in content, (
+            f"Theorem '{self.THEOREM_NAME}' not found in MainTheorem.lean.\n"
+            f"File content:\n{content}"
+        )
+
+    # ── Test 3: lake build passes ─────────────────────────────────────────────
+
+    def test_lake_build_exits_zero(self, smoke_workspace):
+        """After the agent run, independently verify lake build exits 0."""
+        prompt = _build_prompt(smoke_workspace, self.THEOREM_NAME, self.THEOREM_BODY)
+        self._run_agent(smoke_workspace, prompt)
+
+        lean_proofs = smoke_workspace / "lean_proofs"
+        if not lean_proofs.exists():
+            pytest.skip("lean_proofs/ not created — cannot verify lake build")
+
+        result = subprocess.run(
+            ["lake", "build"],
+            cwd=lean_proofs,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        assert result.returncode == 0, (
+            f"lake build failed after agent run (exit {result.returncode}).\n"
+            f"stdout: {result.stdout[-1000:]}\n"
+            f"stderr: {result.stderr[-1000:]}"
+        )
+
+    # ── Test 4: no sorry in final state ──────────────────────────────────────
+
+    def test_no_sorry_in_lean_files(self, smoke_workspace):
+        """The proof must be complete — no sorry placeholders remaining."""
+        prompt = _build_prompt(smoke_workspace, self.THEOREM_NAME, self.THEOREM_BODY)
+        self._run_agent(smoke_workspace, prompt)
+
+        lean_dir = smoke_workspace / "lean_proofs" / "LeanProofs"
+        if not lean_dir.exists():
+            pytest.skip("LeanProofs/ not created — cannot grep for sorry")
+
+        result = subprocess.run(
+            ["grep", "-r", "sorry", str(lean_dir)],
+            capture_output=True,
+            text=True,
+        )
+        # grep exits non-zero when nothing is found — that is what we want
+        assert result.returncode != 0, (
+            f"sorry found in lean files — proof is incomplete.\n"
+            f"Matches:\n{result.stdout}"
+        )
+
+    # ── Test 5: verification.md was produced ──────────────────────────────────
+
+    def test_verification_result_written(self, smoke_workspace):
+        """The agent must write results/lean_smoke_result.txt as instructed."""
+        prompt = _build_prompt(smoke_workspace, self.THEOREM_NAME, self.THEOREM_BODY)
+        self._run_agent(smoke_workspace, prompt)
+
+        result_file = smoke_workspace / "results" / "lean_smoke_result.txt"
+        assert result_file.exists(), (
+            "results/lean_smoke_result.txt not found — agent may not have "
+            "completed all steps.\n"
+            f"Logs: {smoke_workspace / 'logs' / 'lean_smoke.log'}"
+        )
+        content = result_file.read_text()
+        # Must contain the theorem name and a verdict
+        assert self.THEOREM_NAME in content or "PROVED" in content or "lake" in content, (
+            f"Result file exists but content looks wrong:\n{content}"
+        )
+
+
+# ── Consolidated run (one agent call, all assertions) ─────────────────────────
+
+@pytest.mark.lean_llm
+class TestLeanLLMSmokeConsolidated:
+    """
+    Single-agent-call variant: runs the agent ONCE and checks all assertions.
+    Use this to avoid 5 separate agent invocations if running the full class above.
+
+    Run:
+        pytest tests/test_lean_llm_smoke.py::TestLeanLLMSmokeConsolidated -v -s
+    """
+
+    THEOREM_NAME = "add_comm_smoke"
+    THEOREM_BODY = (
+        "/-- Commutativity of addition on ℕ — proved by ring tactic. -/\n"
+        "theorem add_comm_smoke (a b : ℕ) : a + b = b + a := by ring"
+    )
+    TIMEOUT = 900
+
+    @pytest.fixture(autouse=True)
+    def require_claude(self):
+        if not _claude_available():
+            pytest.skip("claude CLI not found on PATH")
+
+    @pytest.fixture(scope="class")
+    def completed_workspace(self, tmp_path_factory):
+        """Runs the agent ONCE; all tests in this class share the result."""
+        # Check here too — scope="class" runs before autouse method fixtures
+        if not _claude_available():
+            pytest.skip("claude CLI not found on PATH")
+
+        work_dir = tmp_path_factory.mktemp("lean_smoke_consolidated")
+        for d in ["logs", "results", "papers", "src"]:
+            (work_dir / d).mkdir()
+
+        # Stub resource finder files
+        (work_dir / "literature_review.md").write_text(
+            "# Stub\n\n## Mathlib Lemma Catalog\n"
+            "| n+m=m+n | Nat.add_comm | ✓ |\n"
+        )
+        (work_dir / "resources.md").write_text(
+            "# Stub\n\n## Mathlib Prerequisites\n"
+            "| Commutativity | Nat.add_comm | main proof |\n"
+        )
+
+        skills_src = TEMPLATES / "skills"
+        skills_dst = work_dir / ".claude" / "skills"
+        skills_dst.mkdir(parents=True)
+        for skill_dir in skills_src.iterdir():
+            if skill_dir.is_dir():
+                shutil.copytree(skill_dir, skills_dst / skill_dir.name)
+
+        # Run agent once
+        prompt = _build_prompt(work_dir, self.THEOREM_NAME, self.THEOREM_BODY)
+        cmd = [
+            "claude", "-p",
+            "--dangerously-skip-permissions",
+            "--verbose", "--output-format", "stream-json",
+        ]
+        log = work_dir / "logs" / "lean_smoke.log"
+        with open(log, "w") as log_f:
+            proc = subprocess.Popen(
+                cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT, text=True, cwd=str(work_dir),
+            )
+            proc.stdin.write(prompt)
+            proc.stdin.close()
+            for line in iter(proc.stdout.readline, ""):
+                if line:
+                    print(line, end="", flush=True)
+                    log_f.write(line)
+            try:
+                proc.wait(timeout=self.TIMEOUT)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                pytest.fail(f"Agent timed out. Log: {log}")
+
+        return work_dir
+
+    def test_lean_project_structure(self, completed_workspace):
+        lp = completed_workspace / "lean_proofs"
+        assert lp.exists(), "lean_proofs/ not created"
+        assert (lp / "lakefile.lean").exists()
+        assert (lp / "lean-toolchain").exists()
+        assert (lp / "LeanProofs").is_dir()
+
+    def test_theorem_in_main_file(self, completed_workspace):
+        f = completed_workspace / "lean_proofs" / "LeanProofs" / "MainTheorem.lean"
+        assert f.exists(), "MainTheorem.lean not found"
+        assert self.THEOREM_NAME in f.read_text()
+
+    def test_lake_build_passes(self, completed_workspace):
+        lp = completed_workspace / "lean_proofs"
+        if not lp.exists():
+            pytest.skip("lean_proofs/ absent")
+        r = subprocess.run(["lake", "build"], cwd=lp,
+                           capture_output=True, text=True, timeout=300)
+        assert r.returncode == 0, (
+            f"lake build failed\nstdout:{r.stdout[-500:]}\nstderr:{r.stderr[-500:]}"
+        )
+
+    def test_no_sorry_remaining(self, completed_workspace):
+        lean_dir = completed_workspace / "lean_proofs" / "LeanProofs"
+        if not lean_dir.exists():
+            pytest.skip("LeanProofs/ absent")
+        r = subprocess.run(["grep", "-r", "sorry", str(lean_dir)],
+                           capture_output=True, text=True)
+        assert r.returncode != 0, f"sorry found:\n{r.stdout}"
+
+    def test_result_file_written(self, completed_workspace):
+        f = completed_workspace / "results" / "lean_smoke_result.txt"
+        assert f.exists(), "lean_smoke_result.txt not written"
+        content = f.read_text()
+        assert len(content) > 20, f"Result file is too short:\n{content}"

--- a/tests/test_lean_resource_finder.py
+++ b/tests/test_lean_resource_finder.py
@@ -1,0 +1,415 @@
+"""
+Unit tests for the mathematics_lean resource finder template.
+
+The resource finder is the first agent in the pipeline. For mathematics_lean
+it has an extra Phase 3 (Mathlib Lemma Catalog) not present in other domains.
+These tests verify:
+
+  1. Domain override resolution  — mathematics_lean loads its own template
+  2. Template rendering          — idea content is injected; no bare {{ }}
+  3. Phase 3 (Mathlib catalog)   — heading, all four steps, naming conventions,
+                                   #check workflow, fallback guidance
+  4. Lean project boundary       — resource finder must NOT set up Lean project
+  5. Phase ordering              — 1 → 2 → 3 → 4 → 5 in rendered text
+  6. literature_review.md format — Mathlib Lemma Catalog section is specified
+  7. resources.md format         — Mathlib Prerequisites table is specified
+  8. Completion marker           — counts Mathlib lemmas (not just papers)
+  9. Differences from baselines  — generic and plain-math templates lack Phase 3
+"""
+
+import sys
+import re
+import pytest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from templates.prompt_generator import PromptGenerator
+
+TEMPLATES_DIR = REPO_ROOT / "templates"
+LEAN_RF_PATH  = TEMPLATES_DIR / "domains" / "mathematics_lean" / "resource_finder.txt"
+
+# ── Sample ideas ───────────────────────────────────────────────────────────────
+
+LEAN_IDEA = {
+    "idea": {
+        "title": "Formal verification of Ramsey-type bounds",
+        "domain": "mathematics_lean",
+        "hypothesis": "For every graph G with chromatic number > k, G contains K_{k+1} as a minor.",
+        "background": {},
+    }
+}
+
+MATH_IDEA = {
+    "idea": {
+        "title": "Ramsey bounds via probabilistic method",
+        "domain": "mathematics",
+        "hypothesis": "Same hypothesis — plain math domain.",
+        "background": {},
+    }
+}
+
+GENERIC_IDEA = {
+    "idea": {
+        "title": "A machine learning experiment",
+        "domain": "machine_learning",
+        "hypothesis": "Fine-tuning beats RAG for domain-specific tasks.",
+        "background": {},
+    }
+}
+
+
+@pytest.fixture
+def gen():
+    return PromptGenerator(TEMPLATES_DIR)
+
+
+@pytest.fixture
+def rendered(gen):
+    return gen.generate_resource_finder_prompt(LEAN_IDEA)
+
+
+@pytest.fixture
+def rendered_math(gen):
+    return gen.generate_resource_finder_prompt(MATH_IDEA)
+
+
+@pytest.fixture
+def rendered_generic(gen):
+    return gen.generate_resource_finder_prompt(GENERIC_IDEA)
+
+
+# ── 1. Domain override resolution ─────────────────────────────────────────────
+
+class TestDomainOverrideResolution:
+    def test_lean_override_file_exists(self):
+        assert LEAN_RF_PATH.exists(), f"Override not found: {LEAN_RF_PATH}"
+
+    def test_lean_template_differs_from_generic_fallback(self, gen):
+        lean    = gen._load_template_with_domain_override(
+            "agents/resource_finder.txt", "mathematics_lean"
+        )
+        generic = gen.load_template("agents/resource_finder.txt")
+        assert lean != generic
+
+    def test_lean_template_differs_from_plain_math(self, gen):
+        lean = gen._load_template_with_domain_override(
+            "agents/resource_finder.txt", "mathematics_lean"
+        )
+        math = gen._load_template_with_domain_override(
+            "agents/resource_finder.txt", "mathematics"
+        )
+        assert lean != math
+
+
+# ── 2. Template rendering ──────────────────────────────────────────────────────
+
+class TestTemplateRendering:
+    def test_no_jinja_placeholders_remain(self, rendered):
+        assert "{{" not in rendered and "}}" not in rendered
+
+    def test_idea_title_injected(self, rendered):
+        assert "Ramsey-type bounds" in rendered
+
+    def test_idea_hypothesis_injected(self, rendered):
+        assert "chromatic number" in rendered
+
+    def test_idea_domain_injected(self, rendered):
+        assert "mathematics_lean" in rendered
+
+    def test_result_is_substantial_string(self, rendered):
+        assert isinstance(rendered, str) and len(rendered) > 1000
+
+
+# ── 3. Phase 3 — Mathlib Lemma Catalog ────────────────────────────────────────
+
+class TestMathlibCatalogPhase:
+    def test_phase3_heading_present(self, rendered):
+        assert "PHASE 3" in rendered, "Phase 3 heading must be in rendered output"
+
+    def test_phase3_mathlib_label(self, rendered):
+        assert "MATHLIB" in rendered.upper() or "Mathlib Lemma Catalog" in rendered, (
+            "Phase 3 must be labelled as the Mathlib lemma catalog"
+        )
+
+    def test_phase3_step1_naming_conventions(self, rendered):
+        """Step 1 documents Mathlib naming conventions."""
+        assert "Nat." in rendered or "Nat.*" in rendered, (
+            "Mathlib Nat.* namespace convention must be documented"
+        )
+        assert "add_comm" in rendered, (
+            "Example lemma name (add_comm) must appear in naming conventions"
+        )
+
+    def test_phase3_step1_multiple_namespaces(self, rendered):
+        """Several type namespaces must be shown, not just Nat."""
+        for ns in ["Nat.", "Int.", "Real.", "Finset.", "List."]:
+            assert ns in rendered, f"Namespace '{ns}' missing from naming conventions"
+
+    def test_phase3_step2_hash_check_verification(self, rendered):
+        """Step 2 must show the #check approach for verifying lemma names."""
+        assert "#check" in rendered, (
+            "#check must be documented as the lemma-name verification tool"
+        )
+        assert "Nat.add_comm" in rendered, (
+            "A concrete #check example (Nat.add_comm) must be shown"
+        )
+
+    def test_phase3_step2_lean_scratch_file(self, rendered):
+        """Step 2 must show the lean_scratch / Check.lean workflow."""
+        assert "lean_scratch" in rendered, (
+            "lean_scratch directory must be part of the #check workflow"
+        )
+        assert "Check.lean" in rendered, (
+            "Check.lean scratch file must be shown in Phase 3 Step 2"
+        )
+
+    def test_phase3_step2_fallback_when_lean_unavailable(self, rendered):
+        """When lean binary is absent, web search is the documented fallback."""
+        assert "leanprover-community.github.io/mathlib4_docs" in rendered, (
+            "Web search fallback URL must be present for when lean is unavailable"
+        )
+
+    def test_phase3_step3_search_for_formalizations(self, rendered):
+        """Step 3 must instruct searching for existing Lean formalizations."""
+        lower = rendered.lower()
+        assert "lean formalization" in lower or "existing lean" in lower, (
+            "Phase 3 Step 3 must tell the agent to search for existing formalizations"
+        )
+
+    def test_phase3_step3_mathlib4_github_mentioned(self, rendered):
+        assert "leanprover-community/mathlib4" in rendered, (
+            "Mathlib4 GitHub URL must be referenced for formalization search"
+        )
+
+    def test_phase3_step4_lemma_table_format(self, rendered):
+        """Step 4 must show the Mathlib lemma table with the required columns."""
+        assert "Mathlib Name" in rendered, "Table column 'Mathlib Name' must be shown"
+        assert "Informal Result" in rendered or "Informal" in rendered, (
+            "Table column for informal result must be shown"
+        )
+        # Verified / Not in Mathlib status symbols
+        assert "✓" in rendered and "✗" in rendered, (
+            "Table must show ✓ (in Mathlib) and ✗ (not in Mathlib) status symbols"
+        )
+
+    def test_phase3_step4_table_has_concrete_examples(self, rendered):
+        """The table must contain at least one worked example row."""
+        assert "Nat.add_comm" in rendered or "Finset.sum_range_succ" in rendered, (
+            "Phase 3 Step 4 table must contain a concrete Mathlib lemma example"
+        )
+
+    def test_phase3_critical_label(self, rendered):
+        """Phase 3 must be marked as CRITICAL (it's unique to this domain)."""
+        # Find Phase 3 section and check nearby text
+        idx = rendered.upper().find("PHASE 3")
+        assert idx != -1
+        window = rendered[idx:idx + 300].upper()
+        assert "CRITICAL" in window, (
+            "Phase 3 must be labelled CRITICAL to signal its importance"
+        )
+
+
+# ── 4. Lean project boundary ───────────────────────────────────────────────────
+
+class TestLeanProjectBoundary:
+    def test_explicit_do_not_setup_lean(self, rendered):
+        """The resource finder must explicitly tell the agent NOT to set up Lean."""
+        lower = rendered.lower()
+        assert "do not set up the lean project" in lower or (
+            "do not" in lower and "lean" in lower and "setup" in lower
+        ) or "experiment runner" in lower and "lean setup" in lower.replace("\n", " "), (
+            "Resource finder must explicitly state Lean project setup is NOT its job"
+        )
+
+    def test_no_lake_build_in_resource_finder(self, rendered):
+        """lake build must NOT be a primary instruction — that belongs to the
+        experiment runner. Only the lean_scratch verification snippet may run lean."""
+        # lake build should not appear as a primary step
+        # It may appear inside the scratch-file snippet (lean lean_scratch/...)
+        # but should NOT appear as a phase instruction
+        occurrences = [m.start() for m in re.finditer(r"lake build", rendered)]
+        # If it appears at all, it must only be inside the scratch-file context
+        # (i.e. not as a standalone phase step)
+        for pos in occurrences:
+            window = rendered[max(0, pos - 100):pos + 100]
+            assert "scratch" in window.lower() or "setup" in window.lower() or \
+                   "verify" in window.lower(), (
+                "'lake build' should only appear in a scratch/verification context "
+                "inside the resource finder, not as a phase instruction"
+            )
+
+    def test_experiment_runner_owns_lean_setup(self, rendered):
+        """The boundary must explicitly name the experiment runner as owner."""
+        assert "experiment runner" in rendered.lower(), (
+            "Resource finder must reference the experiment runner as responsible for Lean setup"
+        )
+
+    def test_dont_list_mentions_lean_project(self, rendered):
+        """The DON'T list must warn against setting up the Lean project."""
+        lower = rendered.lower()
+        assert "don't" in lower or "dont" in lower or "✗" in rendered, (
+            "A DON'T / best-practice list must exist"
+        )
+        # The lean-project warning must exist somewhere
+        assert "lean project" in lower or ("set up" in lower and "lean" in lower), (
+            "DON'T list must warn against setting up the Lean project"
+        )
+
+
+# ── 5. Phase ordering ─────────────────────────────────────────────────────────
+
+class TestPhaseOrdering:
+    """Phases must appear in the correct order in the rendered text."""
+
+    def _phase_position(self, rendered: str, n: int) -> int:
+        match = re.search(rf"PHASE {n}[^0-9]", rendered)
+        assert match, f"PHASE {n} not found in rendered output"
+        return match.start()
+
+    def test_phase1_before_phase2(self, rendered):
+        assert self._phase_position(rendered, 1) < self._phase_position(rendered, 2)
+
+    def test_phase2_before_phase3(self, rendered):
+        assert self._phase_position(rendered, 2) < self._phase_position(rendered, 3)
+
+    def test_phase3_before_phase4(self, rendered):
+        assert self._phase_position(rendered, 3) < self._phase_position(rendered, 4)
+
+    def test_phase4_before_phase5(self, rendered):
+        assert self._phase_position(rendered, 4) < self._phase_position(rendered, 5)
+
+    def test_phase3_is_mathlib_not_tools(self, rendered):
+        """Phase 3 must be the Mathlib catalog, Phase 4 must be computational tools."""
+        p3_start = self._phase_position(rendered, 3)
+        p4_start = self._phase_position(rendered, 4)
+        phase3_text = rendered[p3_start:p4_start].upper()
+        assert "MATHLIB" in phase3_text, (
+            "Phase 3 content must be about Mathlib, not computational tools"
+        )
+
+    def test_phase4_is_computational_tools(self, rendered):
+        p4_start = self._phase_position(rendered, 4)
+        p5_start = self._phase_position(rendered, 5)
+        phase4_text = rendered[p4_start:p5_start].upper()
+        assert "TOOL" in phase4_text or "SYMPY" in phase4_text or "PYTHON" in phase4_text, (
+            "Phase 4 content must be about computational tools"
+        )
+
+
+# ── 6. literature_review.md output format ─────────────────────────────────────
+
+class TestLiteratureReviewFormat:
+    def test_mathlib_lemma_catalog_section_specified(self, rendered):
+        """The literature_review.md template must include a Mathlib Lemma Catalog section."""
+        assert "Mathlib Lemma Catalog" in rendered, (
+            "literature_review.md format must include a 'Mathlib Lemma Catalog' section"
+        )
+
+    def test_existing_lean_formalizations_section_specified(self, rendered):
+        assert "Existing Lean Formalizations" in rendered, (
+            "literature_review.md format must include 'Existing Lean Formalizations' section"
+        )
+
+    def test_recommendations_split_mathlib_vs_scratch(self, rendered):
+        """Recommendations must distinguish 'cite from Mathlib' vs 'prove from scratch'."""
+        lower = rendered.lower()
+        assert "cite" in lower and "mathlib" in lower, (
+            "Recommendations section must mention citing from Mathlib"
+        )
+        assert "prove from scratch" in lower or "prove" in lower and "scratch" in lower, (
+            "Recommendations section must mention what must be proved from scratch"
+        )
+
+    def test_lean_tactics_mentioned_in_recommendations(self, rendered):
+        """The proof strategy recommendation must mention Lean tactics."""
+        lower = rendered.lower()
+        assert "lean tactic" in lower or "tactic" in lower, (
+            "Recommendations must mention Lean tactics likely useful for each step"
+        )
+
+
+# ── 7. resources.md format ────────────────────────────────────────────────────
+
+class TestResourcesMdFormat:
+    def test_mathlib_prerequisites_table_specified(self, rendered):
+        assert "Mathlib Prerequisites" in rendered, (
+            "resources.md format must include a 'Mathlib Prerequisites' table"
+        )
+
+    def test_mathlib_prerequisites_table_has_columns(self, rendered):
+        """The Mathlib Prerequisites table must have the right columns."""
+        assert "Mathlib Name" in rendered, "Column 'Mathlib Name' must appear in table"
+        assert "Used For" in rendered, "Column 'Used For' must appear in table"
+
+    def test_recommendations_split_cite_vs_prove(self, rendered):
+        """resources.md recommendations must split Mathlib cites from scratch proofs."""
+        assert "Mathlib lemmas to cite" in rendered or (
+            "cite directly" in rendered.lower()
+        ), "Recommendations must list Mathlib lemmas to cite"
+        assert "proved from scratch" in rendered.lower() or (
+            "prove from scratch" in rendered.lower()
+        ), "Recommendations must list lemmas to prove from scratch"
+
+
+# ── 8. Completion marker ──────────────────────────────────────────────────────
+
+class TestCompletionMarker:
+    def test_completion_marker_file_present(self, rendered):
+        assert ".resource_finder_complete" in rendered, (
+            "Completion marker file must be mentioned"
+        )
+
+    def test_completion_marker_counts_mathlib_lemmas(self, rendered):
+        """The marker must record Mathlib lemma count, not just papers."""
+        assert "Mathlib lemmas identified" in rendered, (
+            "Completion marker must count Mathlib lemmas found, "
+            "not just papers downloaded"
+        )
+
+    def test_final_checklist_includes_mathlib_check(self, rendered):
+        """The final checklist must include a Mathlib-specific verification step."""
+        lower = rendered.lower()
+        assert "#check" in rendered and "checklist" in lower or (
+            "mathlib lemma" in lower and ("✓" in rendered or "verified" in lower)
+        ), "Final checklist must include the Mathlib lemma #check step"
+
+
+# ── 9. Differences from baselines ─────────────────────────────────────────────
+
+class TestBaselineDifferences:
+    def test_phase3_absent_from_generic_resource_finder(self, rendered_generic):
+        """Generic (ML) resource finder must NOT have the Mathlib catalog phase."""
+        assert "Mathlib Lemma Catalog" not in rendered_generic, (
+            "Mathlib Lemma Catalog must be unique to mathematics_lean"
+        )
+        assert "#check" not in rendered_generic, (
+            "#check verification must be absent from generic resource finder"
+        )
+
+    def test_phase3_absent_from_plain_math_resource_finder(self, rendered_math):
+        """Plain mathematics resource finder must NOT have Phase 3 Mathlib catalog."""
+        assert "Mathlib Lemma Catalog" not in rendered_math, (
+            "Mathlib Lemma Catalog must be unique to mathematics_lean, not plain mathematics"
+        )
+
+    def test_lean_domain_has_more_mathlib_references(self, rendered, rendered_math):
+        lean_count = rendered.count("Mathlib")
+        math_count = rendered_math.count("Mathlib")
+        assert lean_count > math_count, (
+            f"mathematics_lean ({lean_count} refs) should mention Mathlib more "
+            f"than plain mathematics ({math_count} refs)"
+        )
+
+    def test_do_not_setup_lean_absent_from_plain_math(self, rendered_math):
+        """The specific 'Do NOT set up the Lean project here' boundary note
+        must not appear in the plain mathematics resource finder."""
+        lower = rendered_math.lower()
+        # The exact boundary phrase unique to mathematics_lean
+        assert "do not set up the lean project" not in lower and (
+            "experiment runner phase handles lean setup" not in lower
+        ), (
+            "The Lean-project boundary note should only appear in mathematics_lean, "
+            "not in plain mathematics"
+        )

--- a/tests/test_lean_session_instructions.py
+++ b/tests/test_lean_session_instructions.py
@@ -1,0 +1,277 @@
+"""
+Unit tests for the mathematics_lean domain session instructions template.
+
+Tests cover:
+  1. Domain override resolution  — the correct template file is loaded
+  2. Template rendering          — all Jinja2 variables are substituted
+  3. Lean content presence       — key Lean workflow phrases exist in output
+  4. Lean-as-verifier framing    — lake build is the verification signal,
+                                   not just a Python check
+  5. Python-exploration framing  — Python/SymPy is present but scoped to
+                                   exploration, NOT proof validity
+  6. No unrendered placeholders  — no {{ ... }} tokens remain in output
+"""
+
+import sys
+import pytest
+from pathlib import Path
+
+# Make src/ importable without an install
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from templates.prompt_generator import PromptGenerator
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+TEMPLATES_DIR = REPO_ROOT / "templates"
+
+SAMPLE_PROMPT = (
+    "Prove that for every n ≥ 1 the sum of the first n odd numbers equals n²."
+)
+SAMPLE_WORK_DIR = "/workspaces/test-lean-workspace"
+
+
+@pytest.fixture
+def generator():
+    return PromptGenerator(TEMPLATES_DIR)
+
+
+@pytest.fixture
+def rendered(generator):
+    """Rendered session instructions for the mathematics_lean domain."""
+    return generator.generate_session_instructions(
+        prompt=SAMPLE_PROMPT,
+        work_dir=SAMPLE_WORK_DIR,
+        use_scribe=False,
+        domain="mathematics_lean",
+    )
+
+
+@pytest.fixture
+def rendered_scribe(generator):
+    """Rendered session instructions with use_scribe=True (notebook mode)."""
+    return generator.generate_session_instructions(
+        prompt=SAMPLE_PROMPT,
+        work_dir=SAMPLE_WORK_DIR,
+        use_scribe=True,
+        domain="mathematics_lean",
+    )
+
+
+@pytest.fixture
+def rendered_generic(generator):
+    """Rendered session instructions for the plain mathematics domain (baseline)."""
+    return generator.generate_session_instructions(
+        prompt=SAMPLE_PROMPT,
+        work_dir=SAMPLE_WORK_DIR,
+        use_scribe=False,
+        domain="mathematics",
+    )
+
+
+# ── 1. Domain override resolution ─────────────────────────────────────────────
+
+class TestDomainOverrideResolution:
+    def test_lean_template_is_loaded_not_generic(self, generator):
+        """_load_template_with_domain_override picks mathematics_lean over agents/ fallback."""
+        lean_content = generator._load_template_with_domain_override(
+            "agents/session_instructions.txt", "mathematics_lean"
+        )
+        generic_content = generator.load_template("agents/session_instructions.txt")
+
+        # The two templates must be different files
+        assert lean_content != generic_content, (
+            "mathematics_lean should have its own session_instructions.txt override"
+        )
+
+    def test_lean_override_file_exists(self):
+        override_path = TEMPLATES_DIR / "domains" / "mathematics_lean" / "session_instructions.txt"
+        assert override_path.exists(), (
+            f"Override template not found at {override_path}"
+        )
+
+    def test_mathematics_domain_uses_different_template(self, generator):
+        """mathematics and mathematics_lean load distinct session instructions."""
+        lean = generator._load_template_with_domain_override(
+            "agents/session_instructions.txt", "mathematics_lean"
+        )
+        math = generator._load_template_with_domain_override(
+            "agents/session_instructions.txt", "mathematics"
+        )
+        assert lean != math, (
+            "mathematics_lean session_instructions must differ from mathematics"
+        )
+
+
+# ── 2. Template rendering (variable substitution) ─────────────────────────────
+
+class TestTemplateRendering:
+    def test_no_jinja_placeholders_remain(self, rendered):
+        """No {{ variable }} tokens should survive rendering."""
+        assert "{{" not in rendered, "Unrendered Jinja2 opening tag found"
+        assert "}}" not in rendered, "Unrendered Jinja2 closing tag found"
+
+    def test_work_dir_injected(self, rendered):
+        assert SAMPLE_WORK_DIR in rendered, (
+            "work_dir value should appear in rendered output"
+        )
+
+    def test_research_prompt_injected(self, rendered):
+        assert SAMPLE_PROMPT in rendered, (
+            "The research prompt should be embedded in session instructions"
+        )
+
+    def test_renders_as_string(self, rendered):
+        assert isinstance(rendered, str) and len(rendered) > 500, (
+            "Rendered output should be a non-trivial string"
+        )
+
+    def test_scribe_mode_differs_from_script_mode(self, rendered, rendered_scribe):
+        """use_scribe=True should change the code_workflow injection."""
+        assert rendered != rendered_scribe, (
+            "Scribe and non-scribe renders should differ"
+        )
+
+    def test_scribe_mode_mentions_notebooks(self, rendered_scribe):
+        assert "notebook" in rendered_scribe.lower(), (
+            "Scribe mode should reference Jupyter notebooks"
+        )
+
+    def test_script_mode_mentions_scripts(self, rendered):
+        assert "script" in rendered.lower() or "src/" in rendered, (
+            "Non-scribe mode should reference Python scripts or src/"
+        )
+
+
+# ── 3. Lean content presence ──────────────────────────────────────────────────
+
+class TestLeanContentPresence:
+    @pytest.mark.parametrize("phrase", [
+        "lake build",
+        "lean_proofs",
+        "sorry",
+        "elan",
+        "lake-manifest",   # referenced in Phase 4 verification step
+        "Mathlib",
+        "LeanProofs",
+    ])
+    def test_lean_phrase_present(self, rendered, phrase):
+        assert phrase in rendered, (
+            f"Expected Lean phrase '{phrase}' not found in rendered output"
+        )
+
+    def test_phase_lean_setup_present(self, rendered):
+        """Phase 2 should contain Lean/elan setup instructions."""
+        assert "Phase 2" in rendered, "Phase 2 heading missing"
+        # elan or lean setup should appear somewhere in the text
+        assert "elan" in rendered or "lean-prover" in rendered, (
+            "Phase 2 should reference Lean/elan setup"
+        )
+
+    def test_phase_proof_construction_present(self, rendered):
+        assert "Phase 3" in rendered, "Phase 3 heading missing"
+
+    def test_phase_verification_present(self, rendered):
+        assert "Phase 4" in rendered, "Phase 4 heading missing"
+
+    def test_skill_script_referenced(self, rendered):
+        """The setup_lean_project.sh skill script should be mentioned."""
+        assert "setup_lean_project.sh" in rendered or "lean-prover" in rendered, (
+            "Lean setup script or skill should be referenced"
+        )
+
+    def test_grep_sorry_check_present(self, rendered):
+        """The grep-for-sorry completion check must be in the output."""
+        assert "grep" in rendered and "sorry" in rendered, (
+            "Completion check via 'grep sorry' should be present"
+        )
+
+    def test_lake_build_exit_code_mentioned(self, rendered):
+        """Exit code semantics (how to interpret lake build result) should appear."""
+        lower = rendered.lower()
+        assert "exit" in lower or "exit code" in lower or "exit 0" in lower, (
+            "lake build exit code interpretation should be mentioned"
+        )
+
+
+# ── 4. Lean-as-verifier framing ────────────────────────────────────────────────
+
+class TestLeanAsVerifier:
+    def test_lake_build_is_ground_truth(self, rendered):
+        """'lake build' should appear multiple times — it's the core feedback loop."""
+        count = rendered.count("lake build")
+        assert count >= 2, (
+            f"'lake build' appears only {count} time(s); expected ≥2 as the repeated verification step"
+        )
+
+    def test_sorry_is_incomplete_signal(self, rendered):
+        """sorry should be framed as an incompleteness marker, not a valid proof."""
+        # The instructions should warn that sorry means incomplete
+        assert "sorry" in rendered
+        # Some negative framing around sorry
+        lower = rendered.lower()
+        assert any(phrase in lower for phrase in [
+            "no sorry",
+            "not a proof",
+            "incomplete",
+            "remains",
+            "sorry warning",
+        ]), "sorry should be framed as an incompleteness signal"
+
+    def test_proof_complete_condition_is_lake_build(self, rendered):
+        """The proof completion signal should be lake build exit 0 + no sorry."""
+        assert "exit 0" in rendered or "exits 0" in rendered or "exit code" in rendered.lower(), (
+            "Proof completion should be tied to lake build exit code"
+        )
+
+
+# ── 5. Python-exploration framing ─────────────────────────────────────────────
+
+class TestPythonExplorationFraming:
+    def test_python_present_but_scoped(self, rendered):
+        """Python/SymPy should appear but be labelled as exploration, not verification."""
+        assert "Python" in rendered or "SymPy" in rendered or "sympy" in rendered, (
+            "Python tools should still be mentioned for conjecture exploration"
+        )
+
+    def test_python_not_sole_verifier(self, rendered):
+        """Python should not be described as the proof verification tool."""
+        lower = rendered.lower()
+        # The word 'verify' near 'python' should not be the primary framing
+        # Lean / lake build should be the verification path
+        assert "lake build" in rendered, (
+            "lake build must be present as the actual verification mechanism"
+        )
+
+    def test_exploration_label_near_python(self, rendered):
+        """Python usage should be labelled exploratory."""
+        lower = rendered.lower()
+        assert "explor" in lower, (
+            "Python role should be labelled as 'exploration' or 'exploratory'"
+        )
+
+
+# ── 6. mathematics_lean differs from mathematics baseline ─────────────────────
+
+class TestDifferenceFromMathematicsDomain:
+    def test_lean_specific_content_absent_from_math_domain(self, rendered_generic):
+        """The plain mathematics template should NOT mention lake build."""
+        assert "lake build" not in rendered_generic, (
+            "lake build should not appear in the plain mathematics domain output"
+        )
+
+    def test_lean_domain_output_longer_or_different(self, rendered, rendered_generic):
+        """mathematics_lean output should be meaningfully different from mathematics."""
+        assert rendered != rendered_generic, (
+            "mathematics_lean and mathematics should produce different session instructions"
+        )
+
+    def test_lean_domain_has_more_lean_references(self, rendered, rendered_generic):
+        lean_count = rendered.lower().count("lean")
+        math_count = rendered_generic.lower().count("lean")
+        assert lean_count > math_count, (
+            f"mathematics_lean output ({lean_count} 'lean' refs) should mention "
+            f"Lean more than mathematics output ({math_count} refs)"
+        )

--- a/tests/test_lean_skill.py
+++ b/tests/test_lean_skill.py
@@ -1,0 +1,488 @@
+"""
+Unit tests for the lean-prover skill.
+
+Covers three components:
+  1. SKILL.md structure & content
+       — frontmatter validity, required sections, tactic table,
+         verification workflow, error message table
+  2. setup_lean_project.sh content
+       — safety flags, elan conditional install, file structure
+         it creates, cache step ordering, argument handling
+  3. Cross-file consistency
+       — names and paths referenced in SKILL.md match what the
+         script actually produces; setup command in SKILL.md
+         points at a file that exists on disk
+  4. Workspace copy
+       — _copy_workspace_resources copies both files into
+         .claude/skills/lean-prover/ as the agent expects
+"""
+
+import os
+import re
+import shutil
+import stat
+import sys
+import tempfile
+import yaml
+import pytest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+SKILL_DIR    = REPO_ROOT / "templates" / "skills" / "lean-prover"
+SKILL_MD     = SKILL_DIR / "SKILL.md"
+SETUP_SCRIPT = SKILL_DIR / "scripts" / "setup_lean_project.sh"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def parse_frontmatter(path: Path) -> dict:
+    """Return the YAML frontmatter dict from a file with --- delimiters."""
+    text = path.read_text()
+    lines = text.splitlines()
+    if lines[0].strip() != "---":
+        return {}
+    end = next(i for i, l in enumerate(lines[1:], 1) if l.strip() == "---")
+    return yaml.safe_load("\n".join(lines[1:end]))
+
+
+def markdown_sections(path: Path) -> list[str]:
+    """Return list of section heading strings (stripped of # prefix)."""
+    return [
+        line.lstrip("#").strip()
+        for line in path.read_text().splitlines()
+        if line.startswith("#")
+    ]
+
+
+def script_text() -> str:
+    return SETUP_SCRIPT.read_text()
+
+
+# ── 1. SKILL.md — frontmatter ─────────────────────────────────────────────────
+
+class TestSkillFrontmatter:
+    def test_frontmatter_is_valid_yaml(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert isinstance(fm, dict), "Frontmatter must parse as a YAML mapping"
+
+    def test_name_field_present(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert "name" in fm, "Frontmatter must have a 'name' field"
+
+    def test_name_matches_directory(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert fm["name"] == "lean-prover", (
+            f"name '{fm['name']}' does not match directory name 'lean-prover'"
+        )
+
+    def test_description_field_present(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert "description" in fm and fm["description"], (
+            "Frontmatter must have a non-empty 'description' field"
+        )
+
+    def test_description_mentions_lean4(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert "Lean 4" in fm["description"] or "Lean4" in fm["description"], (
+            "description should explicitly mention 'Lean 4'"
+        )
+
+    def test_description_mentions_mathlib(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert "Mathlib" in fm["description"], (
+            "description should mention 'Mathlib'"
+        )
+
+    def test_description_mentions_mathematics_lean_domain(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert "mathematics_lean" in fm["description"], (
+            "description should reference the 'mathematics_lean' domain"
+        )
+
+
+# ── 2. SKILL.md — required sections ──────────────────────────────────────────
+
+REQUIRED_SECTIONS = [
+    "When to Use",
+    "Project Setup",
+    "Project Structure",
+    "Writing Proofs",
+    "Core Tactic Reference",
+    "Searching Mathlib",
+    "Verification Workflow",
+    "Interpreting Lean Error Messages",
+    "Proof Skeleton Template",
+    "Common Mathlib Imports by Area",
+]
+
+class TestSkillSections:
+    @pytest.mark.parametrize("section", REQUIRED_SECTIONS)
+    def test_required_section_exists(self, section):
+        sections = markdown_sections(SKILL_MD)
+        # Allow the heading to have a suffix (e.g. "Verification Workflow (Per Proof)")
+        assert any(s.startswith(section) for s in sections), (
+            f"Required section '{section}' not found in SKILL.md.\n"
+            f"Found sections: {sections}"
+        )
+
+    def test_when_to_use_mentions_mathematics_lean(self):
+        text = SKILL_MD.read_text()
+        # Find the When to Use section content
+        assert "mathematics_lean" in text, (
+            "'mathematics_lean' domain should appear in When to Use section"
+        )
+
+    def test_setup_script_path_in_skill_md(self):
+        """The path referenced in SKILL.md for the setup script must exist."""
+        text = SKILL_MD.read_text()
+        # The skill references: .claude/skills/lean-prover/scripts/setup_lean_project.sh
+        assert "setup_lean_project.sh" in text, (
+            "SKILL.md must reference the setup script"
+        )
+        # The actual file must also exist at the template level
+        assert SETUP_SCRIPT.exists(), (
+            f"setup_lean_project.sh not found at {SETUP_SCRIPT}"
+        )
+
+
+# ── 3. SKILL.md — tactic table ────────────────────────────────────────────────
+
+# Automation tactics the agent should try first (they appear most often)
+AUTOMATION_TACTICS = ["ring", "omega", "linarith", "norm_num", "simp", "decide"]
+# Manual tactics for structural proofs
+STRUCTURAL_TACTICS = ["exact", "apply", "rw", "intro", "cases", "induction", "by_contra", "use"]
+# Tactics that only work interactively — must be flagged as such
+INTERACTIVE_ONLY_TACTICS = ["exact?", "apply?", "simp?"]
+
+class TestTacticTable:
+    @pytest.mark.parametrize("tactic", AUTOMATION_TACTICS)
+    def test_automation_tactic_present(self, tactic):
+        assert f"`{tactic}`" in SKILL_MD.read_text(), (
+            f"Automation tactic '{tactic}' missing from tactic table"
+        )
+
+    @pytest.mark.parametrize("tactic", STRUCTURAL_TACTICS)
+    def test_structural_tactic_present(self, tactic):
+        text = SKILL_MD.read_text()
+        assert f"`{tactic}`" in text or f"`{tactic} " in text, (
+            f"Structural tactic '{tactic}' missing from tactic table"
+        )
+
+    @pytest.mark.parametrize("tactic", INTERACTIVE_ONLY_TACTICS)
+    def test_interactive_tactic_flagged(self, tactic):
+        text = SKILL_MD.read_text()
+        assert tactic in text, f"Interactive tactic '{tactic}' not mentioned"
+        # Must be accompanied by a warning that it's interactive-only
+        assert "Interactive only" in text or "interactive" in text.lower(), (
+            f"Interactive-only tactic '{tactic}' must be flagged as interactive-only"
+        )
+
+
+# ── 4. SKILL.md — verification workflow ──────────────────────────────────────
+
+class TestVerificationWorkflow:
+    def test_lake_build_command_shown(self):
+        assert "lake build" in SKILL_MD.read_text()
+
+    def test_grep_sorry_command_shown(self):
+        text = SKILL_MD.read_text()
+        assert "grep" in text and "sorry" in text, (
+            "Verification workflow must show the grep-sorry completion check"
+        )
+
+    def test_exit_code_semantics_documented(self):
+        text = SKILL_MD.read_text()
+        # Both outcomes must be documented
+        assert "exit code" in text.lower() or ("0" in text and "non-zero" in text), (
+            "lake build exit code semantics (0 vs non-zero) must be documented"
+        )
+
+    def test_sorry_declaration_warning_documented(self):
+        """'declaration uses sorry' is the Lean warning agents will see most often."""
+        assert "declaration uses sorry" in SKILL_MD.read_text(), (
+            "'declaration uses sorry' must appear in the error message table"
+        )
+
+    def test_stub_then_prove_workflow_documented(self):
+        """The sorry-stub → build → replace workflow must be present."""
+        text = SKILL_MD.read_text()
+        assert "sorry" in text
+        # The workflow shows using sorry first to check the type, then replacing
+        assert "stub" in text.lower() or "placeholder" in text.lower() or (
+            "sorry" in text and "replace" in text.lower()
+        ), "Sorry-stub workflow (use sorry first, then replace) must be documented"
+
+
+# ── 5. SKILL.md — error message table ────────────────────────────────────────
+
+REQUIRED_ERRORS = [
+    "unknown identifier",
+    "type mismatch",
+    "unsolved goals",
+    "declaration uses sorry",
+    "failed to synthesize instance",
+]
+
+class TestErrorMessageTable:
+    @pytest.mark.parametrize("error", REQUIRED_ERRORS)
+    def test_error_message_documented(self, error):
+        assert error in SKILL_MD.read_text(), (
+            f"Error message '{error}' not documented in SKILL.md"
+        )
+
+
+# ── 6. setup_lean_project.sh — safety & structure ────────────────────────────
+
+class TestSetupScriptSafety:
+    def test_shebang_is_env_bash(self):
+        first_line = SETUP_SCRIPT.read_text().splitlines()[0]
+        assert first_line == "#!/usr/bin/env bash", (
+            f"Script must start with '#!/usr/bin/env bash', got: '{first_line}'"
+        )
+
+    def test_errexit_set(self):
+        assert "set -euo pipefail" in script_text(), (
+            "Script must have 'set -euo pipefail' for safety"
+        )
+
+    def test_elan_install_is_conditional(self):
+        text = script_text()
+        # elan installation must be inside an if block, not unconditional
+        assert "command -v elan" in text or "command -v lean" in text, (
+            "Script must check if elan/lean is already installed before installing"
+        )
+
+    def test_cache_step_before_build(self):
+        text = script_text()
+        cache_pos = text.find("cache get")
+        build_pos = text.find("lake build")
+        assert cache_pos != -1, "Script must call 'lake exe cache get'"
+        assert build_pos != -1, "Script must call 'lake build'"
+        assert cache_pos < build_pos, (
+            "Cache download must happen before the initial lake build"
+        )
+
+    def test_build_failure_exits_nonzero(self):
+        text = script_text()
+        assert "exit 1" in text, (
+            "Script must exit 1 if lake build fails (not silently succeed)"
+        )
+
+    def test_accepts_custom_project_dir_argument(self):
+        text = script_text()
+        # PROJECT_DIR="${1:-lean_proofs}" pattern
+        assert '${1:-' in text or '"$1"' in text, (
+            "Script must accept a custom project directory as $1"
+        )
+
+    def test_default_project_dir_is_lean_proofs(self):
+        text = script_text()
+        assert '"${1:-lean_proofs}"' in text or "lean_proofs}" in text, (
+            "Default project directory must be 'lean_proofs'"
+        )
+
+
+# ── 7. setup_lean_project.sh — file structure created ────────────────────────
+
+class TestSetupScriptFileStructure:
+    def test_creates_definitions_lean(self):
+        assert "Definitions.lean" in script_text()
+
+    def test_creates_lemmas_lean(self):
+        assert "Lemmas.lean" in script_text()
+
+    def test_creates_main_theorem_lean(self):
+        assert "MainTheorem.lean" in script_text()
+
+    def test_lib_name_is_LeanProofs(self):
+        assert 'LIB_NAME="LeanProofs"' in script_text(), (
+            "Library name must be 'LeanProofs'"
+        )
+
+    def test_root_import_file_created(self):
+        text = script_text()
+        # The root import file uses the $LIB_NAME shell variable, so the
+        # script contains "${LIB_NAME}.Definitions" rather than the literal
+        # expanded form.  Check for the variable-expanded pattern.
+        assert "${LIB_NAME}.Definitions" in text or "LeanProofs.Definitions" in text
+        assert "${LIB_NAME}.Lemmas" in text      or "LeanProofs.Lemmas" in text
+        assert "${LIB_NAME}.MainTheorem" in text or "LeanProofs.MainTheorem" in text
+
+    def test_starter_files_are_idempotent(self):
+        """Files should only be written if they don't already exist."""
+        text = script_text()
+        # Each write should be guarded by [ ! -f ... ]
+        assert '[ ! -f' in text or "! -f" in text, (
+            "Starter file creation must be guarded against overwriting existing files"
+        )
+
+    def test_definitions_lean_imports_mathlib_tactic(self):
+        """Definitions.lean starter must use import Mathlib.Tactic (not full import Mathlib).
+        Mathlib.Tactic provides all tactics at ~1-2GB cache cost vs 5GB for import Mathlib."""
+        text = script_text()
+        assert "import Mathlib.Tactic" in text, (
+            "Starter file must use 'import Mathlib.Tactic', not bare 'import Mathlib'"
+        )
+
+    def test_definitions_lean_does_not_use_bare_import_mathlib(self):
+        """Bare 'import Mathlib' must not appear in the starter Definitions.lean heredoc —
+        it triggers a full 5GB cache download unnecessarily."""
+        text = script_text()
+        # Find the heredoc block for Definitions.lean
+        start = text.find("Definitions.lean")
+        heredoc_block = text[start:start + 400]  # just the heredoc content
+        assert "import Mathlib\n" not in heredoc_block, (
+            "Starter Definitions.lean must not use bare 'import Mathlib' — "
+            "use 'import Mathlib.Tactic' instead"
+        )
+
+    def test_lemmas_lean_imports_definitions(self):
+        """Lemmas.lean starter content must import Definitions (not raw Mathlib)."""
+        assert "import LeanProofs.Definitions" in script_text()
+
+    def test_main_theorem_lean_imports_lemmas(self):
+        """MainTheorem.lean must import Lemmas to complete the dependency chain."""
+        assert "import LeanProofs.Lemmas" in script_text()
+
+    def test_uses_mathlib_lake_template(self):
+        """Must use the official Mathlib lake template, not a bare init."""
+        text = script_text()
+        assert "mathlib4" in text and "math" in text, (
+            "Project must be created with the Mathlib lake template"
+        )
+
+
+# ── 8. Cross-file consistency ─────────────────────────────────────────────────
+
+class TestCrossFileConsistency:
+    def test_skill_md_project_dir_matches_script_default(self):
+        """SKILL.md shows 'lean_proofs/' — must match script's default."""
+        skill_text = SKILL_MD.read_text()
+        assert "lean_proofs" in skill_text, (
+            "SKILL.md must reference 'lean_proofs' as the project directory"
+        )
+        assert "lean_proofs}" in script_text() or '"lean_proofs"' in script_text(), (
+            "Script default must be 'lean_proofs'"
+        )
+
+    def test_skill_md_lib_name_matches_script(self):
+        """SKILL.md shows 'LeanProofs/' — must match script's LIB_NAME."""
+        assert "LeanProofs" in SKILL_MD.read_text(), (
+            "SKILL.md must reference 'LeanProofs' as the library name"
+        )
+        assert "LeanProofs" in script_text(), (
+            "Script must use 'LeanProofs' as the library name"
+        )
+
+    def test_skill_md_file_layout_matches_script_output(self):
+        """All three files in SKILL.md's Project Structure exist in the script."""
+        skill_text = SKILL_MD.read_text()
+        for filename in ["Definitions.lean", "Lemmas.lean", "MainTheorem.lean"]:
+            assert filename in skill_text, (
+                f"{filename} missing from SKILL.md Project Structure"
+            )
+            assert filename in script_text(), (
+                f"{filename} not created by setup_lean_project.sh"
+            )
+
+    def test_setup_command_in_skill_md_matches_actual_path(self):
+        """The 'bash ...setup_lean_project.sh' command in SKILL.md must point
+        to a file that exists under templates/skills/."""
+        skill_text = SKILL_MD.read_text()
+        # Extract the referenced script path
+        match = re.search(r'bash\s+([\w./-]+setup_lean_project\.sh)', skill_text)
+        assert match, "SKILL.md must show a 'bash ...setup_lean_project.sh' command"
+
+        relative_path = match.group(1)
+        # The path is relative to the workspace root at runtime:
+        #   .claude/skills/lean-prover/scripts/setup_lean_project.sh
+        # At template level it lives at:
+        #   templates/skills/lean-prover/scripts/setup_lean_project.sh
+        assert "lean-prover" in relative_path, (
+            f"Path '{relative_path}' must reference the lean-prover skill"
+        )
+        assert "setup_lean_project.sh" in relative_path
+
+    def test_import_chain_is_consistent(self):
+        """Definitions ← Lemmas ← MainTheorem must be present in both files.
+
+        The script uses the shell variable form (${LIB_NAME}.X) while SKILL.md
+        shows the expanded literal form (LeanProofs.X).  Accept either.
+        """
+        script = script_text()
+        skill = SKILL_MD.read_text()
+        for suffix in ["Definitions", "Lemmas", "MainTheorem"]:
+            literal  = f"import LeanProofs.{suffix}"
+            variable = f"import ${{LIB_NAME}}.{suffix}"
+            assert literal in script  or variable in script, (
+                f"Script missing import for LeanProofs.{suffix}"
+            )
+            assert literal in skill, (
+                f"SKILL.md missing: import LeanProofs.{suffix}"
+            )
+
+
+# ── 9. Workspace copy ─────────────────────────────────────────────────────────
+
+class TestWorkspaceCopy:
+    """Verify _copy_workspace_resources plants the lean-prover skill correctly."""
+
+    def test_skill_dir_copied_to_claude_skills(self):
+        """After _copy_workspace_resources, .claude/skills/lean-prover/ exists."""
+        sys.path.insert(0, str(REPO_ROOT / "src"))
+        from core.runner import ResearchRunner
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp)
+            runner = ResearchRunner(project_root=REPO_ROOT, use_github=False)
+            runner._copy_workspace_resources(work_dir)
+
+            skill_dst = work_dir / ".claude" / "skills" / "lean-prover"
+            assert skill_dst.exists(), (
+                f"lean-prover skill not found at {skill_dst} after workspace copy"
+            )
+
+    def test_skill_md_present_after_copy(self):
+        from core.runner import ResearchRunner
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp)
+            runner = ResearchRunner(project_root=REPO_ROOT, use_github=False)
+            runner._copy_workspace_resources(work_dir)
+
+            skill_md_dst = work_dir / ".claude" / "skills" / "lean-prover" / "SKILL.md"
+            assert skill_md_dst.exists(), "SKILL.md must be present after workspace copy"
+
+    def test_setup_script_present_after_copy(self):
+        from core.runner import ResearchRunner
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp)
+            runner = ResearchRunner(project_root=REPO_ROOT, use_github=False)
+            runner._copy_workspace_resources(work_dir)
+
+            script_dst = (
+                work_dir / ".claude" / "skills" / "lean-prover"
+                / "scripts" / "setup_lean_project.sh"
+            )
+            assert script_dst.exists(), (
+                "setup_lean_project.sh must be present after workspace copy"
+            )
+
+    def test_skill_also_copied_to_gemini_and_codex(self):
+        """The skill must land in .gemini/skills/ and .codex/skills/ too."""
+        from core.runner import ResearchRunner
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp)
+            runner = ResearchRunner(project_root=REPO_ROOT, use_github=False)
+            runner._copy_workspace_resources(work_dir)
+
+            for provider_dir in [".gemini", ".codex"]:
+                skill_dst = work_dir / provider_dir / "skills" / "lean-prover"
+                assert skill_dst.exists(), (
+                    f"lean-prover skill missing from {provider_dir}/skills/ — "
+                    "provider-agnostic copy must include lean-prover"
+                )


### PR DESCRIPTION
## Summary

Adds a new optional **scoring mode** to the neurico pipeline that produces per-run, protocol-based evaluation metrics. Enabled by `./neurico run <id> --enable-scoring`. The default (non-scoring) mode is unchanged.

This PR ships the **backbone of the rule_maker extension**: the two new agents (`rule_maker`, `scorer`), the sealing mechanism between them, and the wiring to plug them into the existing orchestrator and CLI. Several planned extensions on top of this backbone (domain-specific supplements, vetted skeleton library, runner sandboxing) are described at the bottom and will land in follow-up PRs.

## How the rule_maker / scorer loop works

The pipeline becomes:

```
resource_finder → rule_maker → [seal scoring/] → experiment_runner → [unseal] → scorer
```

Three actors close a loop around a single protocol:

1. **rule_maker (writer).** Reads the idea, literature review, and resources catalog. Decides *what to measure* (2–4 scalar properties), *what counts as success* (numeric targets), and *how to test it*. Writes four files under `scoring/`:
   - `interface.md` — the runner-facing API spec (file paths, function signatures, input/output schemas).
   - `eval.py` — executable scorer that computes the property values from the runner's artifacts.
   - `targets.json` — numeric pass/fail thresholds and the success rule.
   - `rule_maker_log.md` — rationale (which properties, why these targets, anti-gaming considerations).

2. **runner (implementer).** Sees only `interface.md`. The other three files are moved out of the workspace for the duration of this stage — into a sibling `.scoring_sealed/<workspace>/` directory — so the runner cannot read the eval code or numeric targets. The runner produces artifacts (typically `src/solution.py`) that match the spec exactly.

3. **scorer (judge).** After the runner finishes, the sealed files are restored. `scoring/eval.py` is executed (using the workspace's own `.venv` Python if present) and writes `scoring/results.json` with `{per-property value vs. target, overall_satisfied, bottleneck}`.

The protocol is what closes the loop: the same `eval.py` that the rule_maker wrote is what the scorer executes. The runner can't tune to it (sealed during the runner stage), and it can't lie about its results (the scorer's `results.json` is the authoritative verdict — not the runner's `REPORT.md`).

Default mode is preserved bit-identically — every new code path is gated on `scoring_enabled=False`.

## What's in this PR

**New files (4):**
- `src/agents/rule_maker.py` — agent module (prompt assembly, run, output validation, protocol loading)
- `src/core/scorer.py` — runs `scoring/eval.py`, captures results, resolves the workspace's Python interpreter
- `templates/agents/rule_maker.txt` — general rule_maker prompt (METHODOLOGY → 6 PHASEs → BEST PRACTICES → TROUBLESHOOTING)
- `templates/base/researcher_scoring_addendum.txt` — banner-delimited block appended to the researcher prompt in scoring mode (artifact protocol + sealed-files notice + output-format adherence)

**Modified files (3):**
- `src/core/pipeline_orchestrator.py` — adds `scoring_enabled=False` flag to `run_pipeline()`, plus `_run_rule_maker`, `_run_scorer`, `_sealed_dir_for`, `_seal_runner_inputs`, `_unseal_runner_inputs`. Default arg = False = bit-identical to today.
- `src/core/runner.py` — adds `--enable-scoring`, `--rule-maker-timeout`, `--scorer-timeout` CLI flags; threads them through `run_research()`.
- `src/templates/prompt_generator.py` — adds `scoring_enabled=False` to `generate_research_prompt()`; appends the addendum as one banner-delimited section when true (mirrors the existing `if domain_template:` pattern).

## Planned extensions on this backbone

The pieces below build on what this PR ships. They are intentionally separate PRs so this one stays focused on the backbone:

- **Domain-specific rule_maker supplements** (`templates/domains/<domain>/rule_maker.txt`). The other agents (resource_finder, paper_writer) ship per-domain prompt supplements alongside the general prompt. The rule_maker general prompt works standalone today; the domain supplements (artificial_intelligence, battery, data_science, finance, machine_learning, mathematics, mathematics_lean, particle_physics) will land as a follow-up so each domain gets tailored property selection guidance and worked examples.
- **Vetted `eval.py` skeleton library** (`templates/scoring_examples/`). The current rule_maker writes `scoring/eval.py` from scratch each run. A follow-up will ship a small library of vetted skeleton scripts (algorithmic-speedup, trained-artifact, etc.) the rule_maker can copy and adapt — faster runs, fewer eval bugs, and reviewable scorer code.
- **Runner sandboxing**. The current seal is a move-and-restore; an adversarial runner with filesystem access could traverse `..` and find `.scoring_sealed/`. A real sandbox (containers or namespaces) is a follow-up. The current threat model is aligned-but-undisciplined runners.
- **Default-mode integration**. Scoring mode is opt-in via `--enable-scoring`. After enough empirical validation, a follow-up will fold it into the default pipeline.

## Test plan

- [x] Default-mode prompt is bit-identical to pre-merge (verified: no `SCORING MODE` / `rule_maker` / `scoring/interface.md` strings present)
- [x] Scored-mode prompt = default-mode + addendum (+~2.6KB)
- [x] `runner.py --help` shows new flags; pre-existing flags unchanged
- [x] All touched Python files compile
- [x] No references to deleted parallel files (`scored_pipeline_orchestrator.py`, `run_scored.py`, `researcher_scored.txt`) remain
- [x] Style consistency check: banner convention (`═` major, `─` sub), emoji palette, docstring style, no `# ----` dividers, no unicode box chars — all match peer files (`researcher.txt`, `resource_finder.py`, `paper_writer.py`)
- [x] **Full E2E run** with `--enable-scoring` on a substring-search hypothesis: 4 stages execute cleanly (rule_maker 152s, runner 730s, scorer 0.2s), seal/unseal leaves no `.scoring_sealed/` residue, scorer produces structurally valid `results.json` with `{per-property values, satisfied flags, gaps, overall_satisfied, bottleneck}`. (The hypothesis itself was empirically refuted — a pure-Python BMH cannot beat CPython's C-level `str.find` — which is the framework correctly reporting an honest failure, not a framework bug.)
