### PR TITLE
feat: rule_maker agent + post-run scorer stage

### DIFF
--- a/src/agents/rule_maker.py
+++ b/src/agents/rule_maker.py
@@ -1,0 +1,439 @@
+"""
+Rule Maker Agent
+
+Launches a CLI agent that, given the user's idea and the resource_finder's
+outputs, writes a per-run evaluation harness into the workspace under
+scoring/. The harness consists of:
+
+- scoring/eval.py: a self-contained Python program that measures the
+  experiment_runner's artifact and writes scoring/results.json.
+- scoring/targets.json: numeric targets and the success rule.
+- scoring/interface.md: visible to the experiment_runner -- describes what
+  files the runner must produce and how they will be invoked.
+- scoring/rule_maker_log.md: rationale for the chosen metrics.
+
+This agent runs between resource_finder and experiment_runner. Its outputs
+should be sealed (read-only) before experiment_runner starts so the runner
+cannot influence what it is being judged on.
+"""
+
+from pathlib import Path
+from typing import Optional, Dict, Any
+import subprocess
+import shlex
+import os
+import sys
+import time
+import json
+import ast
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.security import sanitize_text
+
+
+# CLI commands for different providers (mirrors resource_finder.py)
+CLI_COMMANDS = {
+    'claude': 'claude -p',
+    'codex': 'codex exec',
+    'gemini': 'gemini',
+}
+
+# Verbose / structured-transcript output flags per provider
+TRANSCRIPT_FLAGS = {
+    'claude': '--verbose --output-format stream-json',
+    'codex': '--json',
+    'gemini': '--output-format stream-json',
+}
+
+# Files the rule_maker is responsible for producing (relative to scoring/)
+RULE_MAKER_OUTPUT_FILES = {
+    'eval_script': 'eval.py',
+    'targets': 'targets.json',
+    'interface': 'interface.md',
+    'rationale_log': 'rule_maker_log.md',
+}
+
+
+def generate_rule_maker_prompt(
+    idea: Dict[str, Any],
+    work_dir: Path,
+    templates_dir: Path,
+    domain: Optional[str] = None,
+) -> str:
+    """
+    Build the rule_maker agent's prompt.
+
+    Composition (mirrors the researcher prompt pattern):
+
+      1. General body: templates/base/rule_maker.txt
+         -- the universal rule_maker job description, applied to every run.
+      2. Domain supplement (optional): templates/domains/<domain>/rule_maker.txt
+         -- domain-specific guidelines (what metrics matter in this domain,
+            calibration conventions, common reward-hacking traps, etc.).
+
+    Placeholders substituted in the general body:
+      {idea_yaml}        -- the idea spec (JSON-serialized for readability)
+      {workspace}        -- absolute path to the run's workspace
+      {scoring_dir}      -- absolute path to scoring/
+      {output_files}     -- list of files the agent must produce
+      {resource_listing} -- short summary of resource_finder outputs
+
+    Args:
+        idea: Full idea specification.
+        work_dir: Path to the run's workspace.
+        templates_dir: Path to the project's templates/ directory.
+        domain: Domain name (e.g. 'machine_learning'). If None, extracted
+            from idea['idea']['domain'] or idea['domain'], defaulting to
+            'machine_learning' (matches researcher prompt's default).
+
+    The prompt BODIES are user-owned and live in the template files. This
+    function only handles loading + substitution + concatenation.
+    """
+    work_dir = Path(work_dir)
+    templates_dir = Path(templates_dir)
+
+    # Load the general body. It lives at templates/agents/rule_maker.txt,
+    # alongside the other per-run agents (resource_finder.txt, paper_writer.txt).
+    # Per-domain supplements live separately at templates/domains/<d>/rule_maker.txt.
+    base_path = templates_dir / "agents" / "rule_maker.txt"
+    if not base_path.exists():
+        raise FileNotFoundError(
+            f"rule_maker base template not found at {base_path}. "
+            "Create templates/agents/rule_maker.txt before running."
+        )
+    base_template = base_path.read_text(encoding='utf-8')
+
+    scoring_dir = work_dir / "scoring"
+    output_files = "\n".join(
+        f"  - scoring/{name}" for name in RULE_MAKER_OUTPUT_FILES.values()
+    )
+    resource_listing = _summarize_resource_outputs(work_dir)
+
+    try:
+        idea_repr = json.dumps(idea, indent=2, default=str)
+    except (TypeError, ValueError):
+        idea_repr = repr(idea)
+
+    substitutions = {
+        '{idea_yaml}': idea_repr,
+        '{workspace}': str(work_dir),
+        '{scoring_dir}': str(scoring_dir),
+        '{output_files}': output_files,
+        '{resource_listing}': resource_listing,
+    }
+
+    prompt = base_template
+    for placeholder, value in substitutions.items():
+        prompt = prompt.replace(placeholder, value)
+
+    # Append per-domain supplement (if any) with a banner.
+    resolved_domain = _resolve_domain(idea, domain)
+    supplement = _load_domain_supplement(templates_dir, resolved_domain)
+    if supplement:
+        banner = "=" * 80
+        domain_label = resolved_domain.upper().replace('_', ' ')
+        prompt = (
+            f"{prompt}\n\n"
+            f"{banner}\n"
+            f"           RULE MAKER DOMAIN GUIDELINES: {domain_label}\n"
+            f"{banner}\n\n"
+            f"{supplement}\n"
+        )
+
+    return prompt
+
+
+def _resolve_domain(
+    idea: Dict[str, Any], override: Optional[str]
+) -> str:
+    """
+    Pick the domain string used to locate the domain supplement.
+
+    Order of precedence:
+      1. Explicit `override` argument.
+      2. idea['idea']['domain']  (nested spec, as elsewhere in the pipeline).
+      3. idea['domain']          (flat spec).
+      4. Fallback: 'machine_learning' (matches researcher default).
+    """
+    if override:
+        return override
+    nested = idea.get('idea', {}) if isinstance(idea, dict) else {}
+    if isinstance(nested, dict) and nested.get('domain'):
+        return nested['domain']
+    if isinstance(idea, dict) and idea.get('domain'):
+        return idea['domain']
+    return 'machine_learning'
+
+
+def _load_domain_supplement(templates_dir: Path, domain: str) -> str:
+    """
+    Load templates/domains/<domain>/rule_maker.txt if present.
+
+    Returns empty string when the supplement is missing -- the general
+    body alone is then used. (No silent fallback to a different domain;
+    that decision is left to the caller / pipeline.)
+    """
+    supplement_path = templates_dir / "domains" / domain / "rule_maker.txt"
+    if not supplement_path.exists():
+        return ""
+    return supplement_path.read_text(encoding='utf-8')
+
+
+def _summarize_resource_outputs(work_dir: Path) -> str:
+    """
+    Build a short, prompt-safe listing of what resource_finder produced.
+
+    The rule_maker needs to know which files / folders exist so it can
+    reference them in eval.py, but it should not have raw resource
+    contents dumped into its prompt.
+    """
+    work_dir = Path(work_dir)
+    candidates = [
+        ("literature_review.md", work_dir / "literature_review.md"),
+        ("resources.md", work_dir / "resources.md"),
+        ("papers/", work_dir / "papers"),
+        ("datasets/", work_dir / "datasets"),
+        ("code/", work_dir / "code"),
+    ]
+    lines = []
+    for label, path in candidates:
+        if not path.exists():
+            lines.append(f"  - {label}: (missing)")
+            continue
+        if path.is_dir():
+            entries = sorted(p.name for p in path.iterdir())
+            preview = ", ".join(entries[:8])
+            extra = "" if len(entries) <= 8 else f", +{len(entries) - 8} more"
+            lines.append(
+                f"  - {label}: {len(entries)} entries [{preview}{extra}]"
+            )
+        else:
+            size = path.stat().st_size
+            lines.append(f"  - {label}: {size} bytes")
+    return "\n".join(lines) if lines else "  (no resource_finder outputs found)"
+
+
+def run_rule_maker(
+    idea: Dict[str, Any],
+    work_dir: Path,
+    provider: str = "claude",
+    templates_dir: Optional[Path] = None,
+    timeout: int = 1800,  # 30 min
+    full_permissions: bool = True,
+) -> Dict[str, Any]:
+    """
+    Launch the rule_maker CLI agent.
+
+    Returns:
+        Dict with: success, outputs (paths of generated files), issues,
+        log_file, transcript_file, elapsed_time.
+    """
+    if provider not in CLI_COMMANDS:
+        raise ValueError(
+            f"Unsupported provider: {provider}. "
+            f"Choose from: {list(CLI_COMMANDS.keys())}"
+        )
+
+    if templates_dir is None:
+        templates_dir = Path(__file__).parent.parent.parent / "templates"
+
+    work_dir = Path(work_dir)
+    scoring_dir = work_dir / "scoring"
+    scoring_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir = work_dir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"📐 Starting Rule Maker Agent")
+    print(f"   Provider: {provider}")
+    print(f"   Work dir: {work_dir}")
+    print(f"   Timeout: {timeout}s ({timeout // 60} minutes)")
+    print("=" * 80)
+
+    # Generate prompt and persist it for debugging
+    prompt = generate_rule_maker_prompt(idea, work_dir, templates_dir)
+    prompt_file = logs_dir / "rule_maker_prompt.txt"
+    prompt_file.write_text(prompt, encoding='utf-8')
+    print(f"   Prompt saved to: {prompt_file}")
+    print(f"   Prompt length: {len(prompt)} characters")
+
+    # Build CLI command
+    cmd = CLI_COMMANDS[provider]
+    if full_permissions:
+        if provider == "codex":
+            cmd += " --yolo"
+        elif provider == "claude":
+            cmd += " --dangerously-skip-permissions"
+        elif provider == "gemini":
+            cmd += " --yolo --skip-trust"
+
+    transcript_flag = TRANSCRIPT_FLAGS.get(provider, '')
+    if transcript_flag:
+        cmd += f" {transcript_flag}"
+
+    log_file = logs_dir / f"rule_maker_{provider}.log"
+    transcript_file = logs_dir / f"rule_maker_{provider}_transcript.jsonl"
+
+    print(f"▶️  Launching {provider} CLI agent...")
+    print(f"   Command: {cmd}")
+    print(f"   Log file: {log_file}")
+    print()
+    print("=" * 80)
+    print("RULE MAKER OUTPUT (streaming)")
+    print("=" * 80)
+
+    env = os.environ.copy()
+    env['PYTHONUNBUFFERED'] = '1'
+    if provider == "gemini":
+        env['GEMINI_CLI_IDE_DISABLE'] = '1'
+
+    start_time = time.time()
+
+    try:
+        with open(log_file, 'w', encoding='utf-8') as log_f, \
+                open(transcript_file, 'w', encoding='utf-8') as transcript_f:
+            process = subprocess.Popen(
+                shlex.split(cmd),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                env=env,
+                text=True,
+                encoding='utf-8',
+                bufsize=1,
+                cwd=str(work_dir),
+            )
+            process.stdin.write(prompt)
+            process.stdin.close()
+
+            for line in iter(process.stdout.readline, ''):
+                if line:
+                    sanitized = sanitize_text(line)
+                    print(sanitized, end='')
+                    log_f.write(sanitized)
+                    transcript_f.write(sanitized)
+
+            return_code = process.wait(timeout=timeout)
+
+        print()
+        print("=" * 80)
+        elapsed = time.time() - start_time
+        print(
+            f"⏱️  Rule maker completed in {elapsed:.1f}s "
+            f"({elapsed / 60:.1f} minutes)"
+        )
+
+        if return_code == 0:
+            print("✅ Agent process exited cleanly.")
+        else:
+            print(f"⚠️  Agent exited with return code: {return_code}")
+
+    except subprocess.TimeoutExpired:
+        print(f"\n⏱️  Rule maker timed out after {timeout} seconds")
+        process.kill()
+
+    except Exception as e:
+        print(f"\n❌ Error during rule_maker execution: {e}")
+        raise
+
+    # Validate outputs
+    print()
+    print("📦 Validating rule_maker outputs...")
+    validation = validate_rule_maker_outputs(work_dir)
+    success = validation['valid']
+    if success:
+        print("✅ All required rule_maker outputs present and parseable.")
+    else:
+        print("⚠️  Rule maker outputs incomplete or invalid:")
+        for issue in validation['issues']:
+            print(f"     - {issue}")
+
+    return {
+        'success': success,
+        'outputs': validation['found'],
+        'issues': validation['issues'],
+        'log_file': str(log_file),
+        'transcript_file': str(transcript_file),
+        'elapsed_time': time.time() - start_time,
+    }
+
+
+def validate_rule_maker_outputs(work_dir: Path) -> Dict[str, Any]:
+    """
+    Verify the rule_maker produced the expected files in a usable form.
+
+    Checks:
+      - scoring/eval.py exists and parses as valid Python
+      - scoring/targets.json exists and parses as valid JSON
+      - scoring/interface.md exists and is non-empty
+      - scoring/rule_maker_log.md exists (informational; not required)
+
+    Returns:
+        {'valid': bool, 'found': {name: path}, 'issues': [str, ...]}
+    """
+    work_dir = Path(work_dir)
+    scoring_dir = work_dir / "scoring"
+    found: Dict[str, str] = {}
+    issues = []
+
+    eval_path = scoring_dir / RULE_MAKER_OUTPUT_FILES['eval_script']
+    if not eval_path.exists():
+        issues.append(f"missing: {eval_path}")
+    else:
+        try:
+            ast.parse(eval_path.read_text(encoding='utf-8'))
+            found['eval_script'] = str(eval_path)
+        except SyntaxError as e:
+            issues.append(f"eval.py has syntax error: {e}")
+
+    targets_path = scoring_dir / RULE_MAKER_OUTPUT_FILES['targets']
+    if not targets_path.exists():
+        issues.append(f"missing: {targets_path}")
+    else:
+        try:
+            json.loads(targets_path.read_text(encoding='utf-8'))
+            found['targets'] = str(targets_path)
+        except json.JSONDecodeError as e:
+            issues.append(f"targets.json is not valid JSON: {e}")
+
+    interface_path = scoring_dir / RULE_MAKER_OUTPUT_FILES['interface']
+    if not interface_path.exists():
+        issues.append(f"missing: {interface_path}")
+    elif interface_path.stat().st_size == 0:
+        issues.append(f"empty: {interface_path}")
+    else:
+        found['interface'] = str(interface_path)
+
+    rationale_path = scoring_dir / RULE_MAKER_OUTPUT_FILES['rationale_log']
+    if rationale_path.exists():
+        found['rationale_log'] = str(rationale_path)
+
+    return {
+        'valid': len(issues) == 0,
+        'found': found,
+        'issues': issues,
+    }
+
+
+def load_interface_for_runner(work_dir: Path) -> str:
+    """
+    Read scoring/interface.md to inject into the experiment_runner's prompt.
+
+    This is the ONE channel by which rule_maker's output reaches the runner.
+    Everything else under scoring/ (eval.py, targets.json) is hidden from
+    the runner.
+
+    Raises:
+        FileNotFoundError: If interface.md is missing -- the pipeline should
+        not proceed to experiment_runner without it.
+    """
+    interface_path = (
+        Path(work_dir) / "scoring" / RULE_MAKER_OUTPUT_FILES['interface']
+    )
+    if not interface_path.exists():
+        raise FileNotFoundError(
+            f"scoring/interface.md not found at {interface_path}. "
+            "rule_maker must run successfully before experiment_runner."
+        )
+    return interface_path.read_text(encoding='utf-8')

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -6,17 +6,30 @@ This module orchestrates the multi-agent research pipeline:
 2. (Optional) Human review checkpoint
 3. Experiment Runner Agent (CLI-based by default, Scribe optional): Implementation, experimentation, analysis
 
+When scoring_enabled=True is passed to run_pipeline(), two extra stages are
+woven into the flow:
+    - rule_maker (between resource_finder and experiment_runner): writes a
+      per-run artifact protocol (scoring/interface.md, scoring/eval.py,
+      scoring/targets.json, scoring/rule_maker_log.md).
+    - scorer (after experiment_runner): executes scoring/eval.py and writes
+      scoring/results.json.
+Plus a seal/unseal step that moves the scorer-side files out of the workspace
+during the runner stage so the runner cannot read them.
+
 The orchestrator manages agent execution flow, monitors completion, handles errors,
 and tracks pipeline state.
 """
 
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, List, Dict, Any
 import json
+import shutil
 from datetime import datetime
 import time
 
 from agents.resource_finder import run_resource_finder
+from agents.rule_maker import run_rule_maker
+from core.scorer import run_scorer
 from templates.research_agent_instructions import generate_instructions
 
 
@@ -96,6 +109,21 @@ CLI_COMMANDS = {
     'gemini': 'gemini'
 }
 
+# Stage names tracked in PipelineState when scoring_enabled=True
+RULE_MAKER_STAGE = 'rule_maker'
+SCORER_STAGE = 'scorer'
+
+# Files moved out of the workspace during the experiment_runner stage so the
+# runner cannot read them. Restored before the scorer runs.
+#   - eval.py:           the scoring code itself
+#   - targets.json:      numeric targets + success rule
+#   - rule_maker_log.md: rationale, which references the targets in plain text
+SEALED_FILES: List[str] = [
+    "scoring/eval.py",
+    "scoring/targets.json",
+    "scoring/rule_maker_log.md",
+]
+
 
 class ResearchPipelineOrchestrator:
     """
@@ -132,7 +160,10 @@ class ResearchPipelineOrchestrator:
         resource_finder_timeout: int = 2700,  # 45 min
         experiment_runner_timeout: int = 10800,  # 3 hours
         full_permissions: bool = True,
-        use_scribe: bool = False
+        use_scribe: bool = False,
+        scoring_enabled: bool = False,
+        rule_maker_timeout: int = 1800,  # 30 min
+        scorer_timeout: int = 600  # 10 min
     ) -> Dict[str, Any]:
         """
         Execute complete research pipeline.
@@ -146,19 +177,30 @@ class ResearchPipelineOrchestrator:
             experiment_runner_timeout: Timeout for experiment runner in seconds
             full_permissions: Allow full permissions to agents
             use_scribe: If True, use scribe for notebook integration (default: False, raw CLI)
+            scoring_enabled: If True, run in rule_maker (scored) mode. Adds two stages
+                             (rule_maker between resource_finder and experiment_runner,
+                             scorer after experiment_runner) and seals scoring/ inputs
+                             from the runner. Default False = legacy two-stage flow.
+            rule_maker_timeout: Timeout for rule_maker stage in seconds (scoring mode only)
+            scorer_timeout: Timeout for scorer stage in seconds (scoring mode only)
 
         Returns:
             Dictionary with pipeline execution results
         """
         print()
         print("=" * 80)
-        print("MULTI-AGENT RESEARCH PIPELINE")
+        if scoring_enabled:
+            print("MULTI-AGENT RESEARCH PIPELINE  (SCORING MODE)")
+        else:
+            print("MULTI-AGENT RESEARCH PIPELINE")
         print("=" * 80)
         print(f"Work directory: {self.work_dir}")
         print(f"Provider: {provider}")
         print(f"Use scribe (notebooks): {use_scribe}")
         print(f"Pause after resources: {pause_after_resources}")
         print(f"Skip resource finder: {skip_resource_finder}")
+        if scoring_enabled:
+            print(f"Scoring enabled: True (rule_maker + scorer stages)")
         print("=" * 80)
         print()
 
@@ -167,6 +209,8 @@ class ResearchPipelineOrchestrator:
             'stages': {},
             'work_dir': str(self.work_dir)
         }
+        if scoring_enabled:
+            results['mode'] = 'scored'
 
         try:
             # STAGE 1: Resource Finder
@@ -200,23 +244,72 @@ class ResearchPipelineOrchestrator:
                     print("🛑 Pipeline paused. Human did not approve continuation.")
                     return results
 
-            # STAGE 3: Experiment Runner
-            results['stages']['experiment_runner'] = self._run_experiment_runner(
-                idea=idea,
-                provider=provider,
-                timeout=experiment_runner_timeout,
-                full_permissions=full_permissions,
-                use_scribe=use_scribe
-            )
+            # STAGE 2.5 (scoring mode only): Rule Maker
+            # Writes scoring/interface.md, scoring/eval.py, scoring/targets.json,
+            # scoring/rule_maker_log.md before the runner sees the workspace.
+            if scoring_enabled:
+                results['stages'][RULE_MAKER_STAGE] = self._run_rule_maker(
+                    idea=idea,
+                    provider=provider,
+                    timeout=rule_maker_timeout,
+                    full_permissions=full_permissions
+                )
+                if not results['stages'][RULE_MAKER_STAGE]['success']:
+                    print()
+                    print("⚠️  Rule maker stage failed -- aborting.")
+                    return results
 
-            if results['stages']['experiment_runner']['success']:
-                print()
-                print("🎉 PIPELINE COMPLETED SUCCESSFULLY!")
-                self.state.mark_completed()
-                results['success'] = True
+            # STAGE 3: Experiment Runner
+            # In scoring mode, seal eval.py / targets.json / rule_maker_log.md
+            # out of the workspace for the duration of the runner stage. Always
+            # unseal in the finally block (even on runner failure) so the scorer
+            # can run.
+            sealed_dir = self._seal_runner_inputs() if scoring_enabled else None
+            try:
+                results['stages']['experiment_runner'] = self._run_experiment_runner(
+                    idea=idea,
+                    provider=provider,
+                    timeout=experiment_runner_timeout,
+                    full_permissions=full_permissions,
+                    use_scribe=use_scribe,
+                    scoring_enabled=scoring_enabled
+                )
+            finally:
+                if scoring_enabled:
+                    self._unseal_runner_inputs(sealed_dir)
+
+            # STAGE 4 (scoring mode only): Scorer
+            # Executes scoring/eval.py and captures results.json.
+            if scoring_enabled:
+                results['stages'][SCORER_STAGE] = self._run_scorer(
+                    timeout=scorer_timeout
+                )
+
+            runner_ok = results['stages']['experiment_runner']['success']
+
+            if scoring_enabled:
+                scorer_ok = results['stages'][SCORER_STAGE]['success']
+                if runner_ok and scorer_ok:
+                    print()
+                    print("🎉 PIPELINE COMPLETED SUCCESSFULLY!")
+                    self.state.mark_completed()
+                    results['success'] = True
+                elif runner_ok and not scorer_ok:
+                    print()
+                    print("⚠️  Runner finished but scorer failed -- artifact "
+                          "may be unmeasured.")
+                else:
+                    print()
+                    print("⚠️  Pipeline finished with issues.")
             else:
-                print()
-                print("⚠️  Experiment runner stage completed with issues.")
+                if runner_ok:
+                    print()
+                    print("🎉 PIPELINE COMPLETED SUCCESSFULLY!")
+                    self.state.mark_completed()
+                    results['success'] = True
+                else:
+                    print()
+                    print("⚠️  Experiment runner stage completed with issues.")
 
         except Exception as e:
             print()
@@ -227,6 +320,7 @@ class ResearchPipelineOrchestrator:
         finally:
             # Save final results
             results_file = self.work_dir / ".neurico" / "pipeline_results.json"
+            results_file.parent.mkdir(parents=True, exist_ok=True)
             with open(results_file, 'w', encoding='utf-8') as f:
                 json.dump(results, f, indent=2)
 
@@ -315,12 +409,16 @@ class ResearchPipelineOrchestrator:
         provider: str,
         timeout: int,
         full_permissions: bool,
-        use_scribe: bool = False
+        use_scribe: bool = False,
+        scoring_enabled: bool = False
     ) -> Dict[str, Any]:
         """Run experiment runner stage (raw CLI by default, scribe optional)."""
         print()
         print("─" * 80)
-        print("STAGE 3: EXPERIMENT RUNNER")
+        if scoring_enabled:
+            print("STAGE 3: EXPERIMENT RUNNER  (scored prompt)")
+        else:
+            print("STAGE 3: EXPERIMENT RUNNER")
         print("─" * 80)
         print()
 
@@ -337,7 +435,11 @@ class ResearchPipelineOrchestrator:
             from templates.prompt_generator import PromptGenerator
 
             prompt_generator = PromptGenerator(self.templates_dir)
-            prompt = prompt_generator.generate_research_prompt(idea, root_dir=self.work_dir)
+            prompt = prompt_generator.generate_research_prompt(
+                idea,
+                root_dir=self.work_dir,
+                scoring_enabled=scoring_enabled
+            )
 
             # Save prompt
             prompt_file = self.work_dir / "logs" / "research_prompt.txt"
@@ -479,6 +581,195 @@ class ResearchPipelineOrchestrator:
             result = {'success': False, 'error': str(e)}
             self.state.complete_stage('experiment_runner', False, result)
             raise
+
+    # ---- Scoring-mode helpers (rule_maker / scorer / seal) ---------------
+    # These methods are only invoked when run_pipeline(scoring_enabled=True).
+    # In default mode they are not called; their presence does not affect the
+    # legacy two-stage flow.
+
+    def _run_rule_maker(
+        self,
+        idea: Dict[str, Any],
+        provider: str,
+        timeout: int,
+        full_permissions: bool
+    ) -> Dict[str, Any]:
+        """Run the rule_maker stage (scoring mode only)."""
+        print()
+        print("─" * 80)
+        print("STAGE: RULE MAKER")
+        print("─" * 80)
+        print()
+
+        self.state.start_stage(RULE_MAKER_STAGE)
+        try:
+            result = run_rule_maker(
+                idea=idea,
+                work_dir=self.work_dir,
+                provider=provider,
+                templates_dir=self.templates_dir,
+                timeout=timeout,
+                full_permissions=full_permissions
+            )
+            self.state.complete_stage(
+                RULE_MAKER_STAGE,
+                result['success'],
+                result.get('outputs')
+            )
+            return result
+        except Exception as e:
+            print(f"❌ Rule maker stage failed: {e}")
+            self.state.complete_stage(RULE_MAKER_STAGE, False)
+            raise
+
+    def _run_scorer(self, timeout: int) -> Dict[str, Any]:
+        """
+        Run the scorer stage (scoring mode only). Executes scoring/eval.py
+        and captures the structured results into scoring/results.json.
+        """
+        print()
+        print("─" * 80)
+        print("STAGE: SCORER")
+        print("─" * 80)
+        print()
+
+        self.state.start_stage(SCORER_STAGE)
+        try:
+            result = run_scorer(
+                work_dir=self.work_dir,
+                timeout=timeout
+            )
+            self.state.complete_stage(
+                SCORER_STAGE,
+                result['success'],
+                result
+            )
+            return result
+        except Exception as e:
+            print(f"❌ Scorer stage failed: {e}")
+            self.state.complete_stage(SCORER_STAGE, False)
+            raise
+
+    def _sealed_dir_for(self) -> Path:
+        """
+        Return the sibling directory where sealed scoring files live during
+        the experiment_runner stage.
+
+        For a workspace at <workspaces>/<name>/, the sealed directory is at
+        <workspaces>/.scoring_sealed/<name>/. Sealed files keep their
+        relative path inside that directory (e.g. scoring/eval.py).
+        """
+        return self.work_dir.parent / ".scoring_sealed" / self.work_dir.name
+
+    def _seal_runner_inputs(self) -> Optional[Path]:
+        """
+        Move SEALED_FILES out of the workspace BEFORE the runner stage.
+
+        Returns the sealed directory path so it can be passed to
+        _unseal_runner_inputs(). Returns None if nothing was sealed (e.g.,
+        the rule_maker output files did not exist).
+
+        Defense level: against an aligned-but-undisciplined runner, this is
+        a hard guarantee -- the files are not in the workspace at all. Against
+        an actively adversarial runner with full filesystem access, it is a
+        speed bump (the runner could traverse `..` and find the sealed dir).
+        Full hardening against adversarial runners requires sandboxing
+        (deferred to v1.0).
+        """
+        sealed_dir = self._sealed_dir_for()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+
+        moved = []
+        for rel in SEALED_FILES:
+            src = self.work_dir / rel
+            if not src.exists():
+                continue
+            dst = sealed_dir / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dst))
+            moved.append(rel)
+
+        if not moved:
+            # Nothing to seal; remove the empty sealed dir we created.
+            try:
+                sealed_dir.rmdir()
+                sealed_dir.parent.rmdir()  # remove .scoring_sealed if now empty
+            except OSError:
+                pass
+            print("🔒 Nothing to seal (rule_maker outputs not found).")
+            return None
+
+        print(f"🔒 Sealed {len(moved)} scoring files to {sealed_dir}:")
+        for r in moved:
+            print(f"     - {r}")
+        print(
+            f"   (manual recovery if orchestrator crashes: "
+            f"mv {sealed_dir}/scoring/* {self.work_dir}/scoring/)"
+        )
+        return sealed_dir
+
+    def _unseal_runner_inputs(self, sealed_dir: Optional[Path]) -> None:
+        """
+        Move sealed files back to the workspace AFTER the runner stage.
+
+        Best-effort: logs failures but does not raise. The caller must not
+        let an unseal error mask an experiment_runner failure -- this is
+        always called in a finally block.
+        """
+        if sealed_dir is None:
+            return
+
+        if not sealed_dir.exists():
+            print(f"⚠️  Sealed dir disappeared: {sealed_dir}")
+            return
+
+        restored = []
+        errors = []
+        for rel in SEALED_FILES:
+            src = sealed_dir / rel
+            if not src.exists():
+                continue
+            dst = self.work_dir / rel
+            try:
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(src), str(dst))
+                restored.append(rel)
+            except OSError as e:
+                errors.append(f"{rel}: {e}")
+
+        if restored:
+            print(f"🔓 Restored {len(restored)} scoring files from {sealed_dir}")
+
+        if errors:
+            print(f"⚠️  Unseal errors -- sealed dir kept at {sealed_dir} for "
+                  "manual recovery:")
+            for e in errors:
+                print(f"     - {e}")
+            return
+
+        # Best-effort cleanup. All expected files restored cleanly, so the
+        # sealed dir should contain at most empty subdirs (e.g. scoring/ we
+        # created during seal). If a stray FILE shows up, keep the dir for
+        # the user to inspect.
+        try:
+            has_files = any(
+                p.is_file() for p in sealed_dir.rglob("*")
+            ) if sealed_dir.exists() else False
+            if sealed_dir.exists() and not has_files:
+                shutil.rmtree(sealed_dir)
+                # Remove .scoring_sealed/ parent if also empty
+                parent = sealed_dir.parent
+                try:
+                    parent.rmdir()
+                except OSError:
+                    pass
+            elif has_files:
+                print(
+                    f"ℹ️  Unexpected files remain in {sealed_dir}; "
+                    "leaving the directory for inspection."
+                )
+        except OSError as e:
+            print(f"⚠️  Could not clean up {sealed_dir}: {e}")
 
     def get_pipeline_status(self) -> Dict[str, Any]:
         """Get current pipeline execution status."""

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -122,7 +122,10 @@ class ResearchRunner:
                     paper_timeout: int = 3600,
                     no_hash: bool = False,
                     private: bool = False,
-                    force_fresh: bool = False) -> Dict[str, Any]:
+                    force_fresh: bool = False,
+                    scoring_enabled: bool = False,
+                    rule_maker_timeout: int = 1800,
+                    scorer_timeout: int = 600) -> Dict[str, Any]:
         """
         Execute research for a given idea.
 
@@ -306,9 +309,16 @@ class ResearchRunner:
         # Choose execution mode: multi-agent pipeline or legacy monolithic
         if multi_agent:
             print()
-            print("🔀 Using MULTI-AGENT pipeline")
-            print("   Stage 1: Resource Finder (literature review, datasets, code)")
-            print("   Stage 2: Experiment Runner (implementation, experiments, analysis)")
+            if scoring_enabled:
+                print("🔀 Using MULTI-AGENT pipeline (SCORING MODE)")
+                print("   Stage 1: Resource Finder (literature review, datasets, code)")
+                print("   Stage 2: Rule Maker (writes scoring/ artifact protocol)")
+                print("   Stage 3: Experiment Runner (with sealed scoring/ inputs)")
+                print("   Stage 4: Scorer (executes scoring/eval.py)")
+            else:
+                print("🔀 Using MULTI-AGENT pipeline")
+                print("   Stage 1: Resource Finder (literature review, datasets, code)")
+                print("   Stage 2: Experiment Runner (implementation, experiments, analysis)")
             print()
 
             # Use pipeline orchestrator
@@ -344,7 +354,10 @@ class ResearchRunner:
                     resource_finder_timeout=resource_finder_timeout,
                     experiment_runner_timeout=timeout,
                     full_permissions=full_permissions,
-                    use_scribe=use_scribe
+                    use_scribe=use_scribe,
+                    scoring_enabled=scoring_enabled,
+                    rule_maker_timeout=rule_maker_timeout,
+                    scorer_timeout=scorer_timeout
                 )
 
                 success = pipeline_result.get('success', False)
@@ -966,6 +979,25 @@ def main():
         action="store_true",
         help="Run in comment mode: make targeted improvements based on comments in the idea file"
     )
+    parser.add_argument(
+        "--enable-scoring",
+        action="store_true",
+        help="Run in scoring mode: insert rule_maker stage before the runner, "
+             "seal scoring/ inputs from the runner, and run scorer after. "
+             "Requires rule_maker agent + scoring/eval.py protocol."
+    )
+    parser.add_argument(
+        "--rule-maker-timeout",
+        type=int,
+        default=1800,
+        help="Timeout for rule_maker stage in seconds (default: 1800 = 30 min, scoring mode only)"
+    )
+    parser.add_argument(
+        "--scorer-timeout",
+        type=int,
+        default=600,
+        help="Timeout for scorer stage in seconds (default: 600 = 10 min, scoring mode only)"
+    )
 
     args = parser.parse_args()
 
@@ -1013,7 +1045,10 @@ def main():
             paper_timeout=args.paper_timeout,
             no_hash=args.no_hash,
             private=args.private,
-            force_fresh=args.force_fresh
+            force_fresh=args.force_fresh,
+            scoring_enabled=args.enable_scoring,
+            rule_maker_timeout=args.rule_maker_timeout,
+            scorer_timeout=args.scorer_timeout
         )
 
         print()

--- a/src/core/scorer.py
+++ b/src/core/scorer.py
@@ -1,0 +1,185 @@
+"""
+Scorer Stage
+
+Executes scoring/eval.py (written by the rule_maker agent) against the
+artifact produced by experiment_runner. Captures structured results in
+scoring/results.json and stdout/stderr in scoring/eval_log.txt.
+
+The scorer is mechanical: no agent invocation, no LLM call. It simply
+runs the per-run evaluation script as a subprocess and surfaces the JSON
+it writes.
+"""
+
+from pathlib import Path
+from typing import Optional, Dict, Any
+import subprocess
+import json
+import sys
+import time
+
+
+# Files the scorer reads / writes (relative to <workspace>/scoring/)
+EVAL_SCRIPT_NAME = "eval.py"
+RESULTS_FILE_NAME = "results.json"
+LOG_FILE_NAME = "eval_log.txt"
+
+
+def _resolve_python_executable(work_dir: Path) -> str:
+    """
+    Pick the Python interpreter to invoke eval.py with.
+
+    The experiment_runner creates <workspace>/.venv during its setup phase
+    and installs all task-specific dependencies there. eval.py typically
+    imports those same dependencies (numpy, torch, sklearn, etc.), so it
+    must run under the workspace's interpreter rather than the
+    orchestrator's. Falls back to sys.executable if the workspace has no
+    .venv yet (e.g., during a scorer-only smoke test).
+    """
+    posix = work_dir / ".venv" / "bin" / "python"
+    if posix.exists() and posix.is_file():
+        return str(posix)
+    windows = work_dir / ".venv" / "Scripts" / "python.exe"
+    if windows.exists() and windows.is_file():
+        return str(windows)
+    return sys.executable
+
+
+def run_scorer(
+    work_dir: Path,
+    timeout: int = 600,
+    python_executable: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Execute scoring/eval.py against the runner's artifact.
+
+    Args:
+        work_dir: Workspace root containing scoring/eval.py and the
+                  runner's outputs.
+        timeout: Max execution time for eval.py in seconds.
+        python_executable: Python binary to use. Defaults to the workspace's
+                  own .venv interpreter (where the runner installed deps),
+                  falling back to sys.executable.
+
+    Returns:
+        Dict with:
+          - success: bool -- eval.py exited 0 AND results.json parsed cleanly
+          - return_code: int | None -- eval.py's exit code (None on timeout)
+          - results: dict | None -- parsed results.json contents
+          - results_path: str -- absolute path to results.json
+          - log_path: str -- absolute path to eval_log.txt
+          - elapsed_time: float
+          - error: str | None -- error message if anything failed
+    """
+    work_dir = Path(work_dir)
+    scoring_dir = work_dir / "scoring"
+    eval_script = scoring_dir / EVAL_SCRIPT_NAME
+    results_path = scoring_dir / RESULTS_FILE_NAME
+    log_path = scoring_dir / LOG_FILE_NAME
+
+    if not eval_script.exists():
+        return {
+            'success': False,
+            'return_code': None,
+            'results': None,
+            'results_path': str(results_path),
+            'log_path': str(log_path),
+            'elapsed_time': 0.0,
+            'error': f"scoring/eval.py not found at {eval_script}",
+        }
+
+    # Clear stale results so we never read leftover values from a prior run
+    if results_path.exists():
+        results_path.unlink()
+
+    python_executable = python_executable or _resolve_python_executable(work_dir)
+    cmd = [python_executable, str(eval_script)]
+
+    print(f"📊 Running scorer: {' '.join(cmd)}")
+    print(f"   Working dir: {work_dir}")
+    print(f"   Python: {python_executable}")
+    print(f"   Log: {log_path}")
+
+    start_time = time.time()
+    return_code: Optional[int] = None
+    error: Optional[str] = None
+
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=str(work_dir),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+            text=True,
+            encoding='utf-8',
+        )
+        log_path.write_text(completed.stdout or "", encoding='utf-8')
+        return_code = completed.returncode
+        if return_code != 0:
+            error = f"eval.py exited with non-zero code {return_code}"
+    except subprocess.TimeoutExpired as e:
+        error = f"scorer timed out after {timeout}s"
+        print(f"⏱️  {error}")
+        partial = ""
+        if e.stdout:
+            partial = (
+                e.stdout
+                if isinstance(e.stdout, str)
+                else e.stdout.decode('utf-8', errors='replace')
+            )
+        log_path.write_text(
+            f"{partial}\n[TIMEOUT after {timeout}s]\n", encoding='utf-8'
+        )
+    except Exception as e:
+        error = f"scorer exception: {e}"
+        print(f"❌ {error}")
+
+    elapsed = time.time() - start_time
+
+    results: Optional[Dict[str, Any]] = None
+    if results_path.exists():
+        try:
+            results = json.loads(results_path.read_text(encoding='utf-8'))
+        except json.JSONDecodeError as e:
+            json_err = f"results.json is not valid JSON: {e}"
+            error = f"{error}; {json_err}" if error else json_err
+
+    success = return_code == 0 and results is not None and error is None
+
+    if success:
+        print(f"✅ Scorer completed in {elapsed:.1f}s")
+    else:
+        print(
+            f"⚠️  Scorer finished with issues "
+            f"(return_code={return_code}, error={error})"
+        )
+
+    return {
+        'success': success,
+        'return_code': return_code,
+        'results': results,
+        'results_path': str(results_path),
+        'log_path': str(log_path),
+        'elapsed_time': elapsed,
+        'error': error,
+    }
+
+
+def load_scoring_results(work_dir: Path) -> Optional[Dict[str, Any]]:
+    """
+    Read scoring/results.json from a workspace.
+
+    Convenience for downstream consumers (paper_writer, supervisor) that
+    only need the score, not the full scorer-run dict.
+
+    Returns:
+        Parsed results.json contents, or None if the file is missing or
+        unparseable.
+    """
+    results_path = Path(work_dir) / "scoring" / RESULTS_FILE_NAME
+    if not results_path.exists():
+        return None
+    try:
+        return json.loads(results_path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError:
+        return None

--- a/src/templates/prompt_generator.py
+++ b/src/templates/prompt_generator.py
@@ -110,7 +110,8 @@ class PromptGenerator:
         return template.render(**variables)
 
     def generate_research_prompt(self, idea: Dict[str, Any],
-                                 root_dir: Optional[Path] = None) -> str:
+                                 root_dir: Optional[Path] = None,
+                                 scoring_enabled: bool = False) -> str:
         """
         Generate the main research prompt from an idea specification.
 
@@ -118,10 +119,14 @@ class PromptGenerator:
         1. Base researcher template
         2. Domain-specific template
         3. Idea-specific content (hypothesis, constraints, etc.)
+        4. (scoring mode) Scoring protocol / output-adherence addendum
 
         Args:
             idea: Idea specification (parsed from YAML)
             root_dir: Root directory for the research project (for paths)
+            scoring_enabled: If True, append base/researcher_scoring_addendum.txt
+                             as an extra banner-delimited section. Default False
+                             preserves bit-identical behavior to the legacy mode.
 
         Returns:
             Complete research prompt string
@@ -190,6 +195,26 @@ class PromptGenerator:
                 domain_template,
                 ""
             ])
+
+        # Scoring-mode addendum: when the rule_maker has written a per-run
+        # artifact protocol under scoring/, append the corresponding
+        # instructions so the runner reads interface.md and conforms to it.
+        # In default (non-scoring) mode this block is skipped and the prompt
+        # is bit-identical to the legacy version.
+        if scoring_enabled:
+            try:
+                addendum = self.load_template('base/researcher_scoring_addendum.txt')
+            except FileNotFoundError:
+                print("⚠️  scoring_enabled=True but "
+                      "templates/base/researcher_scoring_addendum.txt not found; "
+                      "continuing without scoring addendum")
+                addendum = ""
+            if addendum:
+                prompt_parts.extend([
+                    "=" * 80,
+                    addendum,
+                    ""
+                ])
 
         # Join all parts
         full_prompt = "\n".join(prompt_parts)

--- a/templates/agents/rule_maker.txt
+++ b/templates/agents/rule_maker.txt
@@ -1,0 +1,634 @@
+You are a specialized agent focused on writing per-run evaluation harnesses for automated research pipelines.
+
+Your goal is to take a research idea and a set of pre-gathered resources, decide what success looks like for THIS run, and write a small, self-contained scoring harness that the post-run scorer will execute against the experiment_runner's artifact. You do not run experiments, you do not write the solution, and you do not interpret the final score.
+
+This prompt guides you through a systematic harness-authoring workflow. Complete all phases and create the deliverables listed below before exiting.
+
+═══════════════════════════════════════════════════════════════════════════════
+                    CRITICAL: WORKSPACE SETUP AND DIRECTORY SAFETY
+═══════════════════════════════════════════════════════════════════════════════
+
+You are running in the project workspace directory. All files you create
+must land under {scoring_dir}.
+
+WORKING DIRECTORY VERIFICATION:
+Before writing any files, ALWAYS verify your location:
+
+1. Run `pwd` to check your current directory.
+2. You should be in the WORKSPACE root: {workspace}
+3. The scoring directory ({scoring_dir}) already exists — do NOT recreate it.
+
+MANDATORY VERIFICATION POINTS — run `pwd` and confirm:
+✓ Before each `Write` to scoring/
+✓ After any `cd` command — ALWAYS return to workspace root afterward
+✓ When starting a new phase
+
+SAFE PATTERN FOR DIRECTORY CHANGES:
+  pwd                              # Verify starting location
+  cd scoring && ls && cd -         # cd back using "cd -"
+  pwd                              # Verify you're back in workspace root
+
+⚠️  DO NOT create files outside {scoring_dir}.
+⚠️  DO NOT modify anything under src/, data/, papers/, datasets/, or code/.
+⚠️  DO NOT execute scoring/eval.py — the runner's artifact does not exist
+   yet. Running it would fail and pollute scoring/ with stale results.json.
+
+═══════════════════════════════════════════════════════════════════════════════
+                          RULE MAKER METHODOLOGY
+═══════════════════════════════════════════════════════════════════════════════
+
+MISSION:
+Given a research idea and the resource_finder's outputs, you will:
+1. Identify the quantifiable properties that define success for THIS run.
+2. Write a protocol (scoring/interface.md) telling the experiment_runner
+   exactly what artifact to produce.
+3. Write a self-contained Python scorer (scoring/eval.py) that measures
+   those properties on the runner's artifact.
+4. Write numeric targets (scoring/targets.json) and the success rule.
+5. Document your reasoning (scoring/rule_maker_log.md) so the user can
+   read, refine, and re-run.
+
+INPUTS YOU SEE:
+
+The research idea:
+{idea_yaml}
+
+Workspace root:    {workspace}
+Scoring directory: {scoring_dir}
+
+Resources pre-gathered by the resource_finder stage:
+{resource_listing}
+
+(Read these from disk: literature_review.md, resources.md, papers/,
+datasets/, code/. Use them only to inform your design choices; do not
+copy raw resource contents into scoring/ files.)
+
+OUTPUT DELIVERABLES (all under {scoring_dir}):
+
+{output_files}
+
+Each file's format is specified in the corresponding phase below. Conform
+EXACTLY to the schemas — downstream code parses these files mechanically.
+
+WHAT YOU MUST NOT DO:
+
+✗ Do NOT invent numeric targets. Extract them from the idea's
+  `evaluation_criteria` (or the idea's stated goal). If the user gave no
+  concrete number, propose a defensible one and document the rationale.
+✗ Do NOT run experiments. You are not the experiment_runner.
+✗ Do NOT execute scoring/eval.py. The runner's artifact does not exist
+  yet — running eval.py would fail and pollute scoring/.
+✗ Do NOT read or reference files under data/.test/. Their contents are
+  sealed; only scoring/eval.py touches them at scorer-execution time.
+✗ Do NOT mention targets, test inputs, or the baseline in
+  scoring/interface.md. That file is visible to the runner; leaking
+  these defeats the evaluation.
+✗ Do NOT `import neurico` or any neurico helper module in eval.py. The
+  runner's venv may not have them. Use stdlib only, plus any pip
+  packages installed via the resource_finder's environment (numpy,
+  scikit-learn, etc. — only if a resource you found requires them).
+
+═══════════════════════════════════════════════════════════════════════════════
+                          PHASE 1: TASK ANALYSIS
+═══════════════════════════════════════════════════════════════════════════════
+
+Before writing any files, decide what you are measuring.
+
+STEP 1: Read the idea
+─────────────────────────────────────────────────────────────────────────────
+
+From {idea_yaml}, extract:
+- The goal (hypothesis / research question).
+- Evaluation criteria — explicit numbers if given.
+- Constraints (size budget, latency budget, dataset, etc.).
+- Domain — this shapes which metrics are conventional.
+
+STEP 2: Read resource_finder outputs
+─────────────────────────────────────────────────────────────────────────────
+
+Skim (do not deep-read):
+- literature_review.md — what metrics do prior works use?
+- resources.md — which datasets / baselines are available locally?
+- code/ — is there a baseline implementation you can call from eval.py?
+- datasets/ — is there a held-out split you can use? (look for a
+  data/.test/ subdir; if absent, plan to create one in Phase 3)
+
+STEP 3: Decide the property set
+─────────────────────────────────────────────────────────────────────────────
+
+Pick 1–4 measurable properties that, taken together, define "success"
+for this run. Each must:
+
+✓ Be a single scalar (float or int).
+✓ Have a clear "higher is better" or "lower is better" direction.
+✓ Be computable from the runner's artifact + sealed data + a baseline.
+✓ Be resistant to trivial gaming (a runner that returns 0 always
+  should NOT score well).
+
+EXAMPLE PROPERTY SETS:
+
+| Task family            | Properties                                       |
+|------------------------|--------------------------------------------------|
+| Algorithmic speedup    | correctness (max), speedup (max)                 |
+| Model compression      | accuracy (max), file_size_mb (min)               |
+| Classification         | accuracy (max), calibration_ece (min)            |
+| Optimization solver    | objective_value (min), constraint_violation (min)|
+| Latency-bounded model  | accuracy (max), p99_latency_ms (min)             |
+
+STEP 4: Identify the baseline
+─────────────────────────────────────────────────────────────────────────────
+
+Most measurements are relative to a reference (a naive implementation, a
+trained baseline, a published result). Locate or define one:
+
+✓ FIRST CHOICE: a baseline shipped in code/ by resource_finder. Locate
+  the entry point and document its path.
+✓ SECOND CHOICE: a trivial baseline you can write yourself in
+  baselines/<name>.py (e.g. a naive O(n²) DP for an algorithmic task,
+  a most-frequent-class classifier).
+✓ LAST RESORT: an absolute target with no comparison baseline. Document
+  why no baseline exists in scoring/rule_maker_log.md.
+
+If you write a baseline file, place it at <workspace>/baselines/<name>.py
+— NOT under scoring/. The runner can see baselines/ but cannot see
+scoring/eval.py, so the baseline is fair game for comparison.
+
+═══════════════════════════════════════════════════════════════════════════════
+                  PHASE 2: WRITE scoring/interface.md
+═══════════════════════════════════════════════════════════════════════════════
+
+This file is the ONE channel by which your decisions reach the runner.
+It must specify exactly what the runner must produce, with no leakage of
+targets, test inputs, or the baseline's expected outputs.
+
+WHAT TO INCLUDE:
+✓ The list of files the runner must produce (with paths).
+✓ The signature / schema of each entry point (function names, argument
+  types, return types).
+✓ Any invariants (no side effects, no I/O during the measured call,
+  deterministic given inputs).
+✓ A one-line "what is measured" pointer for context.
+
+WHAT TO EXCLUDE:
+✗ Numeric targets. (Those are in scoring/targets.json — hidden.)
+✗ The baseline's location or expected output values.
+✗ Test inputs or their distribution.
+✗ Anything that would let a runner over-fit the measurement.
+
+FORMAT TEMPLATE (mirror this structure exactly):
+
+```markdown
+# Artifact Protocol
+
+The experiment_runner must produce the artifacts below. Conform exactly to
+paths, signatures, and schemas. Any deviation will cause the post-run
+scorer to fail.
+
+## Files to produce
+
+| Path | Purpose | Required |
+|---|---|---|
+| `src/<file>.py` | <one-line purpose> | yes |
+| `<other_path>`   | <one-line purpose> | yes/no |
+
+## Entry points
+
+### `src/<file>.py`
+
+Must define a top-level function:
+
+​```python
+def <function_name>(<args>) -> <return_type>:
+    """<one-line docstring>."""
+​```
+
+- `<arg>`: <type + valid range or description>
+- Returns: <type + meaning>
+- No side effects. No I/O during the measured call. Deterministic.
+- Must be importable via `importlib.util` without command-line args.
+
+## Invocation
+
+<one paragraph: how the scorer will load + call this artifact>
+
+## What is measured (context only — do not tune)
+
+- **<property_name>** (direction: max | min, <one-line description>)
+- **<property_name>** (direction: max | min, <one-line description>)
+
+Test inputs, the baseline, and numeric targets are sealed. Do not read
+`scoring/eval.py`, `scoring/targets.json`, or anything under `data/.test/`.
+```
+
+CONCRETE EXAMPLE — for an LCS-speedup task:
+
+```markdown
+# Artifact Protocol
+
+The experiment_runner must produce the artifacts below. Conform exactly to
+paths, signatures, and schemas. Any deviation will cause the post-run
+scorer to fail.
+
+## Files to produce
+
+| Path | Purpose | Required |
+|---|---|---|
+| `src/solution.py` | Module exposing the callable being measured | yes |
+
+## Entry points
+
+### `src/solution.py`
+
+Must define a top-level function:
+
+​```python
+def lcs(s1: str, s2: str) -> int:
+    """Return length of the longest common subsequence of s1, s2."""
+​```
+
+- `s1`, `s2`: ASCII strings, length 0–4096 (inclusive).
+- Returns: non-negative `int`.
+- No side effects. No I/O. Deterministic.
+- Must be importable via `importlib.util` without command-line args.
+
+## Invocation
+
+The scorer will import `src/solution.py` and call `lcs(s1, s2)` repeatedly
+on sealed test inputs.
+
+## What is measured (context only — do not tune)
+
+- **correctness** (direction: max, fraction of inputs where the runner's
+  output equals the reference baseline's output).
+- **speedup** (direction: max, median runtime ratio of baseline / runner).
+
+Test inputs, the baseline, and numeric targets are sealed. Do not read
+`scoring/eval.py`, `scoring/targets.json`, or anything under `data/.test/`.
+```
+
+═══════════════════════════════════════════════════════════════════════════════
+                    PHASE 3: WRITE scoring/eval.py
+═══════════════════════════════════════════════════════════════════════════════
+
+This is the per-run scorer. It will be executed (as a subprocess by the
+neurico pipeline) AFTER the runner produces its artifact. It must:
+
+✓ Be self-contained — stdlib + only the libraries the runner already
+  needs (no `import neurico`).
+✓ Load the runner's artifact via importlib (NOT subprocess).
+✓ Load any test inputs from `data/.test/` (sealed; only eval.py reads).
+✓ Compute one scalar per declared property.
+✓ Load targets from `scoring/targets.json`.
+✓ Write structured results to `scoring/results.json`.
+✓ Exit 0 regardless of whether targets are met (success vs. failure of
+  a property is recorded in results.json, not the exit code).
+
+THREE-BLOCK LAYOUT (mandatory):
+
+BLOCK 1 — boilerplate: module loader, timing helper. Copy as-is unless
+the task genuinely needs different I/O.
+
+BLOCK 2 — measurement functions: ONE function per declared property.
+Each function returns `{'value': float, 'direction': 'max' | 'min'}`.
+
+BLOCK 3 — main: load artifact + baseline + test inputs + targets; call
+measurers; assemble results.json schema; write to disk.
+
+FORMAT TEMPLATE (mirror this structure exactly):
+
+```python
+"""
+Per-run scorer for: <idea title>
+Generated by rule_maker. Measures: <comma-separated property names>.
+"""
+import json, importlib.util, time
+from pathlib import Path
+from typing import Callable, Dict, Any
+
+WS = Path(__file__).resolve().parent.parent
+EVAL_VERSION = 1
+
+# === BLOCK 1: boilerplate ===================================================
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise FileNotFoundError(f"could not import {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+def _time_median(fn: Callable, args: tuple, trials: int = 5) -> float:
+    times = []
+    for _ in range(trials):
+        t0 = time.perf_counter()
+        fn(*args)
+        times.append(time.perf_counter() - t0)
+    return sorted(times)[trials // 2]
+
+# === BLOCK 2: property measurements =========================================
+# One function per declared property. Each returns:
+#   {'value': float, 'direction': 'max' | 'min'}
+
+def measure_<property_name>(<args>) -> Dict[str, Any]:
+    """<one-line description of what this measures>."""
+    value = <compute scalar>
+    return {'value': value, 'direction': '<max|min>'}
+
+# (add more measure_* functions as needed)
+
+# === BLOCK 3: main ==========================================================
+
+def main():
+    # Load runner's artifact + reference baseline
+    runner   = _load_module("solution", WS / "src" / "<runner_file>.py").<entry>
+    baseline = _load_module("baseline", WS / "baselines" / "<baseline_file>.py").<entry>
+
+    # Load sealed test inputs
+    inputs = <load from WS / "data" / ".test" / "...">
+
+    # Load targets
+    targets = json.loads((WS / "scoring" / "targets.json").read_text())
+
+    # Run measurers and assemble per-property records
+    properties: Dict[str, Dict[str, Any]] = {}
+    for name, measurer in [
+        ("<property_name>", lambda: measure_<property_name>(<args>)),
+        # ...
+    ]:
+        p = measurer()
+        tgt = targets[name]['target']
+        p['target'] = tgt
+        p['satisfied'] = (p['value'] >= tgt if p['direction'] == 'max'
+                          else p['value'] <= tgt)
+        p['gap'] = p['value'] - tgt
+        properties[name] = p
+
+    failing = [(n, p) for n, p in properties.items() if not p['satisfied']]
+    bottleneck = (min(failing, key=lambda kv: abs(kv[1]['gap']))[0]
+                  if failing else None)
+
+    out = {
+        'properties': properties,
+        'overall_satisfied': all(p['satisfied'] for p in properties.values()),
+        'bottleneck': bottleneck,
+        'eval_meta': {'eval_version': EVAL_VERSION,
+                      'generated_by': 'rule_maker'},
+    }
+    (WS / "scoring" / "results.json").write_text(json.dumps(out, indent=2))
+
+if __name__ == "__main__":
+    main()
+```
+
+CONCRETE EXAMPLE — for an LCS-speedup task (Block 2 + Block 3 only;
+Block 1 unchanged):
+
+```python
+# === BLOCK 2: property measurements =========================================
+
+def measure_correctness(runner_fn, baseline_fn, inputs) -> Dict[str, Any]:
+    hits = sum(runner_fn(s1, s2) == baseline_fn(s1, s2) for s1, s2 in inputs)
+    return {'value': hits / len(inputs), 'direction': 'max'}
+
+def measure_speedup(runner_fn, baseline_fn, inputs) -> Dict[str, Any]:
+    ratios = [_time_median(baseline_fn, (s1, s2)) /
+              _time_median(runner_fn, (s1, s2))
+              for s1, s2 in inputs]
+    return {'value': sorted(ratios)[len(ratios) // 2], 'direction': 'max'}
+
+# === BLOCK 3: main ==========================================================
+
+def main():
+    runner   = _load_module("solution", WS / "src" / "solution.py").lcs
+    baseline = _load_module("baseline", WS / "baselines" / "naive_lcs.py").lcs
+
+    inputs = [tuple(line.split("\t")) for line in
+              (WS / "data" / ".test" / "inputs.tsv").read_text().splitlines()]
+
+    targets = json.loads((WS / "scoring" / "targets.json").read_text())
+
+    properties = {}
+    for name, measurer in [
+        ("correctness", lambda: measure_correctness(runner, baseline, inputs)),
+        ("speedup",     lambda: measure_speedup(runner, baseline, inputs[:30])),
+    ]:
+        p = measurer()
+        tgt = targets[name]['target']
+        p['target'] = tgt
+        p['satisfied'] = (p['value'] >= tgt if p['direction'] == 'max'
+                          else p['value'] <= tgt)
+        p['gap'] = p['value'] - tgt
+        properties[name] = p
+
+    failing = [(n, p) for n, p in properties.items() if not p['satisfied']]
+    bottleneck = (min(failing, key=lambda kv: abs(kv[1]['gap']))[0]
+                  if failing else None)
+
+    out = {
+        'properties': properties,
+        'overall_satisfied': all(p['satisfied'] for p in properties.values()),
+        'bottleneck': bottleneck,
+        'eval_meta': {'eval_version': EVAL_VERSION,
+                      'generated_by': 'rule_maker'},
+    }
+    (WS / "scoring" / "results.json").write_text(json.dumps(out, indent=2))
+```
+
+═══════════════════════════════════════════════════════════════════════════════
+                   PHASE 4: WRITE scoring/targets.json
+═══════════════════════════════════════════════════════════════════════════════
+
+The numeric targets and the rule that decides overall success. Kept in a
+separate file (not hardcoded in eval.py) so that targets can be refined
+between iterations without touching the scoring code.
+
+FORMAT (mirror exactly):
+
+```json
+{
+  "<property_name>": {"target": <number>, "direction": "max" | "min"},
+  "<property_name>": {"target": <number>, "direction": "max" | "min"},
+  "success_rule": "ALL_PROPERTIES_SATISFIED",
+  "meta": {
+    "generated_by": "rule_maker",
+    "domain": "<domain>",
+    "rationale_ref": "scoring/rule_maker_log.md"
+  }
+}
+```
+
+SUPPORTED `success_rule` VALUES:
+
+| Value | Meaning |
+|---|---|
+| `ALL_PROPERTIES_SATISFIED` | Every property must meet its target (default). |
+| `ANY_PROPERTY_SATISFIED`   | Any one is enough (rare; exploratory runs). |
+
+(Weighted-sum rules are reserved for a future version; do not invent.)
+
+WHERE TARGETS COME FROM:
+
+1. PREFER: explicit numbers in the idea's `evaluation_criteria` field.
+2. ELSE: numbers stated in the literature for this task.
+3. ELSE: a defensible heuristic (e.g. "1.5x speedup for a known O(n²) → O(n
+   log n) reduction") — document the choice in rule_maker_log.md.
+4. NEVER invent a number to make the run easy or hard.
+
+CONCRETE EXAMPLE (LCS speedup):
+
+```json
+{
+  "correctness": {"target": 1.0, "direction": "max"},
+  "speedup":     {"target": 3.0, "direction": "max"},
+  "success_rule": "ALL_PROPERTIES_SATISFIED",
+  "meta": {
+    "generated_by": "rule_maker",
+    "domain": "machine_learning",
+    "rationale_ref": "scoring/rule_maker_log.md"
+  }
+}
+```
+
+═══════════════════════════════════════════════════════════════════════════════
+                  PHASE 5: WRITE scoring/rule_maker_log.md
+═══════════════════════════════════════════════════════════════════════════════
+
+A free-form rationale document so the user can audit your choices, edit
+them, and re-run with refined criteria.
+
+STRUCTURE (suggested; deviate as the task warrants):
+
+```markdown
+# Rule Maker Rationale
+
+## Properties chosen
+- **<property_name>**: <why this property captures success>
+- **<property_name>**: <why>
+
+## Properties considered and rejected
+- **<rejected_name>**: <why dropped; gameable, redundant, unmeasurable?>
+
+## Targets
+- **<property_name>**: <number>, source: <idea criteria | literature | heuristic>
+- **<property_name>**: <number>, source: <...>
+
+## Baseline
+- Source: <code/ path | written by rule_maker | absolute>
+- Why this baseline is fair: <one paragraph>
+
+## Metric robustness
+- <what trivial outputs would score artificially well? How does eval.py guard against that?>
+
+## Known limitations
+- <what this scoring misses; what the user should refine if they re-run>
+```
+
+This file is visible to the user (and to a supervisor agent, if later
+iterations add one). Write it for someone who has not seen your reasoning.
+
+═══════════════════════════════════════════════════════════════════════════════
+                  PHASE 6: SELF-VALIDATE BEFORE EXITING
+═══════════════════════════════════════════════════════════════════════════════
+
+Before you finish, verify the four deliverables exist and are well-formed.
+Do NOT skip this — downstream stages parse these files mechanically.
+
+CHECKS (run each from the workspace root):
+
+1. All four files exist:
+   ```bash
+   ls scoring/interface.md scoring/eval.py scoring/targets.json scoring/rule_maker_log.md
+   ```
+
+2. eval.py parses as valid Python (does NOT execute it):
+   ```bash
+   python -c "import ast; ast.parse(open('scoring/eval.py').read()); print('eval.py: OK')"
+   ```
+
+3. targets.json parses as valid JSON:
+   ```bash
+   python -c "import json; json.load(open('scoring/targets.json')); print('targets.json: OK')"
+   ```
+
+4. interface.md is non-empty and references at least one file the runner
+   must produce:
+   ```bash
+   grep -q "Files to produce" scoring/interface.md && echo "interface.md: OK"
+   ```
+
+5. eval.py does NOT contain `import neurico` or `from neurico`:
+   ```bash
+   grep -q "neurico" scoring/eval.py && echo "FAIL: eval.py must not import neurico" || echo "eval.py: no neurico imports"
+   ```
+
+⚠️  DO NOT run `python scoring/eval.py`. The runner's artifact does not
+   exist yet; eval.py will fail and leave stale state behind.
+
+═══════════════════════════════════════════════════════════════════════════════
+                            BEST PRACTICES
+═══════════════════════════════════════════════════════════════════════════════
+
+✓ DO: Pick the smallest property set that captures success (1–3 is ideal).
+✓ DO: Use stdlib in eval.py. Add imports only for libraries already in
+       the runner's venv (numpy, sklearn, etc.).
+✓ DO: Pin every target to a source (idea, literature, or documented heuristic).
+✓ DO: Consider how a trivial runner output would score. If the trivial
+       output scores well, your measurement is wrong — revise.
+✓ DO: Write rule_maker_log.md in plain language. The user will read this.
+
+✗ DON'T: Self-tune targets to match what you guess the runner will produce.
+✗ DON'T: Embed targets in eval.py. They live in targets.json.
+✗ DON'T: Add fields outside the documented results.json schema. Anything
+         extra goes under `eval_meta`.
+✗ DON'T: Reference scoring/eval.py or scoring/targets.json from interface.md.
+✗ DON'T: Reach for complex weighting schemes — `ALL_PROPERTIES_SATISFIED`
+         is the right default. If a property's importance varies, encode
+         that in the property selection, not in a weighted sum.
+
+═══════════════════════════════════════════════════════════════════════════════
+                            TROUBLESHOOTING
+═══════════════════════════════════════════════════════════════════════════════
+
+IF: the idea has no quantifiable evaluation criterion
+THEN:
+  1. Identify the closest measurable proxy (e.g. an open-ended "improve
+     summarization" → ROUGE on a held-out split).
+  2. Document the choice and its limitations in rule_maker_log.md.
+  3. Set a defensible target (literature value, or "beat baseline by X%").
+
+IF: no baseline is available in code/ and writing one is non-trivial
+THEN:
+  1. Use an absolute target with no baseline (direction max/min on the
+     raw value).
+  2. Document the absence in rule_maker_log.md.
+  3. Note that without a baseline, speedup-style ratio measurements are
+     not possible — pick a different property.
+
+IF: the resource_finder did not produce a `data/.test/` split
+THEN:
+  1. Create one in eval.py (NOT in interface.md). Hold out a fixed
+     fraction of any available data using a deterministic seed; write
+     the held-out subset to data/.test/ at scorer-execution time.
+  2. Document the split strategy in rule_maker_log.md.
+
+IF: a property is hard to measure deterministically (timing,
+    random initialization)
+THEN:
+  1. Take a median over multiple trials (≥5) using the `_time_median`
+     helper or an equivalent.
+  2. Document the trial count and aggregation method in rule_maker_log.md.
+
+IF: you are tempted to add a new field to results.json (e.g. "warnings",
+    "diagnostics")
+THEN:
+  1. Put it under `eval_meta` to keep the top-level schema fixed.
+  2. The downstream consumers (scorer.py, paper_writer, supervisor)
+     read the fixed top-level keys; anything else is informational.
+
+═══════════════════════════════════════════════════════════════════════════════
+
+Remember: you are writing the protocol that decides whether this run
+succeeded. Your code will be read by the user, executed by the scorer,
+and consulted by the next iteration's supervisor. Make every choice
+explicit and every file mechanically parseable.

--- a/templates/base/researcher_scoring_addendum.txt
+++ b/templates/base/researcher_scoring_addendum.txt
@@ -1,0 +1,52 @@
+                  SCORING MODE: ARTIFACT PROTOCOL AND ADHERENCE
+═══════════════════════════════════════════════════════════════════════════════
+
+This run is in SCORING MODE. A separate stage (the rule_maker) has written a
+per-run artifact protocol to your workspace, and a post-run scorer will
+measure your output against that protocol independently of anything you
+report.
+
+BEFORE Phase 1 planning you MUST read:
+
+- scoring/interface.md: Specifies the files you must produce, their paths,
+  function signatures, and how they will be invoked by the post-run scorer.
+
+The following files have been MOVED OUT of your workspace for the duration
+of your run. They will be restored after you finish, for the post-run
+scorer. If you somehow do see them, do NOT read them:
+
+- scoring/eval.py            (the scorer code itself)
+- scoring/targets.json       (numeric targets + success rule)
+- scoring/rule_maker_log.md  (rationale doc; contains target values)
+
+Your artifact must conform EXACTLY to scoring/interface.md -- file paths,
+function signatures, output schemas. This is a protocol, not a guideline.
+
+───────────────────────────────────────────────────────────────────────────────
+Output format adherence
+
+All artifacts your implementation produces must conform EXACTLY to the
+protocol in scoring/interface.md:
+   ✓ Produce every file listed in interface.md, at the exact path given
+   ✓ Match every function signature exactly (names, argument counts, types)
+   ✓ Match every output schema exactly (JSON shapes, return types)
+   ✗ Do NOT add fields, paths, or files not requested by interface.md
+   ✗ Do NOT improvise on the protocol -- any deviation will cause the
+     post-run scorer to fail
+
+If interface.md is ambiguous, document the ambiguity in your planning.md
+and pick the most conservative interpretation. Do NOT modify anything
+under scoring/; eval.py and targets.json are sealed.
+
+───────────────────────────────────────────────────────────────────────────────
+General principles for scoring mode
+
+   ✓ Conform EXACTLY to scoring/interface.md -- paths, signatures, schemas
+   ✓ Treat the interface as a protocol, not a suggestion
+   ✓ Produce artifacts only -- the scorer measures them independently
+   ✗ Do NOT write metric numbers into REPORT.md or anywhere else; the
+     scorer is the authoritative source of truth on measured values
+   ✗ Do NOT read scoring/eval.py, scoring/targets.json, or
+     scoring/rule_maker_log.md (these have been moved out of the workspace
+     anyway)
+   ✗ Do NOT modify anything under scoring/


### PR DESCRIPTION
## Summary

Adds a new optional **scoring mode** to the neurico pipeline that produces per-run, protocol-based evaluation metrics. Enabled by `./neurico run <id> --enable-scoring`. The default (non-scoring) mode is unchanged.

This PR ships the **backbone of the rule_maker extension**: the two new agents (`rule_maker`, `scorer`), the sealing mechanism between them, and the wiring to plug them into the existing orchestrator and CLI. Several planned extensions on top of this backbone (domain-specific supplements, vetted skeleton library, runner sandboxing) are described at the bottom and will land in follow-up PRs.

## How the rule_maker / scorer loop works

The pipeline becomes:

```
resource_finder → rule_maker → [seal scoring/] → experiment_runner → [unseal] → scorer
```

Three actors close a loop around a single protocol:

1. **rule_maker (writer).** Reads the idea, literature review, and resources catalog. Decides *what to measure* (2–4 scalar properties), *what counts as success* (numeric targets), and *how to test it*. Writes four files under `scoring/`:
   - `interface.md` — the runner-facing API spec (file paths, function signatures, input/output schemas).
   - `eval.py` — executable scorer that computes the property values from the runner's artifacts.
   - `targets.json` — numeric pass/fail thresholds and the success rule.
   - `rule_maker_log.md` — rationale (which properties, why these targets, anti-gaming considerations).

2. **runner (implementer).** Sees only `interface.md`. The other three files are moved out of the workspace for the duration of this stage — into a sibling `.scoring_sealed/<workspace>/` directory — so the runner cannot read the eval code or numeric targets. The runner produces artifacts (typically `src/solution.py`) that match the spec exactly.

3. **scorer (judge).** After the runner finishes, the sealed files are restored. `scoring/eval.py` is executed (using the workspace's own `.venv` Python if present) and writes `scoring/results.json` with `{per-property value vs. target, overall_satisfied, bottleneck}`.

The protocol is what closes the loop: the same `eval.py` that the rule_maker wrote is what the scorer executes. The runner can't tune to it (sealed during the runner stage), and it can't lie about its results (the scorer's `results.json` is the authoritative verdict — not the runner's `REPORT.md`).

Default mode is preserved bit-identically — every new code path is gated on `scoring_enabled=False`.

## What's in this PR

**New files (4):**
- `src/agents/rule_maker.py` — agent module (prompt assembly, run, output validation, protocol loading)
- `src/core/scorer.py` — runs `scoring/eval.py`, captures results, resolves the workspace's Python interpreter
- `templates/agents/rule_maker.txt` — general rule_maker prompt (METHODOLOGY → 6 PHASEs → BEST PRACTICES → TROUBLESHOOTING)
- `templates/base/researcher_scoring_addendum.txt` — banner-delimited block appended to the researcher prompt in scoring mode (artifact protocol + sealed-files notice + output-format adherence)

**Modified files (3):**
- `src/core/pipeline_orchestrator.py` — adds `scoring_enabled=False` flag to `run_pipeline()`, plus `_run_rule_maker`, `_run_scorer`, `_sealed_dir_for`, `_seal_runner_inputs`, `_unseal_runner_inputs`. Default arg = False = bit-identical to today.
- `src/core/runner.py` — adds `--enable-scoring`, `--rule-maker-timeout`, `--scorer-timeout` CLI flags; threads them through `run_research()`.
- `src/templates/prompt_generator.py` — adds `scoring_enabled=False` to `generate_research_prompt()`; appends the addendum as one banner-delimited section when true (mirrors the existing `if domain_template:` pattern).

## Planned extensions on this backbone

The pieces below build on what this PR ships. They are intentionally separate PRs so this one stays focused on the backbone:

- **Domain-specific rule_maker supplements** (`templates/domains/<domain>/rule_maker.txt`). The other agents (resource_finder, paper_writer) ship per-domain prompt supplements alongside the general prompt. The rule_maker general prompt works standalone today; the domain supplements (artificial_intelligence, battery, data_science, finance, machine_learning, mathematics, mathematics_lean, particle_physics) will land as a follow-up so each domain gets tailored property selection guidance and worked examples.
- **Vetted `eval.py` skeleton library** (`templates/scoring_examples/`). The current rule_maker writes `scoring/eval.py` from scratch each run. A follow-up will ship a small library of vetted skeleton scripts (algorithmic-speedup, trained-artifact, etc.) the rule_maker can copy and adapt — faster runs, fewer eval bugs, and reviewable scorer code.
- **Runner sandboxing**. The current seal is a move-and-restore; an adversarial runner with filesystem access could traverse `..` and find `.scoring_sealed/`. A real sandbox (containers or namespaces) is a follow-up. The current threat model is aligned-but-undisciplined runners.
- **Default-mode integration**. Scoring mode is opt-in via `--enable-scoring`. After enough empirical validation, a follow-up will fold it into the default pipeline.

## Test plan

- [x] Default-mode prompt is bit-identical to pre-merge (verified: no `SCORING MODE` / `rule_maker` / `scoring/interface.md` strings present)
- [x] Scored-mode prompt = default-mode + addendum (+~2.6KB)
- [x] `runner.py --help` shows new flags; pre-existing flags unchanged
- [x] All touched Python files compile
- [x] No references to deleted parallel files (`scored_pipeline_orchestrator.py`, `run_scored.py`, `researcher_scored.txt`) remain
- [x] Style consistency check: banner convention (`═` major, `─` sub), emoji palette, docstring style, no `# ----` dividers, no unicode box chars — all match peer files (`researcher.txt`, `resource_finder.py`, `paper_writer.py`)
- [x] **Full E2E run** with `--enable-scoring` on a substring-search hypothesis: 4 stages execute cleanly (rule_maker 152s, runner 730s, scorer 0.2s), seal/unseal leaves no `.scoring_sealed/` residue, scorer produces structurally valid `results.json` with `{per-property values, satisfied flags, gaps, overall_satisfied, bottleneck}`. (The hypothesis itself was empirically refuted — a pure-Python BMH cannot beat CPython's C-level `str.find` — which is the framework correctly reporting an honest failure, not a framework bug.)
