### PR TITLE
feat: add AutoResearch loop with checkpointed experiment continuation

### DIFF
--- a/src/agents/autoresearch_proposer.py
+++ b/src/agents/autoresearch_proposer.py
@@ -1,0 +1,313 @@
+"""
+AutoResearch Proposal Generator Agent.
+
+This module launches a provider CLI agent to write one structured proposal for
+the next AutoResearch attempt. The agent is a planner only: it writes
+proposal.md into the attempt history directory and must not modify the research
+workspace.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.security import sanitize_text
+
+
+CLI_COMMANDS = {
+    "claude": "claude -p",
+    "codex": "codex exec",
+    "gemini": "gemini",
+}
+
+TRANSCRIPT_FLAGS = {
+    "claude": "--verbose --output-format stream-json",
+    "codex": "--json",
+    "gemini": "--output-format stream-json",
+}
+
+
+def generate_autoresearch_proposal_prompt(
+    idea: Dict[str, Any],
+    work_dir: Path,
+    parent_sha: str,
+    attempt_dir: Path,
+    templates_dir: Path,
+    attempt_history: Optional[list[Dict[str, Any]]] = None,
+) -> str:
+    """
+    Generate the AutoResearch proposer prompt from a curated public context.
+
+    The proposer receives public experiment artifacts and a src/ file tree only.
+    It does not receive source file contents or hidden scoring internals.
+    """
+    from jinja2 import Environment, FileSystemLoader
+
+    work_dir = Path(work_dir)
+    attempt_dir = Path(attempt_dir)
+    templates_dir = Path(templates_dir)
+
+    template_path = templates_dir / "agents" / "autoresearch_proposer.txt"
+    if not template_path.exists():
+        raise FileNotFoundError(f"AutoResearch proposer template not found: {template_path}")
+
+    env = Environment(
+        loader=FileSystemLoader(str(templates_dir)),
+        autoescape=False,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    template = env.get_template("agents/autoresearch_proposer.txt")
+
+    idea_spec = idea.get("idea", idea)
+    context = collect_public_proposal_context(
+        work_dir=work_dir,
+        attempt_history=attempt_history or [],
+    )
+
+    return template.render(
+        title=idea_spec.get("title", "Untitled Research"),
+        domain=idea_spec.get("domain", ""),
+        work_dir=str(work_dir),
+        parent_sha=parent_sha,
+        attempt_dir=str(attempt_dir),
+        proposal_path=str(attempt_dir / "proposal.md"),
+        public_context=context,
+    )
+
+
+def collect_public_proposal_context(
+    work_dir: Path,
+    attempt_history: Optional[list[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """
+    Build the public context for proposal generation.
+
+    This intentionally includes only public scoring artifacts, public reports,
+    a shallow results summary, current-node attempt history, and an src/ file
+    tree. It never reads hidden scoring internals or source file contents.
+    """
+    work_dir = Path(work_dir)
+
+    context: Dict[str, Any] = {
+        "scoring_interface_md": _read_text_if_exists(work_dir / "scoring" / "interface.md"),
+        "scoring_results_json": _read_json_or_text(work_dir / "scoring" / "results.json"),
+        "report_md": _read_text_if_exists(work_dir / "REPORT.md"),
+        "planning_md": _read_text_if_exists(work_dir / "planning.md"),
+        "results_summary": _summarize_directory(work_dir / "results"),
+        "results_metrics_json": _read_json_or_text(work_dir / "results" / "metrics.json"),
+        "src_tree": _list_tree(work_dir / "src"),
+        "attempt_history": attempt_history or [],
+    }
+    return context
+
+
+def run_autoresearch_proposer(
+    idea: Dict[str, Any],
+    work_dir: Path,
+    parent_sha: str,
+    attempt_dir: Path,
+    provider: str = "claude",
+    templates_dir: Optional[Path] = None,
+    timeout: int = 900,
+    full_permissions: bool = True,
+    attempt_history: Optional[list[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """
+    Launch the AutoResearch proposer agent.
+
+    Returns a dict with success, proposal_path, prompt_file, transcript_file,
+    elapsed_time, and error when applicable.
+    """
+    if provider not in CLI_COMMANDS:
+        raise ValueError(
+            f"Unsupported provider: {provider}. Choose from: {list(CLI_COMMANDS.keys())}"
+        )
+
+    if templates_dir is None:
+        templates_dir = Path(__file__).parent.parent.parent / "templates"
+
+    work_dir = Path(work_dir)
+    attempt_dir = Path(attempt_dir)
+    attempt_dir.mkdir(parents=True, exist_ok=True)
+    proposal_path = attempt_dir / "proposal.md"
+
+    print(f"🧭 Starting AutoResearch Proposal Generator")
+    print(f"   Provider: {provider}")
+    print(f"   Work dir: {work_dir}")
+    print(f"   Parent node: {parent_sha}")
+    print(f"   Attempt dir: {attempt_dir}")
+    print(f"   Timeout: {timeout}s ({timeout // 60} minutes)")
+    print("=" * 80)
+
+    prompt = generate_autoresearch_proposal_prompt(
+        idea=idea,
+        work_dir=work_dir,
+        parent_sha=parent_sha,
+        attempt_dir=attempt_dir,
+        templates_dir=Path(templates_dir),
+        attempt_history=attempt_history,
+    )
+
+    prompt_file = attempt_dir / "proposer_prompt.txt"
+    prompt_file.write_text(prompt, encoding="utf-8")
+    print(f"   Prompt saved to: {prompt_file}")
+    print(f"   Prompt length: {len(prompt)} characters")
+
+    cmd = CLI_COMMANDS[provider]
+    if full_permissions:
+        if provider == "codex":
+            cmd += " --yolo"
+        elif provider == "claude":
+            cmd += " --dangerously-skip-permissions"
+        elif provider == "gemini":
+            cmd += " --yolo --skip-trust"
+
+    transcript_flag = TRANSCRIPT_FLAGS.get(provider, "")
+    if transcript_flag:
+        cmd += f" {transcript_flag}"
+
+    transcript_file = attempt_dir / f"proposer_{provider}_transcript.jsonl"
+
+    print(f"▶️  Launching {provider} CLI proposer...")
+    print(f"   Command: {cmd}")
+    print(f"   Proposal: {proposal_path}")
+    print(f"   Transcript: {transcript_file}")
+    print()
+
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+    if provider == "gemini":
+        env["GEMINI_CLI_IDE_DISABLE"] = "1"
+
+    start_time = time.time()
+    return_code: Optional[int] = None
+    error: Optional[str] = None
+
+    try:
+        with open(transcript_file, "w", encoding="utf-8") as transcript_f:
+            process = subprocess.Popen(
+                shlex.split(cmd),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                env=env,
+                text=True,
+                encoding="utf-8",
+                bufsize=1,
+                cwd=str(attempt_dir),
+            )
+
+            process.stdin.write(prompt)
+            process.stdin.close()
+
+            for line in iter(process.stdout.readline, ""):
+                if line:
+                    sanitized_line = sanitize_text(line)
+                    print(sanitized_line, end="")
+                    transcript_f.write(sanitized_line)
+
+            return_code = process.wait(timeout=timeout)
+
+    except subprocess.TimeoutExpired:
+        process.kill()
+        error = f"AutoResearch proposer timed out after {timeout}s"
+        print(f"\n⏱️  {error}")
+    except Exception as e:
+        error = f"AutoResearch proposer error: {e}"
+        print(f"\n❌ {error}")
+        raise
+
+    elapsed = time.time() - start_time
+    proposal_exists = proposal_path.exists() and proposal_path.stat().st_size > 0
+    success = return_code == 0 and proposal_exists and error is None
+
+    if not proposal_exists and error is None:
+        error = f"proposal.md was not created at {proposal_path}"
+
+    if success:
+        print(f"✅ AutoResearch proposal generated in {elapsed:.1f}s")
+    else:
+        print(
+            f"⚠️  AutoResearch proposer finished with issues "
+            f"(return_code={return_code}, error={error})"
+        )
+
+    return {
+        "success": success,
+        "return_code": return_code,
+        "proposal_path": str(proposal_path),
+        "prompt_file": str(prompt_file),
+        "transcript_file": str(transcript_file),
+        "elapsed_time": elapsed,
+        "error": error,
+    }
+
+
+def _read_text_if_exists(path: Path) -> str:
+    if not path.exists() or not path.is_file():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _read_json_or_text(path: Path) -> Any:
+    if not path.exists() or not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def _summarize_directory(path: Path) -> list[Dict[str, Any]]:
+    if not path.exists() or not path.is_dir():
+        return []
+    entries = []
+    for child in sorted(path.rglob("*")):
+        rel = child.relative_to(path).as_posix()
+        if _is_hidden_context_path(rel):
+            continue
+        if child.is_file():
+            entries.append(
+                {
+                    "path": rel,
+                    "type": "file",
+                    "bytes": child.stat().st_size,
+                }
+            )
+        elif child.is_dir():
+            entries.append(
+                {
+                    "path": rel + "/",
+                    "type": "dir",
+                }
+            )
+    return entries
+
+
+def _list_tree(path: Path) -> list[str]:
+    if not path.exists() or not path.is_dir():
+        return []
+    tree = []
+    for child in sorted(path.rglob("*")):
+        rel = child.relative_to(path).as_posix()
+        if _is_hidden_context_path(rel):
+            continue
+        suffix = "/" if child.is_dir() else ""
+        tree.append(f"src/{rel}{suffix}")
+    return tree
+
+
+def _is_hidden_context_path(rel_path: str) -> bool:
+    normalized = rel_path.strip("/")
+    hidden_roots = (".scoring_sealed", "data/.test")
+    return any(normalized == root or normalized.startswith(f"{root}/") for root in hidden_roots)

--- a/src/agents/rule_maker.py
+++ b/src/agents/rule_maker.py
@@ -1,0 +1,439 @@
+"""
+Rule Maker Agent
+
+Launches a CLI agent that, given the user's idea and the resource_finder's
+outputs, writes a per-run evaluation harness into the workspace under
+scoring/. The harness consists of:
+
+- scoring/eval.py: a self-contained Python program that measures the
+  experiment_runner's artifact and writes scoring/results.json.
+- scoring/targets.json: numeric targets and the success rule.
+- scoring/interface.md: visible to the experiment_runner -- describes what
+  files the runner must produce and how they will be invoked.
+- scoring/rule_maker_log.md: rationale for the chosen metrics.
+
+This agent runs between resource_finder and experiment_runner. Its outputs
+should be sealed (read-only) before experiment_runner starts so the runner
+cannot influence what it is being judged on.
+"""
+
+from pathlib import Path
+from typing import Optional, Dict, Any
+import subprocess
+import shlex
+import os
+import sys
+import time
+import json
+import ast
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.security import sanitize_text
+
+
+# CLI commands for different providers (mirrors resource_finder.py)
+CLI_COMMANDS = {
+    'claude': 'claude -p',
+    'codex': 'codex exec',
+    'gemini': 'gemini',
+}
+
+# Verbose / structured-transcript output flags per provider
+TRANSCRIPT_FLAGS = {
+    'claude': '--verbose --output-format stream-json',
+    'codex': '--json',
+    'gemini': '--output-format stream-json',
+}
+
+# Files the rule_maker is responsible for producing (relative to scoring/)
+RULE_MAKER_OUTPUT_FILES = {
+    'eval_script': 'eval.py',
+    'targets': 'targets.json',
+    'interface': 'interface.md',
+    'rationale_log': 'rule_maker_log.md',
+}
+
+
+def generate_rule_maker_prompt(
+    idea: Dict[str, Any],
+    work_dir: Path,
+    templates_dir: Path,
+    domain: Optional[str] = None,
+) -> str:
+    """
+    Build the rule_maker agent's prompt.
+
+    Composition (mirrors the researcher prompt pattern):
+
+      1. General body: templates/base/rule_maker.txt
+         -- the universal rule_maker job description, applied to every run.
+      2. Domain supplement (optional): templates/domains/<domain>/rule_maker.txt
+         -- domain-specific guidelines (what metrics matter in this domain,
+            calibration conventions, common reward-hacking traps, etc.).
+
+    Placeholders substituted in the general body:
+      {idea_yaml}        -- the idea spec (JSON-serialized for readability)
+      {workspace}        -- absolute path to the run's workspace
+      {scoring_dir}      -- absolute path to scoring/
+      {output_files}     -- list of files the agent must produce
+      {resource_listing} -- short summary of resource_finder outputs
+
+    Args:
+        idea: Full idea specification.
+        work_dir: Path to the run's workspace.
+        templates_dir: Path to the project's templates/ directory.
+        domain: Domain name (e.g. 'machine_learning'). If None, extracted
+            from idea['idea']['domain'] or idea['domain'], defaulting to
+            'machine_learning' (matches researcher prompt's default).
+
+    The prompt BODIES are user-owned and live in the template files. This
+    function only handles loading + substitution + concatenation.
+    """
+    work_dir = Path(work_dir)
+    templates_dir = Path(templates_dir)
+
+    # Load the general body. It lives at templates/agents/rule_maker.txt,
+    # alongside the other per-run agents (resource_finder.txt, paper_writer.txt).
+    # Per-domain supplements live separately at templates/domains/<d>/rule_maker.txt.
+    base_path = templates_dir / "agents" / "rule_maker.txt"
+    if not base_path.exists():
+        raise FileNotFoundError(
+            f"rule_maker base template not found at {base_path}. "
+            "Create templates/agents/rule_maker.txt before running."
+        )
+    base_template = base_path.read_text(encoding='utf-8')
+
+    scoring_dir = work_dir / "scoring"
+    output_files = "\n".join(
+        f"  - scoring/{name}" for name in RULE_MAKER_OUTPUT_FILES.values()
+    )
+    resource_listing = _summarize_resource_outputs(work_dir)
+
+    try:
+        idea_repr = json.dumps(idea, indent=2, default=str)
+    except (TypeError, ValueError):
+        idea_repr = repr(idea)
+
+    substitutions = {
+        '{idea_yaml}': idea_repr,
+        '{workspace}': str(work_dir),
+        '{scoring_dir}': str(scoring_dir),
+        '{output_files}': output_files,
+        '{resource_listing}': resource_listing,
+    }
+
+    prompt = base_template
+    for placeholder, value in substitutions.items():
+        prompt = prompt.replace(placeholder, value)
+
+    # Append per-domain supplement (if any) with a banner.
+    resolved_domain = _resolve_domain(idea, domain)
+    supplement = _load_domain_supplement(templates_dir, resolved_domain)
+    if supplement:
+        banner = "=" * 80
+        domain_label = resolved_domain.upper().replace('_', ' ')
+        prompt = (
+            f"{prompt}\n\n"
+            f"{banner}\n"
+            f"           RULE MAKER DOMAIN GUIDELINES: {domain_label}\n"
+            f"{banner}\n\n"
+            f"{supplement}\n"
+        )
+
+    return prompt
+
+
+def _resolve_domain(
+    idea: Dict[str, Any], override: Optional[str]
+) -> str:
+    """
+    Pick the domain string used to locate the domain supplement.
+
+    Order of precedence:
+      1. Explicit `override` argument.
+      2. idea['idea']['domain']  (nested spec, as elsewhere in the pipeline).
+      3. idea['domain']          (flat spec).
+      4. Fallback: 'machine_learning' (matches researcher default).
+    """
+    if override:
+        return override
+    nested = idea.get('idea', {}) if isinstance(idea, dict) else {}
+    if isinstance(nested, dict) and nested.get('domain'):
+        return nested['domain']
+    if isinstance(idea, dict) and idea.get('domain'):
+        return idea['domain']
+    return 'machine_learning'
+
+
+def _load_domain_supplement(templates_dir: Path, domain: str) -> str:
+    """
+    Load templates/domains/<domain>/rule_maker.txt if present.
+
+    Returns empty string when the supplement is missing -- the general
+    body alone is then used. (No silent fallback to a different domain;
+    that decision is left to the caller / pipeline.)
+    """
+    supplement_path = templates_dir / "domains" / domain / "rule_maker.txt"
+    if not supplement_path.exists():
+        return ""
+    return supplement_path.read_text(encoding='utf-8')
+
+
+def _summarize_resource_outputs(work_dir: Path) -> str:
+    """
+    Build a short, prompt-safe listing of what resource_finder produced.
+
+    The rule_maker needs to know which files / folders exist so it can
+    reference them in eval.py, but it should not have raw resource
+    contents dumped into its prompt.
+    """
+    work_dir = Path(work_dir)
+    candidates = [
+        ("literature_review.md", work_dir / "literature_review.md"),
+        ("resources.md", work_dir / "resources.md"),
+        ("papers/", work_dir / "papers"),
+        ("datasets/", work_dir / "datasets"),
+        ("code/", work_dir / "code"),
+    ]
+    lines = []
+    for label, path in candidates:
+        if not path.exists():
+            lines.append(f"  - {label}: (missing)")
+            continue
+        if path.is_dir():
+            entries = sorted(p.name for p in path.iterdir())
+            preview = ", ".join(entries[:8])
+            extra = "" if len(entries) <= 8 else f", +{len(entries) - 8} more"
+            lines.append(
+                f"  - {label}: {len(entries)} entries [{preview}{extra}]"
+            )
+        else:
+            size = path.stat().st_size
+            lines.append(f"  - {label}: {size} bytes")
+    return "\n".join(lines) if lines else "  (no resource_finder outputs found)"
+
+
+def run_rule_maker(
+    idea: Dict[str, Any],
+    work_dir: Path,
+    provider: str = "claude",
+    templates_dir: Optional[Path] = None,
+    timeout: int = 1800,  # 30 min
+    full_permissions: bool = True,
+) -> Dict[str, Any]:
+    """
+    Launch the rule_maker CLI agent.
+
+    Returns:
+        Dict with: success, outputs (paths of generated files), issues,
+        log_file, transcript_file, elapsed_time.
+    """
+    if provider not in CLI_COMMANDS:
+        raise ValueError(
+            f"Unsupported provider: {provider}. "
+            f"Choose from: {list(CLI_COMMANDS.keys())}"
+        )
+
+    if templates_dir is None:
+        templates_dir = Path(__file__).parent.parent.parent / "templates"
+
+    work_dir = Path(work_dir)
+    scoring_dir = work_dir / "scoring"
+    scoring_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir = work_dir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"📐 Starting Rule Maker Agent")
+    print(f"   Provider: {provider}")
+    print(f"   Work dir: {work_dir}")
+    print(f"   Timeout: {timeout}s ({timeout // 60} minutes)")
+    print("=" * 80)
+
+    # Generate prompt and persist it for debugging
+    prompt = generate_rule_maker_prompt(idea, work_dir, templates_dir)
+    prompt_file = logs_dir / "rule_maker_prompt.txt"
+    prompt_file.write_text(prompt, encoding='utf-8')
+    print(f"   Prompt saved to: {prompt_file}")
+    print(f"   Prompt length: {len(prompt)} characters")
+
+    # Build CLI command
+    cmd = CLI_COMMANDS[provider]
+    if full_permissions:
+        if provider == "codex":
+            cmd += " --yolo"
+        elif provider == "claude":
+            cmd += " --dangerously-skip-permissions"
+        elif provider == "gemini":
+            cmd += " --yolo --skip-trust"
+
+    transcript_flag = TRANSCRIPT_FLAGS.get(provider, '')
+    if transcript_flag:
+        cmd += f" {transcript_flag}"
+
+    log_file = logs_dir / f"rule_maker_{provider}.log"
+    transcript_file = logs_dir / f"rule_maker_{provider}_transcript.jsonl"
+
+    print(f"▶️  Launching {provider} CLI agent...")
+    print(f"   Command: {cmd}")
+    print(f"   Log file: {log_file}")
+    print()
+    print("=" * 80)
+    print("RULE MAKER OUTPUT (streaming)")
+    print("=" * 80)
+
+    env = os.environ.copy()
+    env['PYTHONUNBUFFERED'] = '1'
+    if provider == "gemini":
+        env['GEMINI_CLI_IDE_DISABLE'] = '1'
+
+    start_time = time.time()
+
+    try:
+        with open(log_file, 'w', encoding='utf-8') as log_f, \
+                open(transcript_file, 'w', encoding='utf-8') as transcript_f:
+            process = subprocess.Popen(
+                shlex.split(cmd),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                env=env,
+                text=True,
+                encoding='utf-8',
+                bufsize=1,
+                cwd=str(work_dir),
+            )
+            process.stdin.write(prompt)
+            process.stdin.close()
+
+            for line in iter(process.stdout.readline, ''):
+                if line:
+                    sanitized = sanitize_text(line)
+                    print(sanitized, end='')
+                    log_f.write(sanitized)
+                    transcript_f.write(sanitized)
+
+            return_code = process.wait(timeout=timeout)
+
+        print()
+        print("=" * 80)
+        elapsed = time.time() - start_time
+        print(
+            f"⏱️  Rule maker completed in {elapsed:.1f}s "
+            f"({elapsed / 60:.1f} minutes)"
+        )
+
+        if return_code == 0:
+            print("✅ Agent process exited cleanly.")
+        else:
+            print(f"⚠️  Agent exited with return code: {return_code}")
+
+    except subprocess.TimeoutExpired:
+        print(f"\n⏱️  Rule maker timed out after {timeout} seconds")
+        process.kill()
+
+    except Exception as e:
+        print(f"\n❌ Error during rule_maker execution: {e}")
+        raise
+
+    # Validate outputs
+    print()
+    print("📦 Validating rule_maker outputs...")
+    validation = validate_rule_maker_outputs(work_dir)
+    success = validation['valid']
+    if success:
+        print("✅ All required rule_maker outputs present and parseable.")
+    else:
+        print("⚠️  Rule maker outputs incomplete or invalid:")
+        for issue in validation['issues']:
+            print(f"     - {issue}")
+
+    return {
+        'success': success,
+        'outputs': validation['found'],
+        'issues': validation['issues'],
+        'log_file': str(log_file),
+        'transcript_file': str(transcript_file),
+        'elapsed_time': time.time() - start_time,
+    }
+
+
+def validate_rule_maker_outputs(work_dir: Path) -> Dict[str, Any]:
+    """
+    Verify the rule_maker produced the expected files in a usable form.
+
+    Checks:
+      - scoring/eval.py exists and parses as valid Python
+      - scoring/targets.json exists and parses as valid JSON
+      - scoring/interface.md exists and is non-empty
+      - scoring/rule_maker_log.md exists (informational; not required)
+
+    Returns:
+        {'valid': bool, 'found': {name: path}, 'issues': [str, ...]}
+    """
+    work_dir = Path(work_dir)
+    scoring_dir = work_dir / "scoring"
+    found: Dict[str, str] = {}
+    issues = []
+
+    eval_path = scoring_dir / RULE_MAKER_OUTPUT_FILES['eval_script']
+    if not eval_path.exists():
+        issues.append(f"missing: {eval_path}")
+    else:
+        try:
+            ast.parse(eval_path.read_text(encoding='utf-8'))
+            found['eval_script'] = str(eval_path)
+        except SyntaxError as e:
+            issues.append(f"eval.py has syntax error: {e}")
+
+    targets_path = scoring_dir / RULE_MAKER_OUTPUT_FILES['targets']
+    if not targets_path.exists():
+        issues.append(f"missing: {targets_path}")
+    else:
+        try:
+            json.loads(targets_path.read_text(encoding='utf-8'))
+            found['targets'] = str(targets_path)
+        except json.JSONDecodeError as e:
+            issues.append(f"targets.json is not valid JSON: {e}")
+
+    interface_path = scoring_dir / RULE_MAKER_OUTPUT_FILES['interface']
+    if not interface_path.exists():
+        issues.append(f"missing: {interface_path}")
+    elif interface_path.stat().st_size == 0:
+        issues.append(f"empty: {interface_path}")
+    else:
+        found['interface'] = str(interface_path)
+
+    rationale_path = scoring_dir / RULE_MAKER_OUTPUT_FILES['rationale_log']
+    if rationale_path.exists():
+        found['rationale_log'] = str(rationale_path)
+
+    return {
+        'valid': len(issues) == 0,
+        'found': found,
+        'issues': issues,
+    }
+
+
+def load_interface_for_runner(work_dir: Path) -> str:
+    """
+    Read scoring/interface.md to inject into the experiment_runner's prompt.
+
+    This is the ONE channel by which rule_maker's output reaches the runner.
+    Everything else under scoring/ (eval.py, targets.json) is hidden from
+    the runner.
+
+    Raises:
+        FileNotFoundError: If interface.md is missing -- the pipeline should
+        not proceed to experiment_runner without it.
+    """
+    interface_path = (
+        Path(work_dir) / "scoring" / RULE_MAKER_OUTPUT_FILES['interface']
+    )
+    if not interface_path.exists():
+        raise FileNotFoundError(
+            f"scoring/interface.md not found at {interface_path}. "
+            "rule_maker must run successfully before experiment_runner."
+        )
+    return interface_path.read_text(encoding='utf-8')

--- a/src/core/autoresearch.py
+++ b/src/core/autoresearch.py
@@ -1,0 +1,1129 @@
+"""
+AutoResearch support primitives.
+
+This module contains the product-neutral pieces used by the AutoResearch loop:
+Git checkpoints for workspace nodes and external attempt history. It does not
+run agents or make proposal decisions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Optional
+import json
+import math
+import re
+import shutil
+import tempfile
+from datetime import datetime
+
+from core.scorer import load_scoring_results
+from core.scoring_seal import seal_scoring_files, unseal_scoring_files
+
+try:
+    from git import Repo, InvalidGitRepositoryError, NoSuchPathError
+    from git.exc import GitCommandError
+
+    GITPYTHON_AVAILABLE = True
+except ImportError:
+    GITPYTHON_AVAILABLE = False
+
+
+AUTORESEARCH_GIT_USER_NAME = "NeuriCo AutoResearch"
+AUTORESEARCH_GIT_USER_EMAIL = "noreply@neurico.dev"
+
+HIDDEN_SCORING_PATTERNS = (
+    "scoring/eval.py",
+    "scoring/targets.json",
+    "scoring/rule_maker_log.md",
+    "data/.test/",
+    ".scoring_sealed/",
+)
+
+AUTORESEARCH_LOG_PATTERNS = ("logs/experiment-autoresearch/",)
+AUTORESEARCH_STATE_PATTERNS = (".neurico/autoresearch_state.json",)
+AGENT_LOCAL_PATTERNS = (".claude/", ".gemini/", ".codex/")
+PAPER_OUTPUT_PATTERNS = (
+    "paper/",
+    "paper_draft/",
+    "templates/paper_writing/",
+    "logs/paper_writer_prompt.txt",
+    "logs/paper_writer_*.log",
+)
+
+CHECKPOINT_EXCLUDE_PATTERNS = (
+    HIDDEN_SCORING_PATTERNS
+    + AUTORESEARCH_LOG_PATTERNS
+    + AUTORESEARCH_STATE_PATTERNS
+    + AGENT_LOCAL_PATTERNS
+    + PAPER_OUTPUT_PATTERNS
+)
+
+COMPARISON_EPS = 1e-6
+
+ProposalGeneratorHook = Callable[
+    [Dict[str, Any], Path, str, Path, list[Dict[str, Any]]],
+    Any,
+]
+CommentModeHook = Callable[[Dict[str, Any], Path], Dict[str, Any]]
+ScorerHook = Callable[[Path], Dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    """A Git-backed AutoResearch node."""
+
+    sha: str
+    message: str
+
+    @property
+    def node_id(self) -> str:
+        """Node id used in attempt history paths."""
+        return self.sha
+
+
+@dataclass(frozen=True)
+class AutoResearchIterationResult:
+    """Result for one AutoResearch candidate attempt."""
+
+    iteration: int
+    parent_sha: str
+    child_sha: Optional[str]
+    attempt_dir: Path
+    accepted: bool
+    reason: str
+    proposal: str
+    comment_result: Dict[str, Any]
+    scorer_result: Dict[str, Any]
+    parent_summary: ScoreSummary
+    candidate_summary: ScoreSummary
+
+
+@dataclass(frozen=True)
+class AutoResearchRunResult:
+    """Summary of an AutoResearch controller run."""
+
+    success: bool
+    initial_sha: str
+    current_best_sha: str
+    iterations: list[AutoResearchIterationResult] = field(default_factory=list)
+
+
+class CheckpointManager:
+    """
+    Manages AutoResearch node checkpoints inside a workspace Git repository.
+
+    If the workspace is not already a Git repository, this class initializes a
+    local-only repository. It does not create remotes or push.
+    """
+
+    def __init__(self, work_dir: Path):
+        if not GITPYTHON_AVAILABLE:
+            raise ImportError("GitPython is required for AutoResearch checkpoints")
+
+        self.work_dir = Path(work_dir)
+        self.work_dir.mkdir(parents=True, exist_ok=True)
+        self.repo = self._open_or_init_repo()
+        self._ensure_local_git_identity()
+        self._ensure_checkpoint_excludes()
+
+    def _open_or_init_repo(self) -> "Repo":
+        try:
+            return Repo(self.work_dir)
+        except (InvalidGitRepositoryError, NoSuchPathError):
+            return Repo.init(self.work_dir)
+
+    def _ensure_local_git_identity(self) -> None:
+        with self.repo.config_writer() as config:
+            try:
+                config.get_value("user", "name")
+            except Exception:
+                config.set_value("user", "name", AUTORESEARCH_GIT_USER_NAME)
+            try:
+                config.get_value("user", "email")
+            except Exception:
+                config.set_value("user", "email", AUTORESEARCH_GIT_USER_EMAIL)
+
+    def _ensure_checkpoint_excludes(self) -> None:
+        exclude_path = self.work_dir / ".git" / "info" / "exclude"
+        exclude_path.parent.mkdir(parents=True, exist_ok=True)
+
+        existing = exclude_path.read_text(encoding="utf-8") if exclude_path.exists() else ""
+        existing_lines = {line.strip() for line in existing.splitlines()}
+
+        additions = [
+            pattern for pattern in CHECKPOINT_EXCLUDE_PATTERNS if pattern not in existing_lines
+        ]
+        if not additions:
+            return
+
+        with exclude_path.open("a", encoding="utf-8") as f:
+            if existing and not existing.endswith("\n"):
+                f.write("\n")
+            if "# AutoResearch checkpoint excludes" not in existing_lines:
+                f.write("\n# AutoResearch checkpoint excludes\n")
+            for pattern in additions:
+                f.write(f"{pattern}\n")
+
+    @property
+    def has_commits(self) -> bool:
+        try:
+            _ = self.repo.head.commit
+            return True
+        except ValueError:
+            return False
+
+    def create_checkpoint(self, message: str) -> Checkpoint:
+        """
+        Commit the current public experiment state and return the new node.
+
+        Hidden scoring harness files and AutoResearch controller logs are
+        excluded by .git/info/exclude for untracked files and explicitly
+        removed from checkpoint commits for existing repositories.
+        """
+        self.repo.git.add(A=True)
+
+        if self.has_commits:
+            self._remove_checkpoint_excludes_from_index()
+
+        if not self._has_staged_changes():
+            if not self.has_commits:
+                raise RuntimeError(
+                    "Cannot create initial AutoResearch checkpoint: "
+                    "workspace has no public files to commit"
+                )
+            head = self.repo.head.commit
+            return Checkpoint(sha=head.hexsha, message=message)
+
+        commit = self.repo.index.commit(message)
+        return Checkpoint(sha=commit.hexsha, message=message)
+
+    def restore_checkpoint(self, sha: str) -> None:
+        """
+        Restore tracked workspace files to a checkpoint.
+
+        This intentionally avoids `git clean` so ignored datasets, venvs, and
+        other local resources are preserved. AutoResearch controller logs are
+        additionally preserved across reset so attempt history remains a
+        permanent workspace log, not part of mutable experiment state.
+        """
+        preserved_paths = self._copy_preserved_paths_to_temp(
+            AUTORESEARCH_LOG_PATTERNS + PAPER_OUTPUT_PATTERNS
+        )
+        try:
+            self.repo.git.reset("--hard", sha)
+        finally:
+            if preserved_paths is not None:
+                self._restore_preserved_paths_from_temp(preserved_paths)
+
+    def current_sha(self) -> Optional[str]:
+        if not self.has_commits:
+            return None
+        return self.repo.head.commit.hexsha
+
+    def _remove_checkpoint_excludes_from_index(self) -> None:
+        for rel_path in self._checkpoint_excludes_present_or_tracked():
+            try:
+                self.repo.git.rm("--cached", "--ignore-unmatch", "--", rel_path)
+            except GitCommandError:
+                pass
+
+    def _checkpoint_excludes_present_or_tracked(self) -> Iterable[str]:
+        seen = set()
+        for pattern in CHECKPOINT_EXCLUDE_PATTERNS:
+            if pattern.endswith("/"):
+                root = self.work_dir / pattern.rstrip("/")
+                if root.exists():
+                    for path in root.rglob("*"):
+                        if path.is_file():
+                            rel = path.relative_to(self.work_dir).as_posix()
+                            seen.add(rel)
+                continue
+            if (self.work_dir / pattern).exists():
+                seen.add(pattern)
+
+        if self.has_commits:
+            try:
+                tracked = self.repo.git.ls_files(*CHECKPOINT_EXCLUDE_PATTERNS)
+                for line in tracked.splitlines():
+                    if line.strip():
+                        seen.add(line.strip())
+            except GitCommandError:
+                pass
+
+        return sorted(seen)
+
+    def _has_staged_changes(self) -> bool:
+        try:
+            self.repo.git.diff("--cached", "--quiet")
+            return False
+        except GitCommandError as e:
+            return e.status == 1
+
+    def _copy_preserved_paths_to_temp(self, patterns: Iterable[str]) -> Optional[Path]:
+        temp_parent: Optional[Path] = None
+        for rel_path in self._matching_workspace_paths(patterns):
+            source = self.work_dir / rel_path
+            if not source.exists():
+                continue
+            if temp_parent is None:
+                temp_parent = Path(tempfile.mkdtemp(prefix="neurico-autoresearch-preserve-"))
+            target = temp_parent / rel_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if source.is_dir():
+                shutil.copytree(source, target, dirs_exist_ok=True)
+            elif source.is_file():
+                shutil.copy2(source, target)
+        return temp_parent
+
+    def _restore_preserved_paths_from_temp(self, temp_parent: Path) -> None:
+        try:
+            for source in sorted(temp_parent.rglob("*")):
+                if source.is_dir():
+                    continue
+                rel_path = source.relative_to(temp_parent)
+                target = self.work_dir / rel_path
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, target)
+        finally:
+            shutil.rmtree(temp_parent, ignore_errors=True)
+
+    def _matching_workspace_paths(self, patterns: Iterable[str]) -> list[Path]:
+        matches: set[Path] = set()
+        for pattern in patterns:
+            if pattern.endswith("/"):
+                rel_dir = Path(pattern.rstrip("/"))
+                if (self.work_dir / rel_dir).exists():
+                    matches.add(rel_dir)
+                continue
+            if "*" in pattern:
+                matches.update(
+                    path.relative_to(self.work_dir)
+                    for path in self.work_dir.glob(pattern)
+                    if path.exists()
+                )
+                continue
+            rel_file = Path(pattern)
+            if (self.work_dir / rel_file).exists():
+                matches.add(rel_file)
+        return sorted(matches)
+
+
+class AttemptHistoryManager:
+    """Stores AutoResearch attempt history under a NeuriCo logs directory."""
+
+    def __init__(self, history_root: Path, idea_id: str):
+        self.history_root = Path(history_root)
+        self.idea_id = idea_id
+        self.history_root.mkdir(parents=True, exist_ok=True)
+
+    def next_attempt_dir(self, parent_sha: str) -> Path:
+        parent_dir = self.parent_dir(parent_sha)
+        existing = [
+            self._attempt_number(path.name)
+            for path in parent_dir.glob("attempt_*")
+            if path.is_dir()
+        ]
+        next_number = (max(existing) + 1) if existing else 1
+        attempt_dir = parent_dir / f"attempt_{next_number}"
+        attempt_dir.mkdir(parents=True, exist_ok=False)
+        return attempt_dir
+
+    def parent_dir(self, parent_sha: str) -> Path:
+        node_dir = self.history_root / self._safe_path_component(parent_sha)
+        node_dir.mkdir(parents=True, exist_ok=True)
+        return node_dir
+
+    def record_attempt(
+        self,
+        parent_sha: str,
+        child_sha: str,
+        proposal: str,
+        results_path: Path,
+        decision: Dict[str, Any],
+    ) -> Path:
+        attempt_dir = self.next_attempt_dir(parent_sha)
+        self.write_proposal(attempt_dir, proposal)
+        self.complete_attempt(
+            attempt_dir=attempt_dir,
+            parent_sha=parent_sha,
+            child_sha=child_sha,
+            results_path=results_path,
+            decision=decision,
+        )
+        return attempt_dir
+
+    def write_proposal(self, attempt_dir: Path, proposal: str) -> Path:
+        """Write the proposal as the first artifact of an attempt record."""
+        attempt_dir = Path(attempt_dir)
+        attempt_dir.mkdir(parents=True, exist_ok=True)
+        proposal_path = attempt_dir / "proposal.md"
+        proposal_path.write_text(proposal, encoding="utf-8")
+        return proposal_path
+
+    def complete_attempt(
+        self,
+        attempt_dir: Path,
+        parent_sha: str,
+        child_sha: str,
+        results_path: Path,
+        decision: Dict[str, Any],
+    ) -> Path:
+        """Fill in the post-comment-mode artifacts for an existing attempt."""
+        attempt_dir = Path(attempt_dir)
+        attempt_dir.mkdir(parents=True, exist_ok=True)
+
+        (attempt_dir / "child_pointer.txt").write_text(f"{child_sha}\n", encoding="utf-8")
+
+        results_path = Path(results_path)
+        if results_path.exists():
+            shutil.copyfile(results_path, attempt_dir / "results.json")
+        else:
+            (attempt_dir / "results.json").write_text(
+                json.dumps({"error": "results.json missing"}, indent=2),
+                encoding="utf-8",
+            )
+
+        decision_payload = dict(decision)
+        decision_payload.setdefault("parent_sha", parent_sha)
+        decision_payload.setdefault("child_sha", child_sha)
+        (attempt_dir / "decision.json").write_text(
+            json.dumps(decision_payload, indent=2),
+            encoding="utf-8",
+        )
+        return attempt_dir
+
+    def list_attempts(self, parent_sha: str) -> list[Path]:
+        parent_dir = self.parent_dir(parent_sha)
+        return sorted(
+            [path for path in parent_dir.glob("attempt_*") if path.is_dir()],
+            key=lambda path: self._attempt_number(path.name),
+        )
+
+    def load_attempt_summaries(self, parent_sha: str) -> list[Dict[str, Any]]:
+        summaries = []
+        for attempt_dir in self.list_attempts(parent_sha):
+            decision_path = attempt_dir / "decision.json"
+            proposal_path = attempt_dir / "proposal.md"
+            child_path = attempt_dir / "child_pointer.txt"
+
+            decision: Dict[str, Any] = {}
+            if decision_path.exists():
+                try:
+                    decision = json.loads(decision_path.read_text(encoding="utf-8"))
+                except json.JSONDecodeError:
+                    decision = {"error": "invalid decision.json"}
+
+            summaries.append(
+                {
+                    "attempt_dir": str(attempt_dir),
+                    "proposal": proposal_path.read_text(encoding="utf-8")
+                    if proposal_path.exists()
+                    else "",
+                    "child_sha": child_path.read_text(encoding="utf-8").strip()
+                    if child_path.exists()
+                    else "",
+                    "decision": decision,
+                }
+            )
+        return summaries
+
+    @staticmethod
+    def _attempt_number(name: str) -> int:
+        match = re.fullmatch(r"attempt_(\d+)", name)
+        return int(match.group(1)) if match else 0
+
+    @staticmethod
+    def _safe_path_component(value: str) -> str:
+        safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", value.strip())
+        return safe or "unknown"
+
+
+@dataclass(frozen=True)
+class ScoreSummary:
+    """Normalized view of a scoring/results.json payload."""
+
+    valid: bool
+    source: str
+    properties: Optional[Dict[str, Dict[str, Any]]] = None
+    error: Optional[str] = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "valid": self.valid,
+            "source": self.source,
+            "properties": self.properties,
+            "error": self.error,
+        }
+
+
+@dataclass(frozen=True)
+class ComparisonDecision:
+    """Deterministic accept/reject decision for a candidate scoring result."""
+
+    accepted: bool
+    reason: str
+    parent_summary: ScoreSummary
+    candidate_summary: ScoreSummary
+
+
+class ScoringResultComparator:
+    """Compares AutoResearch parent/candidate scorer outputs."""
+
+    def compare_files(
+        self,
+        parent_results_path: Path,
+        candidate_results_path: Path,
+    ) -> ComparisonDecision:
+        parent = self.load_summary(parent_results_path, source="parent")
+        candidate = self.load_summary(candidate_results_path, source="candidate")
+        return self.compare(parent, candidate)
+
+    def compare(
+        self,
+        parent: ScoreSummary,
+        candidate: ScoreSummary,
+    ) -> ComparisonDecision:
+        if not candidate.valid:
+            return ComparisonDecision(
+                accepted=False,
+                reason=f"Candidate scoring result is invalid: {candidate.error}",
+                parent_summary=parent,
+                candidate_summary=candidate,
+            )
+
+        if candidate.properties is None:
+            return ComparisonDecision(
+                accepted=False,
+                reason="Candidate scoring result has no comparable properties.",
+                parent_summary=parent,
+                candidate_summary=candidate,
+            )
+
+        if parent.properties is None:
+            return ComparisonDecision(
+                accepted=False,
+                reason="Parent scoring result has no comparable properties.",
+                parent_summary=parent,
+                candidate_summary=candidate,
+            )
+
+        return self._compare_properties(parent, candidate)
+
+    def _compare_properties(
+        self,
+        parent: ScoreSummary,
+        candidate: ScoreSummary,
+    ) -> ComparisonDecision:
+        assert parent.properties is not None
+        assert candidate.properties is not None
+
+        if not candidate.properties:
+            return ComparisonDecision(
+                accepted=False,
+                reason="Candidate scoring result has no comparable properties.",
+                parent_summary=parent,
+                candidate_summary=candidate,
+            )
+
+        parent_keys = set(parent.properties)
+        candidate_keys = set(candidate.properties)
+        if parent_keys != candidate_keys:
+            return ComparisonDecision(
+                accepted=False,
+                reason="Parent and candidate scoring properties do not match.",
+                parent_summary=parent,
+                candidate_summary=candidate,
+            )
+
+        for name in sorted(candidate_keys):
+            parent_prop = parent.properties[name]
+            candidate_prop = candidate.properties[name]
+            if parent_prop["direction"] != candidate_prop["direction"]:
+                return ComparisonDecision(
+                    accepted=False,
+                    reason=f"Scoring property direction changed for {name}.",
+                    parent_summary=parent,
+                    candidate_summary=candidate,
+                )
+            if abs(parent_prop["target"] - candidate_prop["target"]) > COMPARISON_EPS:
+                return ComparisonDecision(
+                    accepted=False,
+                    reason=f"Scoring property target changed for {name}.",
+                    parent_summary=parent,
+                    candidate_summary=candidate,
+                )
+
+        parent_satisfied = {name for name, prop in parent.properties.items() if prop["satisfied"]}
+        candidate_satisfied = {
+            name for name, prop in candidate.properties.items() if prop["satisfied"]
+        }
+        lost_satisfied = sorted(parent_satisfied - candidate_satisfied)
+        gained_satisfied = sorted(candidate_satisfied - parent_satisfied)
+
+        if lost_satisfied:
+            return ComparisonDecision(
+                accepted=False,
+                reason=(
+                    "Candidate loses previously satisfied scoring properties: "
+                    f"{', '.join(lost_satisfied)}."
+                ),
+                parent_summary=parent,
+                candidate_summary=candidate,
+            )
+
+        if gained_satisfied:
+            return ComparisonDecision(
+                accepted=True,
+                reason=(
+                    "Candidate satisfies a strict superset of parent scoring "
+                    f"properties: {', '.join(gained_satisfied)}."
+                ),
+                parent_summary=parent,
+                candidate_summary=candidate,
+            )
+
+        improved_properties = []
+        for name in sorted(candidate_keys):
+            parent_prop = parent.properties[name]
+            candidate_prop = candidate.properties[name]
+            parent_margin = parent_prop["margin"]
+            candidate_margin = candidate_prop["margin"]
+            if candidate_margin < parent_margin - COMPARISON_EPS:
+                return ComparisonDecision(
+                    accepted=False,
+                    reason=f"Candidate regressed normalized margin for scoring property {name}.",
+                    parent_summary=parent,
+                    candidate_summary=candidate,
+                )
+            if candidate_margin > parent_margin + COMPARISON_EPS:
+                improved_properties.append(name)
+
+        if improved_properties:
+            return ComparisonDecision(
+                accepted=True,
+                reason=(
+                    "Candidate keeps the same satisfied-property set, has no metric "
+                    "normalized-margin regressions, and improves "
+                    f"{', '.join(improved_properties)}."
+                ),
+                parent_summary=parent,
+                candidate_summary=candidate,
+            )
+
+        return ComparisonDecision(
+            accepted=False,
+            reason=(
+                "Candidate keeps the same satisfied-property set but does not improve any metric."
+            ),
+            parent_summary=parent,
+            candidate_summary=candidate,
+        )
+
+    def load_summary(self, results_path: Path, source: str = "results") -> ScoreSummary:
+        results_path = Path(results_path)
+        payload = self._load_results_payload(results_path)
+        if payload is not None:
+            return self.summarize(payload, source=source)
+
+        if not results_path.exists():
+            return ScoreSummary(
+                valid=False,
+                source=source,
+                error=f"results.json not found at {results_path}",
+            )
+
+        try:
+            payload = json.loads(results_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            return ScoreSummary(
+                valid=False,
+                source=source,
+                error=f"results.json is not valid JSON: {e}",
+            )
+
+        return self.summarize(payload, source=source)
+
+    @staticmethod
+    def _load_results_payload(results_path: Path) -> Optional[Dict[str, Any]]:
+        if results_path.name == "results.json" and results_path.parent.name == "scoring":
+            return load_scoring_results(results_path.parent.parent)
+        return None
+
+    def summarize(self, payload: Dict[str, Any], source: str = "results") -> ScoreSummary:
+        if not isinstance(payload, dict):
+            return ScoreSummary(
+                valid=False, source=source, error="results payload is not an object"
+            )
+
+        properties = payload.get("properties")
+        if isinstance(properties, dict):
+            try:
+                comparable_properties = {}
+                for name, prop in properties.items():
+                    if not isinstance(name, str):
+                        raise ValueError("property name is not a string")
+                    if not isinstance(prop, dict):
+                        raise ValueError("property record is not an object")
+                    comparable_prop = self._normalize_property(prop)
+                    comparable_properties[name] = comparable_prop
+                return ScoreSummary(
+                    valid=True,
+                    source=source,
+                    properties=comparable_properties,
+                )
+            except (KeyError, TypeError, ValueError) as e:
+                return ScoreSummary(
+                    valid=False,
+                    source=source,
+                    error=f"invalid properties schema: {e}",
+                )
+
+        return ScoreSummary(
+            valid=False,
+            source=source,
+            error="results payload has no properties",
+        )
+
+    @staticmethod
+    def _finite_float(value: Any, field_name: str) -> float:
+        if isinstance(value, bool):
+            raise ValueError(f"{field_name} is not numeric")
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"{field_name} is not numeric") from e
+        if not math.isfinite(numeric):
+            raise ValueError(f"{field_name} is not finite")
+        return numeric
+
+    @classmethod
+    def _normalize_property(cls, prop: Dict[str, Any]) -> Dict[str, Any]:
+        direction = prop["direction"]
+        if direction not in {"max", "min"}:
+            raise ValueError(f"Unknown direction: {direction}")
+        value = cls._finite_float(prop["value"], "value")
+        target = cls._finite_float(prop["target"], "target")
+        satisfied = prop["satisfied"]
+        if not isinstance(satisfied, bool):
+            raise ValueError("satisfied is not boolean")
+        normalized = {
+            "value": value,
+            "target": target,
+            "direction": direction,
+        }
+        return {
+            "value": value,
+            "target": target,
+            "direction": direction,
+            "satisfied": satisfied,
+            "margin": normalized_margin(normalized),
+        }
+
+
+class AutoResearchController:
+    """
+    Runs the experiment-stage AutoResearch loop.
+
+    The controller is intentionally thin: proposal generation, comment-mode
+    modification, and scoring are injected callables. Phase 5 wires those
+    callables to NeuriCo's existing agents; Phase 4 tests use fakes.
+    """
+
+    def __init__(
+        self,
+        idea: Dict[str, Any],
+        idea_id: str,
+        work_dir: Path,
+        history_root: Path,
+        proposal_generator: ProposalGeneratorHook,
+        comment_mode: CommentModeHook,
+        scorer: ScorerHook,
+        checkpoint_manager: Optional[CheckpointManager] = None,
+        history_manager: Optional[AttemptHistoryManager] = None,
+        comparator: Optional[ScoringResultComparator] = None,
+    ):
+        self.idea = idea
+        self.idea_id = idea_id
+        self.work_dir = Path(work_dir)
+        self.checkpoints = checkpoint_manager or CheckpointManager(self.work_dir)
+        self.history = history_manager or AttemptHistoryManager(history_root, idea_id)
+        self.comparator = comparator or ScoringResultComparator()
+        self.proposal_generator = proposal_generator
+        self.comment_mode = comment_mode
+        self.scorer = scorer
+
+    def run(self, iterations: int) -> AutoResearchRunResult:
+        """
+        Execute AutoResearch iterations from the current scored workspace state.
+
+        The initial checkpoint is created from the already-scored public state.
+        Each candidate checkpoint is created only after the scorer writes that
+        candidate's own scoring/results.json.
+        """
+        if iterations < 0:
+            raise ValueError("iterations must be non-negative")
+
+        self._ensure_results_json("initial")
+        initial = self.checkpoints.create_checkpoint("AutoResearch initial public scored state")
+        current_best_sha = initial.sha
+        iteration_results: list[AutoResearchIterationResult] = []
+
+        for iteration in range(1, iterations + 1):
+            result = self.run_iteration(iteration, current_best_sha)
+            iteration_results.append(result)
+            if result.accepted and result.child_sha:
+                current_best_sha = result.child_sha
+
+        self.checkpoints.restore_checkpoint(current_best_sha)
+        return AutoResearchRunResult(
+            success=True,
+            initial_sha=initial.sha,
+            current_best_sha=current_best_sha,
+            iterations=iteration_results,
+        )
+
+    def run_iteration(
+        self,
+        iteration: int,
+        parent_sha: str,
+    ) -> AutoResearchIterationResult:
+        """Run one proposal/comment/scorer/checkpoint/compare attempt."""
+        self.checkpoints.restore_checkpoint(parent_sha)
+        parent_results_path = self.work_dir / "scoring" / "results.json"
+        parent_summary = self.comparator.load_summary(
+            parent_results_path,
+            source="parent",
+        )
+
+        attempt_history = self.history.load_attempt_summaries(parent_sha)
+        attempt_dir = self.history.next_attempt_dir(parent_sha)
+
+        sealed_dir = seal_scoring_files(self.work_dir)
+        proposal = ""
+        comment_result: Dict[str, Any] = {}
+        pre_scoring_error: Optional[str] = None
+        try:
+            try:
+                proposal_result = self.proposal_generator(
+                    self.idea,
+                    self.work_dir,
+                    parent_sha,
+                    attempt_dir,
+                    attempt_history,
+                )
+                proposal = self._resolve_proposal_text(attempt_dir, proposal_result)
+                self.history.write_proposal(attempt_dir, proposal)
+
+                comment_idea = self._idea_with_comments(proposal)
+                comment_result = self.comment_mode(comment_idea, self.work_dir)
+            except Exception as e:
+                pre_scoring_error = str(e)
+                comment_result = {
+                    "success": False,
+                    "error": f"AutoResearch proposal/comment stage failed: {e}",
+                }
+        finally:
+            unseal_scoring_files(self.work_dir, sealed_dir)
+
+        if pre_scoring_error is not None:
+            candidate_summary = ScoreSummary(
+                valid=False,
+                source="candidate",
+                error=f"AutoResearch proposal/comment stage failed: {pre_scoring_error}",
+            )
+            decision_payload = {
+                "parent_node_id": parent_sha,
+                "parent_sha": parent_sha,
+                "child_node_id": None,
+                "child_sha": None,
+                "accepted": False,
+                "reason": candidate_summary.error,
+                "parent_score_summary": parent_summary.as_dict(),
+                "child_score_summary": candidate_summary.as_dict(),
+                "comment_result": comment_result,
+                "scorer_result": {},
+            }
+            self._record_failed_before_checkpoint(
+                attempt_dir=attempt_dir,
+                parent_sha=parent_sha,
+                results_path=self.work_dir / "scoring" / "results.json",
+                decision=decision_payload,
+                failure_results={
+                    "overall_satisfied": False,
+                    "error": candidate_summary.error,
+                    "generated_by": "autoresearch",
+                    "created_at": datetime.now().isoformat(),
+                },
+            )
+            self.checkpoints.restore_checkpoint(parent_sha)
+            return AutoResearchIterationResult(
+                iteration=iteration,
+                parent_sha=parent_sha,
+                child_sha=None,
+                attempt_dir=attempt_dir,
+                accepted=False,
+                reason=candidate_summary.error,
+                proposal=proposal,
+                comment_result=comment_result,
+                scorer_result={},
+                parent_summary=parent_summary,
+                candidate_summary=candidate_summary,
+            )
+
+        self._clear_stale_results_json()
+        try:
+            scorer_result = self.scorer(self.work_dir)
+        except Exception as e:
+            scorer_result = {
+                "success": False,
+                "error": f"AutoResearch scorer raised an exception: {e}",
+            }
+        results_path = self._ensure_results_json(
+            stage="candidate",
+            scorer_result=scorer_result,
+        )
+
+        candidate_checkpoint: Optional[Checkpoint] = None
+        child_sha: Optional[str] = None
+        checkpoint_error: Optional[str] = None
+        try:
+            candidate_checkpoint = self.checkpoints.create_checkpoint(
+                f"AutoResearch candidate iteration {iteration}"
+            )
+            child_sha = candidate_checkpoint.sha
+        except Exception as e:
+            checkpoint_error = str(e)
+
+        candidate_summary = self.comparator.load_summary(
+            results_path,
+            source="candidate",
+        )
+        decision = self.comparator.compare(parent_summary, candidate_summary)
+        accepted = decision.accepted and child_sha is not None
+        reason = decision.reason
+        if checkpoint_error:
+            accepted = False
+            reason = f"Candidate could not be checkpointed: {checkpoint_error}"
+
+        decision_payload = {
+            "parent_node_id": parent_sha,
+            "parent_sha": parent_sha,
+            "child_node_id": child_sha,
+            "child_sha": child_sha,
+            "accepted": accepted,
+            "reason": reason,
+            "parent_score_summary": parent_summary.as_dict(),
+            "child_score_summary": candidate_summary.as_dict(),
+            "comment_result": comment_result,
+            "scorer_result": scorer_result,
+        }
+
+        if child_sha:
+            self.history.complete_attempt(
+                attempt_dir=attempt_dir,
+                parent_sha=parent_sha,
+                child_sha=child_sha,
+                results_path=results_path,
+                decision=decision_payload,
+            )
+        else:
+            self._record_failed_before_checkpoint(
+                attempt_dir=attempt_dir,
+                parent_sha=parent_sha,
+                results_path=results_path,
+                decision=decision_payload,
+            )
+
+        if not accepted:
+            self.checkpoints.restore_checkpoint(parent_sha)
+
+        return AutoResearchIterationResult(
+            iteration=iteration,
+            parent_sha=parent_sha,
+            child_sha=child_sha,
+            attempt_dir=attempt_dir,
+            accepted=accepted,
+            reason=reason,
+            proposal=proposal,
+            comment_result=comment_result,
+            scorer_result=scorer_result,
+            parent_summary=parent_summary,
+            candidate_summary=candidate_summary,
+        )
+
+    def _ensure_results_json(
+        self,
+        stage: str,
+        scorer_result: Optional[Dict[str, Any]] = None,
+    ) -> Path:
+        """
+        Ensure a public scoring/results.json exists for node traceability.
+
+        If the scorer fails before producing results.json, write a small public
+        failure payload so the candidate state can still be checkpointed.
+        """
+        results_path = self.work_dir / "scoring" / "results.json"
+        if results_path.exists():
+            return results_path
+
+        results_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "overall_satisfied": False,
+            "error": f"AutoResearch {stage} scorer did not produce scoring/results.json",
+            "scorer_result": scorer_result or {},
+            "generated_by": "autoresearch",
+            "created_at": datetime.now().isoformat(),
+        }
+        results_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return results_path
+
+    @staticmethod
+    def _resolve_proposal_text(attempt_dir: Path, proposal_result: Any) -> str:
+        proposal_path = Path(attempt_dir) / "proposal.md"
+        if isinstance(proposal_result, str):
+            return proposal_result
+        if isinstance(proposal_result, dict):
+            if isinstance(proposal_result.get("proposal"), str):
+                return proposal_result["proposal"]
+            path_value = proposal_result.get("proposal_path")
+            if path_value and Path(path_value).exists():
+                return Path(path_value).read_text(encoding="utf-8")
+        if proposal_path.exists():
+            return proposal_path.read_text(encoding="utf-8")
+        raise RuntimeError("Proposal generator did not return or write proposal.md")
+
+    def _idea_with_comments(self, proposal: str) -> Dict[str, Any]:
+        idea_copy = json.loads(json.dumps(self.idea, default=str))
+        idea_spec = idea_copy.setdefault("idea", {})
+        idea_spec["comments"] = proposal
+        return idea_copy
+
+    def _clear_stale_results_json(self) -> None:
+        results_path = self.work_dir / "scoring" / "results.json"
+        if results_path.exists():
+            results_path.unlink()
+
+    def _record_failed_before_checkpoint(
+        self,
+        attempt_dir: Path,
+        parent_sha: str,
+        results_path: Path,
+        decision: Dict[str, Any],
+        failure_results: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        attempt_dir = Path(attempt_dir)
+        (attempt_dir / "child_pointer.txt").write_text("", encoding="utf-8")
+        results_path = Path(results_path)
+        if failure_results is not None:
+            (attempt_dir / "results.json").write_text(
+                json.dumps(failure_results, indent=2),
+                encoding="utf-8",
+            )
+        elif results_path.exists():
+            shutil.copyfile(results_path, attempt_dir / "results.json")
+        else:
+            (attempt_dir / "results.json").write_text(
+                json.dumps({"error": "results.json missing"}, indent=2),
+                encoding="utf-8",
+            )
+        decision_payload = dict(decision)
+        decision_payload.setdefault("parent_sha", parent_sha)
+        decision_payload.setdefault("child_sha", None)
+        (attempt_dir / "decision.json").write_text(
+            json.dumps(decision_payload, indent=2),
+            encoding="utf-8",
+        )
+
+
+def run_autoresearch_loop(
+    idea: Dict[str, Any],
+    idea_id: str,
+    work_dir: Path,
+    history_root: Path,
+    iterations: int,
+    provider: str = "claude",
+    templates_dir: Optional[Path] = None,
+    full_permissions: bool = True,
+    proposal_timeout: int = 900,
+    comment_timeout: int = 1800,
+    scorer_timeout: int = 600,
+) -> AutoResearchRunResult:
+    """
+    Run AutoResearch with NeuriCo's real proposer, comment handler, and scorer.
+
+    This is the production integration point used by runner.py in Phase 6.
+    """
+    from agents.autoresearch_proposer import run_autoresearch_proposer
+    from agents.comment_handler import run_comment_handler
+    from core.scorer import run_scorer
+
+    work_dir = Path(work_dir)
+    if templates_dir is None:
+        templates_dir = Path(__file__).parent.parent.parent / "templates"
+
+    def proposal_generator(
+        idea_payload: Dict[str, Any],
+        proposal_work_dir: Path,
+        parent_sha: str,
+        attempt_dir: Path,
+        attempt_history: list[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        return run_autoresearch_proposer(
+            idea=idea_payload,
+            work_dir=proposal_work_dir,
+            parent_sha=parent_sha,
+            attempt_dir=attempt_dir,
+            provider=provider,
+            templates_dir=templates_dir,
+            timeout=proposal_timeout,
+            full_permissions=full_permissions,
+            attempt_history=attempt_history,
+        )
+
+    def comment_mode(comment_idea: Dict[str, Any], comment_work_dir: Path) -> Dict[str, Any]:
+        return run_comment_handler(
+            idea=comment_idea,
+            work_dir=comment_work_dir,
+            provider=provider,
+            templates_dir=templates_dir,
+            timeout=comment_timeout,
+            full_permissions=full_permissions,
+        )
+
+    def scorer(score_work_dir: Path) -> Dict[str, Any]:
+        return run_scorer(
+            work_dir=score_work_dir,
+            timeout=scorer_timeout,
+        )
+
+    controller = AutoResearchController(
+        idea=idea,
+        idea_id=idea_id,
+        work_dir=work_dir,
+        history_root=history_root,
+        proposal_generator=proposal_generator,
+        comment_mode=comment_mode,
+        scorer=scorer,
+    )
+    return controller.run(iterations=iterations)
+
+
+def normalized_margin(prop: Dict[str, Any]) -> float:
+    """
+    Relative target margin for one scorer property.
+
+    For max properties the margin is (value - target) / max(abs(target), 1).
+    For min properties the margin is (target - value) / max(abs(target), 1).
+    Higher margin is better.
+    """
+    value = ScoringResultComparator._finite_float(prop["value"], "value")
+    target = ScoringResultComparator._finite_float(prop["target"], "target")
+    direction = prop["direction"]
+    denom = max(abs(target), 1.0)
+    if direction == "max":
+        return (value - target) / denom
+    if direction == "min":
+        return (target - value) / denom
+    raise ValueError(f"Unknown direction: {direction}")

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -21,15 +21,15 @@ and tracks pipeline state.
 """
 
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Optional, Dict, Any
 import json
-import shutil
 from datetime import datetime
 import time
 
 from agents.resource_finder import run_resource_finder
 from agents.rule_maker import run_rule_maker
 from core.scorer import run_scorer
+from core.scoring_seal import sealed_dir_for, seal_scoring_files, unseal_scoring_files
 from templates.research_agent_instructions import generate_instructions
 
 
@@ -43,86 +43,77 @@ class PipelineState:
 
         # Initialize or load state
         if self.state_file.exists():
-            with open(self.state_file, 'r', encoding='utf-8') as f:
+            with open(self.state_file, "r", encoding="utf-8") as f:
                 self.state = json.load(f)
         else:
             self.state = {
-                'created_at': datetime.now().isoformat(),
-                'stages': {},
-                'current_stage': None,
-                'completed': False
+                "created_at": datetime.now().isoformat(),
+                "stages": {},
+                "current_stage": None,
+                "completed": False,
             }
             self._save()
 
     def _save(self):
         """Save state to disk."""
-        with open(self.state_file, 'w', encoding='utf-8') as f:
+        with open(self.state_file, "w", encoding="utf-8") as f:
             json.dump(self.state, f, indent=2)
 
     def start_stage(self, stage_name: str):
         """Mark a stage as started."""
-        self.state['current_stage'] = stage_name
-        self.state['stages'][stage_name] = {
-            'status': 'in_progress',
-            'started_at': datetime.now().isoformat(),
-            'completed_at': None,
-            'success': None,
-            'outputs': {}
+        self.state["current_stage"] = stage_name
+        self.state["stages"][stage_name] = {
+            "status": "in_progress",
+            "started_at": datetime.now().isoformat(),
+            "completed_at": None,
+            "success": None,
+            "outputs": {},
         }
         self._save()
 
     def complete_stage(self, stage_name: str, success: bool, outputs: Optional[Dict] = None):
         """Mark a stage as completed."""
-        if stage_name not in self.state['stages']:
-            self.state['stages'][stage_name] = {}
+        if stage_name not in self.state["stages"]:
+            self.state["stages"][stage_name] = {}
 
-        self.state['stages'][stage_name].update({
-            'status': 'completed' if success else 'failed',
-            'completed_at': datetime.now().isoformat(),
-            'success': success,
-            'outputs': outputs or {}
-        })
-        self.state['current_stage'] = None
+        self.state["stages"][stage_name].update(
+            {
+                "status": "completed" if success else "failed",
+                "completed_at": datetime.now().isoformat(),
+                "success": success,
+                "outputs": outputs or {},
+            }
+        )
+        self.state["current_stage"] = None
         self._save()
 
     def mark_completed(self):
         """Mark entire pipeline as completed."""
-        self.state['completed'] = True
-        self.state['completed_at'] = datetime.now().isoformat()
+        self.state["completed"] = True
+        self.state["completed_at"] = datetime.now().isoformat()
         self._save()
 
     def get_stage_status(self, stage_name: str) -> Optional[str]:
         """Get status of a stage (in_progress, completed, failed, or None)."""
-        return self.state['stages'].get(stage_name, {}).get('status')
+        return self.state["stages"].get(stage_name, {}).get("status")
 
     def is_stage_completed(self, stage_name: str) -> bool:
         """Check if a stage completed successfully."""
-        stage = self.state['stages'].get(stage_name, {})
-        return stage.get('status') == 'completed' and stage.get('success', False)
+        stage = self.state["stages"].get(stage_name, {})
+        return stage.get("status") == "completed" and stage.get("success", False)
 
 
 # CLI commands for different providers (same as resource_finder.py)
 # Note: For claude, we use '-p' (print mode) to enable streaming JSON output
 CLI_COMMANDS = {
-    'claude': 'claude -p',  # Print mode enables streaming JSON output with stdin
-    'codex': 'codex exec',  # Non-interactive mode: read from stdin
-    'gemini': 'gemini'
+    "claude": "claude -p",  # Print mode enables streaming JSON output with stdin
+    "codex": "codex exec",  # Non-interactive mode: read from stdin
+    "gemini": "gemini",
 }
 
 # Stage names tracked in PipelineState when scoring_enabled=True
-RULE_MAKER_STAGE = 'rule_maker'
-SCORER_STAGE = 'scorer'
-
-# Files moved out of the workspace during the experiment_runner stage so the
-# runner cannot read them. Restored before the scorer runs.
-#   - eval.py:           the scoring code itself
-#   - targets.json:      numeric targets + success rule
-#   - rule_maker_log.md: rationale, which references the targets in plain text
-SEALED_FILES: List[str] = [
-    "scoring/eval.py",
-    "scoring/targets.json",
-    "scoring/rule_maker_log.md",
-]
+RULE_MAKER_STAGE = "rule_maker"
+SCORER_STAGE = "scorer"
 
 
 class ResearchPipelineOrchestrator:
@@ -163,7 +154,7 @@ class ResearchPipelineOrchestrator:
         use_scribe: bool = False,
         scoring_enabled: bool = False,
         rule_maker_timeout: int = 1800,  # 30 min
-        scorer_timeout: int = 600  # 10 min
+        scorer_timeout: int = 600,  # 10 min
     ) -> Dict[str, Any]:
         """
         Execute complete research pipeline.
@@ -204,42 +195,42 @@ class ResearchPipelineOrchestrator:
         print("=" * 80)
         print()
 
-        results = {
-            'success': False,
-            'stages': {},
-            'work_dir': str(self.work_dir)
-        }
+        results = {"success": False, "stages": {}, "work_dir": str(self.work_dir)}
         if scoring_enabled:
-            results['mode'] = 'scored'
+            results["mode"] = "scored"
 
         try:
             # STAGE 1: Resource Finder
             if not skip_resource_finder:
-                results['stages']['resource_finder'] = self._run_resource_finder(
+                results["stages"]["resource_finder"] = self._run_resource_finder(
                     idea=idea,
                     provider=provider,
                     timeout=resource_finder_timeout,
-                    full_permissions=full_permissions
+                    full_permissions=full_permissions,
                 )
 
-                if not results['stages']['resource_finder']['success']:
+                if not results["stages"]["resource_finder"]["success"]:
                     print()
                     print("⚠️  Resource finder stage failed!")
                     print("   You can:")
                     print("   1. Review logs and fix issues")
-                    print("   2. Re-run with --skip-resource-finder if resources are already gathered")
+                    print(
+                        "   2. Re-run with --skip-resource-finder if resources are already gathered"
+                    )
                     print("   3. Manually add resources to workspace and continue")
                     return results
             else:
                 print("⏭️  Skipping resource finder stage (resources assumed to be ready)")
-                self.state.complete_stage('resource_finder', success=True, outputs={'skipped': True})
-                results['stages']['resource_finder'] = {'success': True, 'skipped': True}
+                self.state.complete_stage(
+                    "resource_finder", success=True, outputs={"skipped": True}
+                )
+                results["stages"]["resource_finder"] = {"success": True, "skipped": True}
 
             # STAGE 2: Human Review (Optional)
             if pause_after_resources:
-                results['stages']['human_review'] = self._wait_for_human_approval()
+                results["stages"]["human_review"] = self._wait_for_human_approval()
 
-                if not results['stages']['human_review']['approved']:
+                if not results["stages"]["human_review"]["approved"]:
                     print()
                     print("🛑 Pipeline paused. Human did not approve continuation.")
                     return results
@@ -248,13 +239,13 @@ class ResearchPipelineOrchestrator:
             # Writes scoring/interface.md, scoring/eval.py, scoring/targets.json,
             # scoring/rule_maker_log.md before the runner sees the workspace.
             if scoring_enabled:
-                results['stages'][RULE_MAKER_STAGE] = self._run_rule_maker(
+                results["stages"][RULE_MAKER_STAGE] = self._run_rule_maker(
                     idea=idea,
                     provider=provider,
                     timeout=rule_maker_timeout,
-                    full_permissions=full_permissions
+                    full_permissions=full_permissions,
                 )
-                if not results['stages'][RULE_MAKER_STAGE]['success']:
+                if not results["stages"][RULE_MAKER_STAGE]["success"]:
                     print()
                     print("⚠️  Rule maker stage failed -- aborting.")
                     return results
@@ -266,13 +257,13 @@ class ResearchPipelineOrchestrator:
             # can run.
             sealed_dir = self._seal_runner_inputs() if scoring_enabled else None
             try:
-                results['stages']['experiment_runner'] = self._run_experiment_runner(
+                results["stages"]["experiment_runner"] = self._run_experiment_runner(
                     idea=idea,
                     provider=provider,
                     timeout=experiment_runner_timeout,
                     full_permissions=full_permissions,
                     use_scribe=use_scribe,
-                    scoring_enabled=scoring_enabled
+                    scoring_enabled=scoring_enabled,
                 )
             finally:
                 if scoring_enabled:
@@ -281,23 +272,20 @@ class ResearchPipelineOrchestrator:
             # STAGE 4 (scoring mode only): Scorer
             # Executes scoring/eval.py and captures results.json.
             if scoring_enabled:
-                results['stages'][SCORER_STAGE] = self._run_scorer(
-                    timeout=scorer_timeout
-                )
+                results["stages"][SCORER_STAGE] = self._run_scorer(timeout=scorer_timeout)
 
-            runner_ok = results['stages']['experiment_runner']['success']
+            runner_ok = results["stages"]["experiment_runner"]["success"]
 
             if scoring_enabled:
-                scorer_ok = results['stages'][SCORER_STAGE]['success']
+                scorer_ok = results["stages"][SCORER_STAGE]["success"]
                 if runner_ok and scorer_ok:
                     print()
                     print("🎉 PIPELINE COMPLETED SUCCESSFULLY!")
                     self.state.mark_completed()
-                    results['success'] = True
+                    results["success"] = True
                 elif runner_ok and not scorer_ok:
                     print()
-                    print("⚠️  Runner finished but scorer failed -- artifact "
-                          "may be unmeasured.")
+                    print("⚠️  Runner finished but scorer failed -- artifact may be unmeasured.")
                 else:
                     print()
                     print("⚠️  Pipeline finished with issues.")
@@ -306,7 +294,7 @@ class ResearchPipelineOrchestrator:
                     print()
                     print("🎉 PIPELINE COMPLETED SUCCESSFULLY!")
                     self.state.mark_completed()
-                    results['success'] = True
+                    results["success"] = True
                 else:
                     print()
                     print("⚠️  Experiment runner stage completed with issues.")
@@ -314,14 +302,14 @@ class ResearchPipelineOrchestrator:
         except Exception as e:
             print()
             print(f"❌ Pipeline error: {e}")
-            results['error'] = str(e)
+            results["error"] = str(e)
             raise
 
         finally:
             # Save final results
             results_file = self.work_dir / ".neurico" / "pipeline_results.json"
             results_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(results_file, 'w', encoding='utf-8') as f:
+            with open(results_file, "w", encoding="utf-8") as f:
                 json.dump(results, f, indent=2)
 
             print()
@@ -330,11 +318,7 @@ class ResearchPipelineOrchestrator:
         return results
 
     def _run_resource_finder(
-        self,
-        idea: Dict[str, Any],
-        provider: str,
-        timeout: int,
-        full_permissions: bool
+        self, idea: Dict[str, Any], provider: str, timeout: int, full_permissions: bool
     ) -> Dict[str, Any]:
         """Run resource finder stage."""
         print()
@@ -343,7 +327,7 @@ class ResearchPipelineOrchestrator:
         print("─" * 80)
         print()
 
-        self.state.start_stage('resource_finder')
+        self.state.start_stage("resource_finder")
 
         try:
             result = run_resource_finder(
@@ -352,16 +336,16 @@ class ResearchPipelineOrchestrator:
                 provider=provider,
                 templates_dir=self.templates_dir,
                 timeout=timeout,
-                full_permissions=full_permissions
+                full_permissions=full_permissions,
             )
 
-            self.state.complete_stage('resource_finder', result['success'], result.get('outputs'))
+            self.state.complete_stage("resource_finder", result["success"], result.get("outputs"))
 
             return result
 
         except Exception as e:
             print(f"❌ Resource finder stage failed: {e}")
-            self.state.complete_stage('resource_finder', False)
+            self.state.complete_stage("resource_finder", False)
             raise
 
     def _wait_for_human_approval(self) -> Dict[str, Any]:
@@ -372,7 +356,7 @@ class ResearchPipelineOrchestrator:
         print("─" * 80)
         print()
 
-        self.state.start_stage('human_review')
+        self.state.start_stage("human_review")
 
         print("🛑 Pipeline paused for human review.")
         print()
@@ -387,14 +371,11 @@ class ResearchPipelineOrchestrator:
 
         response = input("Continue with experiment runner? (yes/no): ").strip().lower()
 
-        approved = response in ['yes', 'y']
+        approved = response in ["yes", "y"]
 
-        result = {
-            'approved': approved,
-            'timestamp': datetime.now().isoformat()
-        }
+        result = {"approved": approved, "timestamp": datetime.now().isoformat()}
 
-        self.state.complete_stage('human_review', approved, result)
+        self.state.complete_stage("human_review", approved, result)
 
         if approved:
             print("✅ Proceeding to experiment runner stage...")
@@ -410,7 +391,7 @@ class ResearchPipelineOrchestrator:
         timeout: int,
         full_permissions: bool,
         use_scribe: bool = False,
-        scoring_enabled: bool = False
+        scoring_enabled: bool = False,
     ) -> Dict[str, Any]:
         """Run experiment runner stage (raw CLI by default, scribe optional)."""
         print()
@@ -422,7 +403,7 @@ class ResearchPipelineOrchestrator:
         print("─" * 80)
         print()
 
-        self.state.start_stage('experiment_runner')
+        self.state.start_stage("experiment_runner")
 
         # Import here to avoid circular dependency
         import subprocess
@@ -436,15 +417,13 @@ class ResearchPipelineOrchestrator:
 
             prompt_generator = PromptGenerator(self.templates_dir)
             prompt = prompt_generator.generate_research_prompt(
-                idea,
-                root_dir=self.work_dir,
-                scoring_enabled=scoring_enabled
+                idea, root_dir=self.work_dir, scoring_enabled=scoring_enabled
             )
 
             # Save prompt
             prompt_file = self.work_dir / "logs" / "research_prompt.txt"
             prompt_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(prompt_file, 'w', encoding='utf-8') as f:
+            with open(prompt_file, "w", encoding="utf-8") as f:
                 f.write(prompt)
 
             print(f"📝 Research prompt generated ({len(prompt)} chars)")
@@ -452,17 +431,14 @@ class ResearchPipelineOrchestrator:
             print()
 
             # Generate session instructions (resource-aware version)
-            domain = idea.get('idea', {}).get('domain', 'general')
+            domain = idea.get("idea", {}).get("domain", "general")
             session_instructions = generate_instructions(
-                prompt=prompt,
-                work_dir=str(self.work_dir),
-                use_scribe=use_scribe,
-                domain=domain
+                prompt=prompt, work_dir=str(self.work_dir), use_scribe=use_scribe, domain=domain
             )
 
             # Save session instructions
             session_file = self.work_dir / "logs" / "session_instructions.txt"
-            with open(session_file, 'w', encoding='utf-8') as f:
+            with open(session_file, "w", encoding="utf-8") as f:
                 f.write(session_instructions)
 
             # Prepare command - raw CLI by default, scribe if requested
@@ -505,16 +481,18 @@ class ResearchPipelineOrchestrator:
 
             # Set environment
             env = os.environ.copy()
-            env['PYTHONUNBUFFERED'] = '1'
+            env["PYTHONUNBUFFERED"] = "1"
             if use_scribe:
-                env['SCRIBE_RUN_DIR'] = str(self.work_dir)
+                env["SCRIBE_RUN_DIR"] = str(self.work_dir)
 
             # Execute agent
             success = False
             start_time = time.time()
 
-            with open(log_file, 'w', encoding='utf-8') as log_f, \
-                 open(transcript_file, 'w', encoding='utf-8') as transcript_f:
+            with (
+                open(log_file, "w", encoding="utf-8") as log_f,
+                open(transcript_file, "w", encoding="utf-8") as transcript_f,
+            ):
                 process = subprocess.Popen(
                     shlex.split(cmd),
                     stdin=subprocess.PIPE,
@@ -522,9 +500,9 @@ class ResearchPipelineOrchestrator:
                     stderr=subprocess.STDOUT,
                     env=env,
                     text=True,
-                    encoding='utf-8',
+                    encoding="utf-8",
                     bufsize=1,
-                    cwd=str(self.work_dir)
+                    cwd=str(self.work_dir),
                 )
 
                 # Send session instructions
@@ -534,10 +512,10 @@ class ResearchPipelineOrchestrator:
                 # Stream output to both log file and transcript file (sanitized for security)
                 # For Claude/Codex with JSON flags, the output IS the transcript
                 # For Gemini, the output is regular text but sessions are saved separately
-                for line in iter(process.stdout.readline, ''):
+                for line in iter(process.stdout.readline, ""):
                     if line:
                         sanitized_line = sanitize_text(line)
-                        print(sanitized_line, end='')
+                        print(sanitized_line, end="")
                         log_f.write(sanitized_line)
                         transcript_f.write(sanitized_line)
 
@@ -548,7 +526,7 @@ class ResearchPipelineOrchestrator:
             print("=" * 80)
 
             elapsed = time.time() - start_time
-            print(f"⏱️  Experiment runner completed in {elapsed:.1f}s ({elapsed/60:.1f} minutes)")
+            print(f"⏱️  Experiment runner completed in {elapsed:.1f}s ({elapsed / 60:.1f} minutes)")
 
             if return_code == 0:
                 print("✅ Experiment execution completed successfully!")
@@ -558,28 +536,28 @@ class ResearchPipelineOrchestrator:
                 success = False
 
             result = {
-                'success': success,
-                'return_code': return_code,
-                'elapsed_time': elapsed,
-                'log_file': str(log_file),
-                'transcript_file': str(transcript_file)
+                "success": success,
+                "return_code": return_code,
+                "elapsed_time": elapsed,
+                "log_file": str(log_file),
+                "transcript_file": str(transcript_file),
             }
 
-            self.state.complete_stage('experiment_runner', success, result)
+            self.state.complete_stage("experiment_runner", success, result)
 
             return result
 
         except subprocess.TimeoutExpired:
             print(f"\n⏱️  Experiment runner timed out after {timeout} seconds")
             process.kill()
-            result = {'success': False, 'error': 'timeout'}
-            self.state.complete_stage('experiment_runner', False, result)
+            result = {"success": False, "error": "timeout"}
+            self.state.complete_stage("experiment_runner", False, result)
             return result
 
         except Exception as e:
             print(f"❌ Experiment runner stage failed: {e}")
-            result = {'success': False, 'error': str(e)}
-            self.state.complete_stage('experiment_runner', False, result)
+            result = {"success": False, "error": str(e)}
+            self.state.complete_stage("experiment_runner", False, result)
             raise
 
     # ---- Scoring-mode helpers (rule_maker / scorer / seal) ---------------
@@ -588,11 +566,7 @@ class ResearchPipelineOrchestrator:
     # legacy two-stage flow.
 
     def _run_rule_maker(
-        self,
-        idea: Dict[str, Any],
-        provider: str,
-        timeout: int,
-        full_permissions: bool
+        self, idea: Dict[str, Any], provider: str, timeout: int, full_permissions: bool
     ) -> Dict[str, Any]:
         """Run the rule_maker stage (scoring mode only)."""
         print()
@@ -609,13 +583,9 @@ class ResearchPipelineOrchestrator:
                 provider=provider,
                 templates_dir=self.templates_dir,
                 timeout=timeout,
-                full_permissions=full_permissions
+                full_permissions=full_permissions,
             )
-            self.state.complete_stage(
-                RULE_MAKER_STAGE,
-                result['success'],
-                result.get('outputs')
-            )
+            self.state.complete_stage(RULE_MAKER_STAGE, result["success"], result.get("outputs"))
             return result
         except Exception as e:
             print(f"❌ Rule maker stage failed: {e}")
@@ -635,15 +605,8 @@ class ResearchPipelineOrchestrator:
 
         self.state.start_stage(SCORER_STAGE)
         try:
-            result = run_scorer(
-                work_dir=self.work_dir,
-                timeout=timeout
-            )
-            self.state.complete_stage(
-                SCORER_STAGE,
-                result['success'],
-                result
-            )
+            result = run_scorer(work_dir=self.work_dir, timeout=timeout)
+            self.state.complete_stage(SCORER_STAGE, result["success"], result)
             return result
         except Exception as e:
             print(f"❌ Scorer stage failed: {e}")
@@ -659,11 +622,11 @@ class ResearchPipelineOrchestrator:
         <workspaces>/.scoring_sealed/<name>/. Sealed files keep their
         relative path inside that directory (e.g. scoring/eval.py).
         """
-        return self.work_dir.parent / ".scoring_sealed" / self.work_dir.name
+        return sealed_dir_for(self.work_dir)
 
     def _seal_runner_inputs(self) -> Optional[Path]:
         """
-        Move SEALED_FILES out of the workspace BEFORE the runner stage.
+        Move hidden scoring files out of the workspace BEFORE the runner stage.
 
         Returns the sealed directory path so it can be passed to
         _unseal_runner_inputs(). Returns None if nothing was sealed (e.g.,
@@ -676,37 +639,7 @@ class ResearchPipelineOrchestrator:
         Full hardening against adversarial runners requires sandboxing
         (deferred to v1.0).
         """
-        sealed_dir = self._sealed_dir_for()
-        sealed_dir.mkdir(parents=True, exist_ok=True)
-
-        moved = []
-        for rel in SEALED_FILES:
-            src = self.work_dir / rel
-            if not src.exists():
-                continue
-            dst = sealed_dir / rel
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(src), str(dst))
-            moved.append(rel)
-
-        if not moved:
-            # Nothing to seal; remove the empty sealed dir we created.
-            try:
-                sealed_dir.rmdir()
-                sealed_dir.parent.rmdir()  # remove .scoring_sealed if now empty
-            except OSError:
-                pass
-            print("🔒 Nothing to seal (rule_maker outputs not found).")
-            return None
-
-        print(f"🔒 Sealed {len(moved)} scoring files to {sealed_dir}:")
-        for r in moved:
-            print(f"     - {r}")
-        print(
-            f"   (manual recovery if orchestrator crashes: "
-            f"mv {sealed_dir}/scoring/* {self.work_dir}/scoring/)"
-        )
-        return sealed_dir
+        return seal_scoring_files(self.work_dir)
 
     def _unseal_runner_inputs(self, sealed_dir: Optional[Path]) -> None:
         """
@@ -716,68 +649,15 @@ class ResearchPipelineOrchestrator:
         let an unseal error mask an experiment_runner failure -- this is
         always called in a finally block.
         """
-        if sealed_dir is None:
-            return
-
-        if not sealed_dir.exists():
-            print(f"⚠️  Sealed dir disappeared: {sealed_dir}")
-            return
-
-        restored = []
-        errors = []
-        for rel in SEALED_FILES:
-            src = sealed_dir / rel
-            if not src.exists():
-                continue
-            dst = self.work_dir / rel
-            try:
-                dst.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(str(src), str(dst))
-                restored.append(rel)
-            except OSError as e:
-                errors.append(f"{rel}: {e}")
-
-        if restored:
-            print(f"🔓 Restored {len(restored)} scoring files from {sealed_dir}")
-
-        if errors:
-            print(f"⚠️  Unseal errors -- sealed dir kept at {sealed_dir} for "
-                  "manual recovery:")
-            for e in errors:
-                print(f"     - {e}")
-            return
-
-        # Best-effort cleanup. All expected files restored cleanly, so the
-        # sealed dir should contain at most empty subdirs (e.g. scoring/ we
-        # created during seal). If a stray FILE shows up, keep the dir for
-        # the user to inspect.
-        try:
-            has_files = any(
-                p.is_file() for p in sealed_dir.rglob("*")
-            ) if sealed_dir.exists() else False
-            if sealed_dir.exists() and not has_files:
-                shutil.rmtree(sealed_dir)
-                # Remove .scoring_sealed/ parent if also empty
-                parent = sealed_dir.parent
-                try:
-                    parent.rmdir()
-                except OSError:
-                    pass
-            elif has_files:
-                print(
-                    f"ℹ️  Unexpected files remain in {sealed_dir}; "
-                    "leaving the directory for inspection."
-                )
-        except OSError as e:
-            print(f"⚠️  Could not clean up {sealed_dir}: {e}")
+        unseal_scoring_files(self.work_dir, sealed_dir)
 
     def get_pipeline_status(self) -> Dict[str, Any]:
         """Get current pipeline execution status."""
         return {
-            'current_stage': self.state.state.get('current_stage'),
-            'completed': self.state.state.get('completed', False),
-            'stages': self.state.state.get('stages', {}),
-            'state_file': str(self.state.state_file)
+            "current_stage": self.state.state.get("current_stage"),
+            "completed": self.state.state.get("completed", False),
+            "stages": self.state.state.get("stages", {}),
+            "state_file": str(self.state.state_file),
         }
 
     def resume_pipeline(
@@ -786,7 +666,7 @@ class ResearchPipelineOrchestrator:
         provider: str = "claude",
         pause_after_resources: bool = False,
         full_permissions: bool = True,
-        use_scribe: bool = False
+        use_scribe: bool = False,
     ) -> Dict[str, Any]:
         """
         Resume pipeline from last completed stage.
@@ -808,22 +688,22 @@ class ResearchPipelineOrchestrator:
         print()
 
         # Check what stages are already completed
-        resource_finder_done = self.state.is_stage_completed('resource_finder')
-        experiment_runner_done = self.state.is_stage_completed('experiment_runner')
+        resource_finder_done = self.state.is_stage_completed("resource_finder")
+        experiment_runner_done = self.state.is_stage_completed("experiment_runner")
 
         skip_resource_finder = resource_finder_done
 
-        print(f"   Resource Finder: {'✅ Completed' if resource_finder_done else '❌ Not completed'}")
-        print(f"   Experiment Runner: {'✅ Completed' if experiment_runner_done else '❌ Not completed'}")
+        print(
+            f"   Resource Finder: {'✅ Completed' if resource_finder_done else '❌ Not completed'}"
+        )
+        print(
+            f"   Experiment Runner: {'✅ Completed' if experiment_runner_done else '❌ Not completed'}"
+        )
         print()
 
         if resource_finder_done and experiment_runner_done:
             print("✅ All stages already completed!")
-            return {
-                'success': True,
-                'resumed': False,
-                'message': 'Pipeline already complete'
-            }
+            return {"success": True, "resumed": False, "message": "Pipeline already complete"}
 
         # Resume from last incomplete stage
         return self.run_pipeline(
@@ -832,5 +712,5 @@ class ResearchPipelineOrchestrator:
             pause_after_resources=pause_after_resources,
             skip_resource_finder=skip_resource_finder,
             full_permissions=full_permissions,
-            use_scribe=use_scribe
+            use_scribe=use_scribe,
         )

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -6,17 +6,30 @@ This module orchestrates the multi-agent research pipeline:
 2. (Optional) Human review checkpoint
 3. Experiment Runner Agent (CLI-based by default, Scribe optional): Implementation, experimentation, analysis
 
+When scoring_enabled=True is passed to run_pipeline(), two extra stages are
+woven into the flow:
+    - rule_maker (between resource_finder and experiment_runner): writes a
+      per-run artifact protocol (scoring/interface.md, scoring/eval.py,
+      scoring/targets.json, scoring/rule_maker_log.md).
+    - scorer (after experiment_runner): executes scoring/eval.py and writes
+      scoring/results.json.
+Plus a seal/unseal step that moves the scorer-side files out of the workspace
+during the runner stage so the runner cannot read them.
+
 The orchestrator manages agent execution flow, monitors completion, handles errors,
 and tracks pipeline state.
 """
 
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, List, Dict, Any
 import json
+import shutil
 from datetime import datetime
 import time
 
 from agents.resource_finder import run_resource_finder
+from agents.rule_maker import run_rule_maker
+from core.scorer import run_scorer
 from templates.research_agent_instructions import generate_instructions
 
 
@@ -96,6 +109,21 @@ CLI_COMMANDS = {
     'gemini': 'gemini'
 }
 
+# Stage names tracked in PipelineState when scoring_enabled=True
+RULE_MAKER_STAGE = 'rule_maker'
+SCORER_STAGE = 'scorer'
+
+# Files moved out of the workspace during the experiment_runner stage so the
+# runner cannot read them. Restored before the scorer runs.
+#   - eval.py:           the scoring code itself
+#   - targets.json:      numeric targets + success rule
+#   - rule_maker_log.md: rationale, which references the targets in plain text
+SEALED_FILES: List[str] = [
+    "scoring/eval.py",
+    "scoring/targets.json",
+    "scoring/rule_maker_log.md",
+]
+
 
 class ResearchPipelineOrchestrator:
     """
@@ -132,7 +160,10 @@ class ResearchPipelineOrchestrator:
         resource_finder_timeout: int = 2700,  # 45 min
         experiment_runner_timeout: int = 10800,  # 3 hours
         full_permissions: bool = True,
-        use_scribe: bool = False
+        use_scribe: bool = False,
+        scoring_enabled: bool = False,
+        rule_maker_timeout: int = 1800,  # 30 min
+        scorer_timeout: int = 600  # 10 min
     ) -> Dict[str, Any]:
         """
         Execute complete research pipeline.
@@ -146,19 +177,30 @@ class ResearchPipelineOrchestrator:
             experiment_runner_timeout: Timeout for experiment runner in seconds
             full_permissions: Allow full permissions to agents
             use_scribe: If True, use scribe for notebook integration (default: False, raw CLI)
+            scoring_enabled: If True, run in rule_maker (scored) mode. Adds two stages
+                             (rule_maker between resource_finder and experiment_runner,
+                             scorer after experiment_runner) and seals scoring/ inputs
+                             from the runner. Default False = legacy two-stage flow.
+            rule_maker_timeout: Timeout for rule_maker stage in seconds (scoring mode only)
+            scorer_timeout: Timeout for scorer stage in seconds (scoring mode only)
 
         Returns:
             Dictionary with pipeline execution results
         """
         print()
         print("=" * 80)
-        print("MULTI-AGENT RESEARCH PIPELINE")
+        if scoring_enabled:
+            print("MULTI-AGENT RESEARCH PIPELINE  (SCORING MODE)")
+        else:
+            print("MULTI-AGENT RESEARCH PIPELINE")
         print("=" * 80)
         print(f"Work directory: {self.work_dir}")
         print(f"Provider: {provider}")
         print(f"Use scribe (notebooks): {use_scribe}")
         print(f"Pause after resources: {pause_after_resources}")
         print(f"Skip resource finder: {skip_resource_finder}")
+        if scoring_enabled:
+            print(f"Scoring enabled: True (rule_maker + scorer stages)")
         print("=" * 80)
         print()
 
@@ -167,6 +209,8 @@ class ResearchPipelineOrchestrator:
             'stages': {},
             'work_dir': str(self.work_dir)
         }
+        if scoring_enabled:
+            results['mode'] = 'scored'
 
         try:
             # STAGE 1: Resource Finder
@@ -200,23 +244,72 @@ class ResearchPipelineOrchestrator:
                     print("🛑 Pipeline paused. Human did not approve continuation.")
                     return results
 
-            # STAGE 3: Experiment Runner
-            results['stages']['experiment_runner'] = self._run_experiment_runner(
-                idea=idea,
-                provider=provider,
-                timeout=experiment_runner_timeout,
-                full_permissions=full_permissions,
-                use_scribe=use_scribe
-            )
+            # STAGE 2.5 (scoring mode only): Rule Maker
+            # Writes scoring/interface.md, scoring/eval.py, scoring/targets.json,
+            # scoring/rule_maker_log.md before the runner sees the workspace.
+            if scoring_enabled:
+                results['stages'][RULE_MAKER_STAGE] = self._run_rule_maker(
+                    idea=idea,
+                    provider=provider,
+                    timeout=rule_maker_timeout,
+                    full_permissions=full_permissions
+                )
+                if not results['stages'][RULE_MAKER_STAGE]['success']:
+                    print()
+                    print("⚠️  Rule maker stage failed -- aborting.")
+                    return results
 
-            if results['stages']['experiment_runner']['success']:
-                print()
-                print("🎉 PIPELINE COMPLETED SUCCESSFULLY!")
-                self.state.mark_completed()
-                results['success'] = True
+            # STAGE 3: Experiment Runner
+            # In scoring mode, seal eval.py / targets.json / rule_maker_log.md
+            # out of the workspace for the duration of the runner stage. Always
+            # unseal in the finally block (even on runner failure) so the scorer
+            # can run.
+            sealed_dir = self._seal_runner_inputs() if scoring_enabled else None
+            try:
+                results['stages']['experiment_runner'] = self._run_experiment_runner(
+                    idea=idea,
+                    provider=provider,
+                    timeout=experiment_runner_timeout,
+                    full_permissions=full_permissions,
+                    use_scribe=use_scribe,
+                    scoring_enabled=scoring_enabled
+                )
+            finally:
+                if scoring_enabled:
+                    self._unseal_runner_inputs(sealed_dir)
+
+            # STAGE 4 (scoring mode only): Scorer
+            # Executes scoring/eval.py and captures results.json.
+            if scoring_enabled:
+                results['stages'][SCORER_STAGE] = self._run_scorer(
+                    timeout=scorer_timeout
+                )
+
+            runner_ok = results['stages']['experiment_runner']['success']
+
+            if scoring_enabled:
+                scorer_ok = results['stages'][SCORER_STAGE]['success']
+                if runner_ok and scorer_ok:
+                    print()
+                    print("🎉 PIPELINE COMPLETED SUCCESSFULLY!")
+                    self.state.mark_completed()
+                    results['success'] = True
+                elif runner_ok and not scorer_ok:
+                    print()
+                    print("⚠️  Runner finished but scorer failed -- artifact "
+                          "may be unmeasured.")
+                else:
+                    print()
+                    print("⚠️  Pipeline finished with issues.")
             else:
-                print()
-                print("⚠️  Experiment runner stage completed with issues.")
+                if runner_ok:
+                    print()
+                    print("🎉 PIPELINE COMPLETED SUCCESSFULLY!")
+                    self.state.mark_completed()
+                    results['success'] = True
+                else:
+                    print()
+                    print("⚠️  Experiment runner stage completed with issues.")
 
         except Exception as e:
             print()
@@ -227,6 +320,7 @@ class ResearchPipelineOrchestrator:
         finally:
             # Save final results
             results_file = self.work_dir / ".neurico" / "pipeline_results.json"
+            results_file.parent.mkdir(parents=True, exist_ok=True)
             with open(results_file, 'w', encoding='utf-8') as f:
                 json.dump(results, f, indent=2)
 
@@ -315,12 +409,16 @@ class ResearchPipelineOrchestrator:
         provider: str,
         timeout: int,
         full_permissions: bool,
-        use_scribe: bool = False
+        use_scribe: bool = False,
+        scoring_enabled: bool = False
     ) -> Dict[str, Any]:
         """Run experiment runner stage (raw CLI by default, scribe optional)."""
         print()
         print("─" * 80)
-        print("STAGE 3: EXPERIMENT RUNNER")
+        if scoring_enabled:
+            print("STAGE 3: EXPERIMENT RUNNER  (scored prompt)")
+        else:
+            print("STAGE 3: EXPERIMENT RUNNER")
         print("─" * 80)
         print()
 
@@ -337,7 +435,11 @@ class ResearchPipelineOrchestrator:
             from templates.prompt_generator import PromptGenerator
 
             prompt_generator = PromptGenerator(self.templates_dir)
-            prompt = prompt_generator.generate_research_prompt(idea, root_dir=self.work_dir)
+            prompt = prompt_generator.generate_research_prompt(
+                idea,
+                root_dir=self.work_dir,
+                scoring_enabled=scoring_enabled
+            )
 
             # Save prompt
             prompt_file = self.work_dir / "logs" / "research_prompt.txt"
@@ -479,6 +581,195 @@ class ResearchPipelineOrchestrator:
             result = {'success': False, 'error': str(e)}
             self.state.complete_stage('experiment_runner', False, result)
             raise
+
+    # ---- Scoring-mode helpers (rule_maker / scorer / seal) ---------------
+    # These methods are only invoked when run_pipeline(scoring_enabled=True).
+    # In default mode they are not called; their presence does not affect the
+    # legacy two-stage flow.
+
+    def _run_rule_maker(
+        self,
+        idea: Dict[str, Any],
+        provider: str,
+        timeout: int,
+        full_permissions: bool
+    ) -> Dict[str, Any]:
+        """Run the rule_maker stage (scoring mode only)."""
+        print()
+        print("─" * 80)
+        print("STAGE: RULE MAKER")
+        print("─" * 80)
+        print()
+
+        self.state.start_stage(RULE_MAKER_STAGE)
+        try:
+            result = run_rule_maker(
+                idea=idea,
+                work_dir=self.work_dir,
+                provider=provider,
+                templates_dir=self.templates_dir,
+                timeout=timeout,
+                full_permissions=full_permissions
+            )
+            self.state.complete_stage(
+                RULE_MAKER_STAGE,
+                result['success'],
+                result.get('outputs')
+            )
+            return result
+        except Exception as e:
+            print(f"❌ Rule maker stage failed: {e}")
+            self.state.complete_stage(RULE_MAKER_STAGE, False)
+            raise
+
+    def _run_scorer(self, timeout: int) -> Dict[str, Any]:
+        """
+        Run the scorer stage (scoring mode only). Executes scoring/eval.py
+        and captures the structured results into scoring/results.json.
+        """
+        print()
+        print("─" * 80)
+        print("STAGE: SCORER")
+        print("─" * 80)
+        print()
+
+        self.state.start_stage(SCORER_STAGE)
+        try:
+            result = run_scorer(
+                work_dir=self.work_dir,
+                timeout=timeout
+            )
+            self.state.complete_stage(
+                SCORER_STAGE,
+                result['success'],
+                result
+            )
+            return result
+        except Exception as e:
+            print(f"❌ Scorer stage failed: {e}")
+            self.state.complete_stage(SCORER_STAGE, False)
+            raise
+
+    def _sealed_dir_for(self) -> Path:
+        """
+        Return the sibling directory where sealed scoring files live during
+        the experiment_runner stage.
+
+        For a workspace at <workspaces>/<name>/, the sealed directory is at
+        <workspaces>/.scoring_sealed/<name>/. Sealed files keep their
+        relative path inside that directory (e.g. scoring/eval.py).
+        """
+        return self.work_dir.parent / ".scoring_sealed" / self.work_dir.name
+
+    def _seal_runner_inputs(self) -> Optional[Path]:
+        """
+        Move SEALED_FILES out of the workspace BEFORE the runner stage.
+
+        Returns the sealed directory path so it can be passed to
+        _unseal_runner_inputs(). Returns None if nothing was sealed (e.g.,
+        the rule_maker output files did not exist).
+
+        Defense level: against an aligned-but-undisciplined runner, this is
+        a hard guarantee -- the files are not in the workspace at all. Against
+        an actively adversarial runner with full filesystem access, it is a
+        speed bump (the runner could traverse `..` and find the sealed dir).
+        Full hardening against adversarial runners requires sandboxing
+        (deferred to v1.0).
+        """
+        sealed_dir = self._sealed_dir_for()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+
+        moved = []
+        for rel in SEALED_FILES:
+            src = self.work_dir / rel
+            if not src.exists():
+                continue
+            dst = sealed_dir / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dst))
+            moved.append(rel)
+
+        if not moved:
+            # Nothing to seal; remove the empty sealed dir we created.
+            try:
+                sealed_dir.rmdir()
+                sealed_dir.parent.rmdir()  # remove .scoring_sealed if now empty
+            except OSError:
+                pass
+            print("🔒 Nothing to seal (rule_maker outputs not found).")
+            return None
+
+        print(f"🔒 Sealed {len(moved)} scoring files to {sealed_dir}:")
+        for r in moved:
+            print(f"     - {r}")
+        print(
+            f"   (manual recovery if orchestrator crashes: "
+            f"mv {sealed_dir}/scoring/* {self.work_dir}/scoring/)"
+        )
+        return sealed_dir
+
+    def _unseal_runner_inputs(self, sealed_dir: Optional[Path]) -> None:
+        """
+        Move sealed files back to the workspace AFTER the runner stage.
+
+        Best-effort: logs failures but does not raise. The caller must not
+        let an unseal error mask an experiment_runner failure -- this is
+        always called in a finally block.
+        """
+        if sealed_dir is None:
+            return
+
+        if not sealed_dir.exists():
+            print(f"⚠️  Sealed dir disappeared: {sealed_dir}")
+            return
+
+        restored = []
+        errors = []
+        for rel in SEALED_FILES:
+            src = sealed_dir / rel
+            if not src.exists():
+                continue
+            dst = self.work_dir / rel
+            try:
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(src), str(dst))
+                restored.append(rel)
+            except OSError as e:
+                errors.append(f"{rel}: {e}")
+
+        if restored:
+            print(f"🔓 Restored {len(restored)} scoring files from {sealed_dir}")
+
+        if errors:
+            print(f"⚠️  Unseal errors -- sealed dir kept at {sealed_dir} for "
+                  "manual recovery:")
+            for e in errors:
+                print(f"     - {e}")
+            return
+
+        # Best-effort cleanup. All expected files restored cleanly, so the
+        # sealed dir should contain at most empty subdirs (e.g. scoring/ we
+        # created during seal). If a stray FILE shows up, keep the dir for
+        # the user to inspect.
+        try:
+            has_files = any(
+                p.is_file() for p in sealed_dir.rglob("*")
+            ) if sealed_dir.exists() else False
+            if sealed_dir.exists() and not has_files:
+                shutil.rmtree(sealed_dir)
+                # Remove .scoring_sealed/ parent if also empty
+                parent = sealed_dir.parent
+                try:
+                    parent.rmdir()
+                except OSError:
+                    pass
+            elif has_files:
+                print(
+                    f"ℹ️  Unexpected files remain in {sealed_dir}; "
+                    "leaving the directory for inspection."
+                )
+        except OSError as e:
+            print(f"⚠️  Could not clean up {sealed_dir}: {e}")
 
     def get_pipeline_status(self) -> Dict[str, Any]:
         """Get current pipeline execution status."""

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -122,7 +122,10 @@ class ResearchRunner:
                     paper_timeout: int = 3600,
                     no_hash: bool = False,
                     private: bool = False,
-                    force_fresh: bool = False) -> Dict[str, Any]:
+                    force_fresh: bool = False,
+                    scoring_enabled: bool = False,
+                    rule_maker_timeout: int = 1800,
+                    scorer_timeout: int = 600) -> Dict[str, Any]:
         """
         Execute research for a given idea.
 
@@ -306,9 +309,16 @@ class ResearchRunner:
         # Choose execution mode: multi-agent pipeline or legacy monolithic
         if multi_agent:
             print()
-            print("🔀 Using MULTI-AGENT pipeline")
-            print("   Stage 1: Resource Finder (literature review, datasets, code)")
-            print("   Stage 2: Experiment Runner (implementation, experiments, analysis)")
+            if scoring_enabled:
+                print("🔀 Using MULTI-AGENT pipeline (SCORING MODE)")
+                print("   Stage 1: Resource Finder (literature review, datasets, code)")
+                print("   Stage 2: Rule Maker (writes scoring/ artifact protocol)")
+                print("   Stage 3: Experiment Runner (with sealed scoring/ inputs)")
+                print("   Stage 4: Scorer (executes scoring/eval.py)")
+            else:
+                print("🔀 Using MULTI-AGENT pipeline")
+                print("   Stage 1: Resource Finder (literature review, datasets, code)")
+                print("   Stage 2: Experiment Runner (implementation, experiments, analysis)")
             print()
 
             # Use pipeline orchestrator
@@ -344,7 +354,10 @@ class ResearchRunner:
                     resource_finder_timeout=resource_finder_timeout,
                     experiment_runner_timeout=timeout,
                     full_permissions=full_permissions,
-                    use_scribe=use_scribe
+                    use_scribe=use_scribe,
+                    scoring_enabled=scoring_enabled,
+                    rule_maker_timeout=rule_maker_timeout,
+                    scorer_timeout=scorer_timeout
                 )
 
                 success = pipeline_result.get('success', False)
@@ -966,6 +979,25 @@ def main():
         action="store_true",
         help="Run in comment mode: make targeted improvements based on comments in the idea file"
     )
+    parser.add_argument(
+        "--enable-scoring",
+        action="store_true",
+        help="Run in scoring mode: insert rule_maker stage before the runner, "
+             "seal scoring/ inputs from the runner, and run scorer after. "
+             "Requires rule_maker agent + scoring/eval.py protocol."
+    )
+    parser.add_argument(
+        "--rule-maker-timeout",
+        type=int,
+        default=1800,
+        help="Timeout for rule_maker stage in seconds (default: 1800 = 30 min, scoring mode only)"
+    )
+    parser.add_argument(
+        "--scorer-timeout",
+        type=int,
+        default=600,
+        help="Timeout for scorer stage in seconds (default: 600 = 10 min, scoring mode only)"
+    )
 
     args = parser.parse_args()
 
@@ -1013,7 +1045,10 @@ def main():
             paper_timeout=args.paper_timeout,
             no_hash=args.no_hash,
             private=args.private,
-            force_fresh=args.force_fresh
+            force_fresh=args.force_fresh,
+            scoring_enabled=args.enable_scoring,
+            rule_maker_timeout=args.rule_maker_timeout,
+            scorer_timeout=args.scorer_timeout
         )
 
         print()

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -11,6 +11,9 @@ This module orchestrates the execution of research by:
 
 from pathlib import Path
 from typing import Optional, List, Dict, Any
+from datetime import datetime
+import fnmatch
+import json
 import subprocess
 import shlex
 import sys
@@ -20,13 +23,16 @@ import yaml
 # Force UTF-8 stdout/stderr on Windows where the default is cp1252.
 # Claude CLI output contains Unicode characters that cp1252 cannot represent,
 # causing a UnicodeEncodeError when print() tries to write them to the terminal.
-if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
-    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
-if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
-    sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if sys.stderr.encoding and sys.stderr.encoding.lower() != "utf-8":
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
-# Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# Add src/ and project root to path for direct script execution.
+_SRC_ROOT = Path(__file__).parent.parent
+_PROJECT_ROOT = _SRC_ROOT.parent
+sys.path.insert(0, str(_SRC_ROOT))
+sys.path.insert(0, str(_PROJECT_ROOT))
 
 from core.idea_manager import IdeaManager
 from core.config_loader import ConfigLoader
@@ -36,6 +42,7 @@ from templates.research_agent_instructions import generate_instructions
 
 try:
     from core.github_manager import GitHubManager
+
     GITHUB_AVAILABLE = True
 except ImportError:
     GITHUB_AVAILABLE = False
@@ -44,9 +51,9 @@ except ImportError:
 # CLI commands for different providers (same as resource_finder.py)
 # Note: For claude, we use '-p' (print mode) to enable streaming JSON output
 CLI_COMMANDS = {
-    'claude': 'claude -p',  # Print mode enables streaming JSON output with stdin
-    'codex': 'codex exec',  # Non-interactive mode: read from stdin
-    'gemini': 'gemini'
+    "claude": "claude -p",  # Print mode enables streaming JSON output with stdin
+    "codex": "codex exec",  # Non-interactive mode: read from stdin
+    "gemini": "gemini",
 }
 
 
@@ -56,10 +63,9 @@ class ResearchRunner:
     Supports optional GitHub integration for automatic repo creation and pushing.
     """
 
-    def __init__(self,
-                 project_root: Optional[Path] = None,
-                 use_github: bool = True,
-                 github_org: str = ""):
+    def __init__(
+        self, project_root: Optional[Path] = None, use_github: bool = True, github_org: str = ""
+    ):
         """
         Initialize research runner.
 
@@ -92,7 +98,7 @@ class ResearchRunner:
                 print("⚠️  GitHub integration disabled: GitHubManager not available")
                 print("   Install dependencies: pip install PyGithub GitPython")
                 self.use_github = False
-            elif not os.getenv('GITHUB_TOKEN'):
+            elif not os.getenv("GITHUB_TOKEN"):
                 print("⚠️  GitHub integration disabled: GITHUB_TOKEN not set")
                 print("   Set GITHUB_TOKEN environment variable or create .env file")
                 self.use_github = False
@@ -108,24 +114,31 @@ class ResearchRunner:
                     print(f"⚠️  GitHub integration failed: {e}")
                     self.use_github = False
 
-    def run_research(self, idea_id: str,
-                    provider: str = "claude",
-                    timeout: int = 3600,
-                    full_permissions: bool = True,
-                    multi_agent: bool = True,
-                    pause_after_resources: bool = False,
-                    skip_resource_finder: bool = False,
-                    resource_finder_timeout: int = 2700,
-                    use_scribe: bool = False,
-                    write_paper: bool = True,
-                    paper_style: str = None,
-                    paper_timeout: int = 3600,
-                    no_hash: bool = False,
-                    private: bool = False,
-                    force_fresh: bool = False,
-                    scoring_enabled: bool = False,
-                    rule_maker_timeout: int = 1800,
-                    scorer_timeout: int = 600) -> Dict[str, Any]:
+    def run_research(
+        self,
+        idea_id: str,
+        provider: str = "claude",
+        timeout: int = 3600,
+        full_permissions: bool = True,
+        multi_agent: bool = True,
+        pause_after_resources: bool = False,
+        skip_resource_finder: bool = False,
+        resource_finder_timeout: int = 2700,
+        use_scribe: bool = False,
+        write_paper: bool = True,
+        paper_style: str = None,
+        paper_timeout: int = 3600,
+        no_hash: bool = False,
+        private: bool = False,
+        force_fresh: bool = False,
+        scoring_enabled: bool = False,
+        rule_maker_timeout: int = 1800,
+        scorer_timeout: int = 600,
+        autoresearch: bool = False,
+        autoresearch_iterations: int = 1,
+        autoresearch_history_dir: Optional[Path] = None,
+        continue_autoresearch: bool = False,
+    ) -> Dict[str, Any]:
         """
         Execute research for a given idea.
 
@@ -159,6 +172,16 @@ class ResearchRunner:
         print(f"🚀 Starting research: {idea_id}")
         print(f"   Provider: {provider}")
         print(f"   GitHub: {'Enabled' if self.use_github else 'Disabled'}")
+        if autoresearch and continue_autoresearch:
+            raise ValueError(
+                "Use either --autoresearch for a full pipeline run or "
+                "--continue-autoresearch for an existing scored workspace, not both."
+            )
+        if autoresearch and not scoring_enabled:
+            print("   AutoResearch requires scoring; enabling scoring mode.")
+            scoring_enabled = True
+        if continue_autoresearch:
+            print("   Continue AutoResearch: enabled")
         print("=" * 80)
 
         # Load idea
@@ -166,17 +189,17 @@ class ResearchRunner:
         if idea is None:
             raise ValueError(f"Idea not found: {idea_id}")
 
-        idea_spec = idea.get('idea', {})
-        title = idea_spec.get('title', 'Untitled Research')
+        idea_spec = idea.get("idea", {})
+        title = idea_spec.get("title", "Untitled Research")
 
         # Resolve paper style: explicit user choice > domain config default
         # (get_domain_paper_style falls back to config's default_paper_style)
         if paper_style is None:
-            domain = idea_spec.get('domain', 'general')
+            domain = idea_spec.get("domain", "general")
             paper_style = ConfigLoader().get_domain_paper_style(domain)
 
         # Update status
-        self.idea_manager.update_status(idea_id, 'in_progress')
+        self.idea_manager.update_status(idea_id, "in_progress")
 
         # Setup working directory (GitHub repo or local runs/)
         github_url = None
@@ -185,7 +208,7 @@ class ResearchRunner:
         if self.use_github and self.github_manager:
             # Check if workspace already exists from submission
             # Try to get repo_name from metadata (new method with short names)
-            repo_name = idea_spec.get('metadata', {}).get('github_repo_name')
+            repo_name = idea_spec.get("metadata", {}).get("github_repo_name")
             existing_workspace = self.github_manager.get_workspace_path(idea_id, repo_name)
 
             if existing_workspace:
@@ -205,11 +228,12 @@ class ResearchRunner:
                 # Get GitHub URL from remote
                 try:
                     from git import Repo as GitRepo
+
                     repo = GitRepo(existing_workspace)
-                    github_url = list(repo.remote('origin').urls)[0].replace('.git', '')
-                    if 'https://' in github_url and '@' in github_url:
+                    github_url = list(repo.remote("origin").urls)[0].replace(".git", "")
+                    if "https://" in github_url and "@" in github_url:
                         # Remove token from URL for display
-                        github_url = github_url.split('@')[1]
+                        github_url = github_url.split("@")[1]
                         github_url = f"https://{github_url}"
                     print(f"   URL: {github_url}\n")
                 except Exception as e:
@@ -221,49 +245,44 @@ class ResearchRunner:
                 print(f"   (Tip: Use submit.py to create workspace before running)\n")
 
                 try:
-                    domain = idea_spec.get('domain', 'research')
+                    domain = idea_spec.get("domain", "research")
                     repo_info = self.github_manager.create_research_repo(
                         idea_id=idea_id,
                         title=title,
-                        description=idea_spec.get('hypothesis', ''),
+                        description=idea_spec.get("hypothesis", ""),
                         private=private,
                         domain=domain,
                         provider=provider,
-                        no_hash=no_hash
+                        no_hash=no_hash,
                     )
 
-                    github_url = repo_info['repo_url']
-                    github_repo = repo_info['repo_object']
+                    github_url = repo_info["repo_url"]
+                    github_repo = repo_info["repo_object"]
 
                     # Store repo_name in idea metadata
-                    idea['idea']['metadata'] = idea['idea'].get('metadata', {})
-                    idea['idea']['metadata']['github_repo_name'] = repo_info['repo_name']
-                    idea['idea']['metadata']['github_repo_url'] = github_url
+                    idea["idea"]["metadata"] = idea["idea"].get("metadata", {})
+                    idea["idea"]["metadata"]["github_repo_name"] = repo_info["repo_name"]
+                    idea["idea"]["metadata"]["github_repo_url"] = github_url
 
                     # Save updated metadata
                     idea_path = self.idea_manager.ideas_dir / "submitted" / f"{idea_id}.yaml"
-                    with open(idea_path, 'w', encoding='utf-8') as f:
+                    with open(idea_path, "w", encoding="utf-8") as f:
                         yaml.dump(idea, f, default_flow_style=False, sort_keys=False)
 
                     # Clone repository
                     repo = self.github_manager.clone_repo(
-                        repo_info['clone_url'],
-                        repo_info['local_path']
+                        repo_info["clone_url"], repo_info["local_path"]
                     )
 
                     # Add research metadata
-                    self.github_manager.add_research_metadata(
-                        repo_info['local_path'],
-                        idea
-                    )
+                    self.github_manager.add_research_metadata(repo_info["local_path"], idea)
 
                     # Commit metadata
                     self.github_manager.commit_and_push(
-                        repo_info['local_path'],
-                        "Initialize research project with metadata"
+                        repo_info["local_path"], "Initialize research project with metadata"
                     )
 
-                    work_dir = repo_info['local_path']
+                    work_dir = repo_info["local_path"]
                     is_resuming = False
                     print(f"\n✅ Working in GitHub repository")
                     print(f"   URL: {github_url}")
@@ -276,7 +295,7 @@ class ResearchRunner:
                     # Fall through to local setup below
 
         if not self.use_github:
-            existing_workspace = idea.get('idea', {}).get('metadata', {}).get('local_workspace')
+            existing_workspace = idea.get("idea", {}).get("metadata", {}).get("local_workspace")
 
             if not force_fresh and existing_workspace and Path(existing_workspace).exists():
                 work_dir = Path(existing_workspace)
@@ -288,9 +307,11 @@ class ResearchRunner:
                 is_resuming = False
 
                 # Persist workspace path in idea metadata for future runs
-                idea.setdefault('idea', {}).setdefault('metadata', {})['local_workspace'] = str(work_dir)
+                idea.setdefault("idea", {}).setdefault("metadata", {})["local_workspace"] = str(
+                    work_dir
+                )
                 idea_path = self.idea_manager.get_idea_path(idea_id)
-                with open(idea_path, 'w', encoding='utf-8') as f:
+                with open(idea_path, "w", encoding="utf-8") as f:
                     yaml.dump(idea, f, default_flow_style=False, sort_keys=False)
 
                 print(f"📁 Working directory: {work_dir}\n")
@@ -302,6 +323,44 @@ class ResearchRunner:
         # Only create notebooks/ when using scribe
         if use_scribe:
             (work_dir / "notebooks").mkdir(parents=True, exist_ok=True)
+
+        if continue_autoresearch:
+            success = False
+            pipeline_result: Dict[str, Any] = {}
+            try:
+                pipeline_result = self._run_continue_autoresearch(
+                    idea=idea,
+                    idea_id=idea_id,
+                    work_dir=work_dir,
+                    provider=provider,
+                    full_permissions=full_permissions,
+                    scorer_timeout=scorer_timeout,
+                    autoresearch_iterations=autoresearch_iterations,
+                    autoresearch_history_dir=autoresearch_history_dir,
+                )
+                success = pipeline_result.get("success", False)
+
+                if write_paper and success:
+                    self._run_paper_writer_stage(
+                        idea=idea,
+                        work_dir=work_dir,
+                        provider=provider,
+                        paper_style=paper_style,
+                        paper_timeout=paper_timeout,
+                        full_permissions=full_permissions,
+                    )
+            except Exception as e:
+                print(f"\n❌ Continue AutoResearch error: {e}")
+                success = False
+            finally:
+                self._finalize_research(idea_id, work_dir, github_url, title, provider, success)
+
+            return {
+                "work_dir": work_dir,
+                "github_url": github_url,
+                "success": success,
+                "autoresearch": pipeline_result.get("autoresearch"),
+            }
 
         # Copy helper scripts to workspace
         self._copy_workspace_resources(work_dir)
@@ -315,6 +374,10 @@ class ResearchRunner:
                 print("   Stage 2: Rule Maker (writes scoring/ artifact protocol)")
                 print("   Stage 3: Experiment Runner (with sealed scoring/ inputs)")
                 print("   Stage 4: Scorer (executes scoring/eval.py)")
+                if autoresearch:
+                    print(
+                        f"   AutoResearch: {autoresearch_iterations} iteration(s) after initial scorer"
+                    )
             else:
                 print("🔀 Using MULTI-AGENT pipeline")
                 print("   Stage 1: Resource Finder (literature review, datasets, code)")
@@ -325,8 +388,7 @@ class ResearchRunner:
             from core.pipeline_orchestrator import ResearchPipelineOrchestrator
 
             orchestrator = ResearchPipelineOrchestrator(
-                work_dir=work_dir,
-                templates_dir=self.project_root / "templates"
+                work_dir=work_dir, templates_dir=self.project_root / "templates"
             )
 
             # If resuming into an existing workspace, check which stages already completed
@@ -336,10 +398,11 @@ class ResearchRunner:
                 state_file = work_dir / ".neurico" / "pipeline_state.json"
                 try:
                     import json as _json
-                    with open(state_file, 'r', encoding='utf-8') as _f:
+
+                    with open(state_file, "r", encoding="utf-8") as _f:
                         _state = _json.load(_f)
-                    rf_stage = _state.get('stages', {}).get('resource_finder', {})
-                    if rf_stage.get('status') == 'completed' and rf_stage.get('success'):
+                    rf_stage = _state.get("stages", {}).get("resource_finder", {})
+                    if rf_stage.get("status") == "completed" and rf_stage.get("success"):
                         print("⏭️  Resource finder already completed — skipping.")
                         skip_resource_finder = True
                 except Exception:
@@ -357,35 +420,44 @@ class ResearchRunner:
                     use_scribe=use_scribe,
                     scoring_enabled=scoring_enabled,
                     rule_maker_timeout=rule_maker_timeout,
-                    scorer_timeout=scorer_timeout
+                    scorer_timeout=scorer_timeout,
                 )
 
-                success = pipeline_result.get('success', False)
+                success = pipeline_result.get("success", False)
+
+                if autoresearch and success:
+                    print()
+                    print("=" * 80)
+                    print("🔁 STAGE: AutoResearch")
+                    print("=" * 80)
+                    print()
+
+                    history_root, _history_source = self._resolve_autoresearch_history_root(
+                        work_dir=work_dir,
+                        explicit_history_root=autoresearch_history_dir,
+                    )
+                    autoresearch_result = self._run_autoresearch_stage(
+                        idea=idea,
+                        idea_id=idea_id,
+                        work_dir=work_dir,
+                        history_root=history_root,
+                        provider=provider,
+                        full_permissions=full_permissions,
+                        iterations=autoresearch_iterations,
+                        scorer_timeout=scorer_timeout,
+                    )
+                    pipeline_result["autoresearch"] = autoresearch_result
 
                 # Paper writing stage (optional)
                 if write_paper and success:
-                    print()
-                    print("=" * 80)
-                    print("📝 STAGE 3: Paper Writing")
-                    print("=" * 80)
-                    print()
-
-                    from agents.paper_writer import run_paper_writer
-
-                    domain = idea.get('idea', {}).get('domain', 'general')
-                    paper_result = run_paper_writer(
+                    self._run_paper_writer_stage(
+                        idea=idea,
                         work_dir=work_dir,
                         provider=provider,
-                        style=paper_style,
-                        timeout=paper_timeout,
+                        paper_style=paper_style,
+                        paper_timeout=paper_timeout,
                         full_permissions=full_permissions,
-                        domain=domain
                     )
-
-                    if paper_result.get('success'):
-                        print(f"\n✅ Paper generated: {paper_result['draft_dir']}/main.tex")
-                    else:
-                        print(f"\n⚠️  Paper generation failed (research still succeeded)")
 
             except Exception as e:
                 print(f"\n❌ Pipeline error: {e}")
@@ -396,11 +468,7 @@ class ResearchRunner:
                 self._finalize_research(idea_id, work_dir, github_url, title, provider, success)
 
             # Return result info
-            return {
-                'work_dir': work_dir,
-                'github_url': github_url,
-                'success': success
-            }
+            return {"work_dir": work_dir, "github_url": github_url, "success": success}
 
         # LEGACY MONOLITHIC MODE BELOW
         print()
@@ -410,13 +478,11 @@ class ResearchRunner:
 
         # Generate prompt
         print("📝 Generating research prompt...")
-        prompt = self.prompt_generator.generate_research_prompt(
-            idea, root_dir=work_dir
-        )
+        prompt = self.prompt_generator.generate_research_prompt(idea, root_dir=work_dir)
 
         # Save prompt for reference
         prompt_file = work_dir / "logs" / "research_prompt.txt"
-        with open(prompt_file, 'w', encoding='utf-8') as f:
+        with open(prompt_file, "w", encoding="utf-8") as f:
             f.write(prompt)
 
         print(f"   Prompt saved to: {prompt_file}")
@@ -424,17 +490,14 @@ class ResearchRunner:
         print()
 
         # Prepare session instructions using the new template
-        domain = idea.get('idea', {}).get('domain', 'general')
+        domain = idea.get("idea", {}).get("domain", "general")
         session_instructions = generate_instructions(
-            prompt=prompt,
-            work_dir=str(work_dir),
-            use_scribe=use_scribe,
-            domain=domain
+            prompt=prompt, work_dir=str(work_dir), use_scribe=use_scribe, domain=domain
         )
 
         # Save session instructions
         session_file = work_dir / "logs" / "session_instructions.txt"
-        with open(session_file, 'w', encoding='utf-8') as f:
+        with open(session_file, "w", encoding="utf-8") as f:
             f.write(session_instructions)
 
         mode_str = "scribe (notebooks)" if use_scribe else "raw CLI"
@@ -448,9 +511,9 @@ class ResearchRunner:
         try:
             # Set environment variables
             env = os.environ.copy()
-            env['PYTHONUNBUFFERED'] = '1'
+            env["PYTHONUNBUFFERED"] = "1"
             if use_scribe:
-                env['SCRIBE_RUN_DIR'] = str(work_dir)
+                env["SCRIBE_RUN_DIR"] = str(work_dir)
 
             # Prepare command
             log_file = work_dir / "logs" / f"execution_{provider}.log"
@@ -486,7 +549,7 @@ class ResearchRunner:
             print("=" * 80)
             print()
 
-            with open(log_file, 'w', encoding='utf-8') as log_f:
+            with open(log_file, "w", encoding="utf-8") as log_f:
                 # Start process in workspace directory
                 process = subprocess.Popen(
                     shlex.split(cmd),
@@ -495,9 +558,9 @@ class ResearchRunner:
                     stderr=subprocess.STDOUT,
                     env=env,
                     text=True,
-                    encoding='utf-8',
+                    encoding="utf-8",
                     bufsize=1,
-                    cwd=str(work_dir)
+                    cwd=str(work_dir),
                 )
 
                 # Send session instructions
@@ -505,10 +568,10 @@ class ResearchRunner:
                 process.stdin.close()
 
                 # Stream output (sanitized for security)
-                for line in iter(process.stdout.readline, ''):
+                for line in iter(process.stdout.readline, ""):
                     if line:
                         sanitized_line = sanitize_text(line)
-                        print(sanitized_line, end='')
+                        print(sanitized_line, end="")
                         log_f.write(sanitized_line)
 
                 # Wait for completion
@@ -554,10 +617,7 @@ https://github.com/ChicagoHAI/neurico
 """
 
                     # Commit and push
-                    self.github_manager.commit_and_push(
-                        work_dir,
-                        commit_msg
-                    )
+                    self.github_manager.commit_and_push(work_dir, commit_msg)
 
                     print(f"\n🎉 Results published to GitHub!")
                     print(f"   {github_url}")
@@ -567,7 +627,7 @@ https://github.com/ChicagoHAI/neurico
                     print("   Results are available locally")
 
             # Update idea status
-            self.idea_manager.update_status(idea_id, 'completed')
+            self.idea_manager.update_status(idea_id, "completed")
 
             print()
             print(f"✅ Research completed!")
@@ -576,18 +636,14 @@ https://github.com/ChicagoHAI/neurico
                 print(f"   GitHub: {github_url}")
 
         # Return result info
-        return {
-            'work_dir': work_dir,
-            'github_url': github_url,
-            'success': success
-        }
+        return {"work_dir": work_dir, "github_url": github_url, "success": success}
 
     def run_comment_mode(
         self,
         idea_id: str,
         provider: str = "claude",
         timeout: int = 1800,
-        full_permissions: bool = True
+        full_permissions: bool = True,
     ) -> Dict[str, Any]:
         """
         Run comment mode: make targeted improvements based on user comments.
@@ -619,11 +675,11 @@ https://github.com/ChicagoHAI/neurico
         if not idea:
             raise ValueError(f"Idea not found: {idea_id}")
 
-        idea_spec = idea.get('idea', idea)
-        title = idea_spec.get('title', idea_id)
+        idea_spec = idea.get("idea", idea)
+        title = idea_spec.get("title", idea_id)
 
         # Validate that comments exist
-        comments = idea_spec.get('comments')
+        comments = idea_spec.get("comments")
         if not comments:
             raise ValueError(
                 f"No comments found in idea '{idea_id}'. "
@@ -639,7 +695,7 @@ https://github.com/ChicagoHAI/neurico
             idea=idea,
             idea_id=idea_id,
             github_manager=self.github_manager if self.use_github else None,
-            workspace_dir=self.runs_dir
+            workspace_dir=self.runs_dir,
         )
 
         if not work_dir:
@@ -657,10 +713,11 @@ https://github.com/ChicagoHAI/neurico
         if self.use_github and (work_dir / ".git").exists():
             try:
                 from git import Repo as GitRepo
+
                 repo = GitRepo(work_dir)
-                github_url = list(repo.remote('origin').urls)[0].replace('.git', '')
-                if 'https://' in github_url and '@' in github_url:
-                    github_url = github_url.split('@')[1]
+                github_url = list(repo.remote("origin").urls)[0].replace(".git", "")
+                if "https://" in github_url and "@" in github_url:
+                    github_url = github_url.split("@")[1]
                     github_url = f"https://{github_url}"
             except Exception:
                 pass
@@ -672,11 +729,11 @@ https://github.com/ChicagoHAI/neurico
             provider=provider,
             templates_dir=self.project_root / "templates",
             timeout=timeout,
-            full_permissions=full_permissions
+            full_permissions=full_permissions,
         )
 
         # Commit changes to GitHub if enabled
-        if self.use_github and self.github_manager and result['success']:
+        if self.use_github and self.github_manager and result["success"]:
             try:
                 print()
                 print("Pushing changes to GitHub...")
@@ -700,11 +757,267 @@ https://github.com/ChicagoHAI/neurico
                 print(f"Warning: Failed to push to GitHub: {e}")
                 print("   Changes are available locally")
 
+        return {"work_dir": work_dir, "github_url": github_url, "success": result["success"]}
+
+    def _run_continue_autoresearch(
+        self,
+        idea: Dict[str, Any],
+        idea_id: str,
+        work_dir: Path,
+        provider: str,
+        full_permissions: bool,
+        scorer_timeout: int,
+        autoresearch_iterations: int,
+        autoresearch_history_dir: Optional[Path],
+    ) -> Dict[str, Any]:
+        """Continue AutoResearch from an existing scored workspace."""
+        print()
+        print("=" * 80)
+        print("🔁 CONTINUE AUTORESEARCH")
+        print("=" * 80)
+        print()
+
+        current_sha = self._validate_continue_autoresearch_workspace(work_dir)
+        history_root, history_source = self._resolve_autoresearch_history_root(
+            work_dir=work_dir,
+            explicit_history_root=autoresearch_history_dir,
+        )
+
+        from core.autoresearch import AttemptHistoryManager
+
+        history = AttemptHistoryManager(history_root, idea_id)
+        existing_attempts = history.list_attempts(current_sha)
+
+        print(f"   Work dir: {work_dir}")
+        print(f"   Current parent node: {current_sha}")
+        print(f"   History root: {history_root}")
+        print(f"   History source: {history_source}")
+        print(f"   Existing attempts for this node: {len(existing_attempts)}")
+        print(f"   Next attempt: attempt_{len(existing_attempts) + 1}")
+        print(f"   Iterations: {autoresearch_iterations}")
+        print()
+
+        autoresearch_payload = self._run_autoresearch_stage(
+            idea=idea,
+            idea_id=idea_id,
+            work_dir=work_dir,
+            history_root=history_root,
+            provider=provider,
+            full_permissions=full_permissions,
+            iterations=autoresearch_iterations,
+            scorer_timeout=scorer_timeout,
+        )
+
         return {
-            'work_dir': work_dir,
-            'github_url': github_url,
-            'success': result['success']
+            "success": autoresearch_payload["success"],
+            "mode": "continue_autoresearch",
+            "work_dir": str(work_dir),
+            "autoresearch": autoresearch_payload,
         }
+
+    def _validate_continue_autoresearch_workspace(self, work_dir: Path) -> str:
+        """Validate the workspace can be used as a continuation parent."""
+        from core.autoresearch import CheckpointManager
+
+        work_dir = Path(work_dir)
+        if not work_dir.exists():
+            raise ValueError(f"Workspace does not exist: {work_dir}")
+
+        checkpoints = CheckpointManager(work_dir)
+        if not checkpoints.has_commits:
+            raise ValueError(
+                "Cannot continue AutoResearch because the workspace has no Git checkpoint."
+            )
+
+        required_paths = [
+            work_dir / "scoring" / "results.json",
+            work_dir / "scoring" / "interface.md",
+            work_dir / "scoring" / "eval.py",
+        ]
+        missing = [str(path.relative_to(work_dir)) for path in required_paths if not path.exists()]
+        if missing:
+            raise ValueError(
+                "Cannot continue AutoResearch because required scoring files are missing: "
+                + ", ".join(missing)
+            )
+
+        status_lines = [
+            line
+            for line in checkpoints.repo.git.status("--porcelain").splitlines()
+            if line.strip() and not self._is_allowed_continue_dirty_status(line)
+        ]
+        if status_lines:
+            raise ValueError(
+                "Cannot continue AutoResearch with a dirty workspace. "
+                "Commit, stash, or remove pending changes first. Status:\n"
+                + "\n".join(status_lines[:20])
+            )
+
+        current_sha = checkpoints.current_sha()
+        if current_sha is None:
+            raise ValueError("Cannot continue AutoResearch because Git HEAD is unavailable.")
+        return current_sha
+
+    @staticmethod
+    def _is_allowed_continue_dirty_status(status_line: str) -> bool:
+        """Allow known paper-writer outputs to coexist with continuation."""
+        from core.autoresearch import PAPER_OUTPUT_PATTERNS
+
+        rel_path = ResearchRunner._status_line_path(status_line)
+        if rel_path is None:
+            return False
+
+        for pattern in PAPER_OUTPUT_PATTERNS:
+            if pattern.endswith("/") and rel_path.startswith(pattern):
+                return True
+            if fnmatch.fnmatch(rel_path, pattern):
+                return True
+        return False
+
+    @staticmethod
+    def _status_line_path(status_line: str) -> Optional[str]:
+        if len(status_line) < 4:
+            return None
+        path = status_line[3:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if path.startswith('"') and path.endswith('"'):
+            path = path[1:-1]
+        return path or None
+
+    def _run_autoresearch_stage(
+        self,
+        idea: Dict[str, Any],
+        idea_id: str,
+        work_dir: Path,
+        history_root: Path,
+        provider: str,
+        full_permissions: bool,
+        iterations: int,
+        scorer_timeout: int,
+    ) -> Dict[str, Any]:
+        """Run AutoResearch and persist continuation metadata."""
+        from core.autoresearch import run_autoresearch_loop
+
+        autoresearch_result = run_autoresearch_loop(
+            idea=idea,
+            idea_id=idea_id,
+            work_dir=work_dir,
+            history_root=history_root,
+            iterations=iterations,
+            provider=provider,
+            templates_dir=self.project_root / "templates",
+            full_permissions=full_permissions,
+            scorer_timeout=scorer_timeout,
+        )
+        payload = self._autoresearch_result_payload(autoresearch_result)
+        self._write_autoresearch_state(
+            work_dir=work_dir,
+            history_root=history_root,
+            autoresearch_payload=payload,
+            iterations=iterations,
+        )
+        return payload
+
+    @staticmethod
+    def _autoresearch_result_payload(autoresearch_result) -> Dict[str, Any]:
+        return {
+            "success": autoresearch_result.success,
+            "initial_sha": autoresearch_result.initial_sha,
+            "current_best_sha": autoresearch_result.current_best_sha,
+            "iterations": [
+                {
+                    "iteration": item.iteration,
+                    "parent_sha": item.parent_sha,
+                    "child_sha": item.child_sha,
+                    "accepted": item.accepted,
+                    "reason": item.reason,
+                    "attempt_dir": str(item.attempt_dir),
+                }
+                for item in autoresearch_result.iterations
+            ],
+        }
+
+    def _resolve_autoresearch_history_root(
+        self,
+        work_dir: Path,
+        explicit_history_root: Optional[Path],
+    ) -> tuple[Path, str]:
+        if explicit_history_root is not None:
+            return Path(explicit_history_root), "cli"
+
+        state_path = self._autoresearch_state_path(work_dir)
+        if state_path.exists():
+            try:
+                state = json.loads(state_path.read_text(encoding="utf-8"))
+                saved_history_root = state.get("history_root")
+                if saved_history_root:
+                    saved_path = Path(saved_history_root)
+                    if saved_path.exists():
+                        return saved_path, "saved autoresearch state"
+                    print(
+                        "   Warning: Saved AutoResearch history root does not exist; "
+                        f"using default instead: {saved_path}"
+                    )
+            except (OSError, json.JSONDecodeError):
+                print(f"   Warning: Could not read AutoResearch state: {state_path}")
+
+        return Path(work_dir) / "logs" / "experiment-autoresearch", "default"
+
+    def _write_autoresearch_state(
+        self,
+        work_dir: Path,
+        history_root: Path,
+        autoresearch_payload: Dict[str, Any],
+        iterations: int,
+    ) -> None:
+        state_path = self._autoresearch_state_path(work_dir)
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state = {
+            "history_root": str(Path(history_root)),
+            "last_initial_sha": autoresearch_payload.get("initial_sha"),
+            "last_current_best_sha": autoresearch_payload.get("current_best_sha"),
+            "last_run_iterations": iterations,
+            "updated_at": datetime.now().isoformat(),
+        }
+        state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+    @staticmethod
+    def _autoresearch_state_path(work_dir: Path) -> Path:
+        return Path(work_dir) / ".neurico" / "autoresearch_state.json"
+
+    def _run_paper_writer_stage(
+        self,
+        idea: Dict[str, Any],
+        work_dir: Path,
+        provider: str,
+        paper_style: Optional[str],
+        paper_timeout: int,
+        full_permissions: bool,
+    ) -> Dict[str, Any]:
+        print()
+        print("=" * 80)
+        print("📝 STAGE: Paper Writing")
+        print("=" * 80)
+        print()
+
+        from agents.paper_writer import run_paper_writer
+
+        domain = idea.get("idea", {}).get("domain", "general")
+        paper_result = run_paper_writer(
+            work_dir=work_dir,
+            provider=provider,
+            style=paper_style,
+            timeout=paper_timeout,
+            full_permissions=full_permissions,
+            domain=domain,
+        )
+
+        if paper_result.get("success"):
+            print(f"\n✅ Paper generated: {paper_result['draft_dir']}/main.tex")
+        else:
+            print(f"\n⚠️  Paper generation failed (research still succeeded)")
+        return paper_result
 
     def _copy_workspace_resources(self, work_dir: Path):
         """
@@ -776,36 +1089,45 @@ https://github.com/ChicagoHAI/neurico
             print("   Warning: templates/.gitignore not found, skipping")
             return
 
-        template_content = template_gitignore.read_text(encoding='utf-8')
+        template_content = template_gitignore.read_text(encoding="utf-8")
 
         if workspace_gitignore.exists():
             # Merge: append only patterns not already present
-            existing_content = workspace_gitignore.read_text(encoding='utf-8')
+            existing_content = workspace_gitignore.read_text(encoding="utf-8")
             existing_lines = set(
-                line.strip() for line in existing_content.splitlines()
-                if line.strip() and not line.strip().startswith('#')
+                line.strip()
+                for line in existing_content.splitlines()
+                if line.strip() and not line.strip().startswith("#")
             )
 
             new_lines = []
             for line in template_content.splitlines():
                 stripped = line.strip()
-                if stripped.startswith('#') or not stripped:
+                if stripped.startswith("#") or not stripped:
                     # Keep comments and blank lines for readability
                     new_lines.append(line)
                 elif stripped not in existing_lines:
                     new_lines.append(line)
 
-            merged_content = existing_content.rstrip('\n') + '\n\n' + '\n'.join(new_lines) + '\n'
-            workspace_gitignore.write_text(merged_content, encoding='utf-8')
+            merged_content = existing_content.rstrip("\n") + "\n\n" + "\n".join(new_lines) + "\n"
+            workspace_gitignore.write_text(merged_content, encoding="utf-8")
             print(f"   Merged research .gitignore patterns into workspace")
         else:
             # No existing .gitignore (e.g. local-only mode), copy template directly
             import shutil
+
             shutil.copy2(template_gitignore, workspace_gitignore)
             print(f"   Copied .gitignore template to workspace")
 
-    def _finalize_research(self, idea_id: str, work_dir: Path, github_url: Optional[str],
-                          title: str, provider: str, success: bool):
+    def _finalize_research(
+        self,
+        idea_id: str,
+        work_dir: Path,
+        github_url: Optional[str],
+        title: str,
+        provider: str,
+        success: bool,
+    ):
         """
         Finalize research execution: commit to GitHub and update status.
 
@@ -836,10 +1158,7 @@ https://github.com/ChicagoHAI/neurico
 """
 
                 # Commit and push
-                self.github_manager.commit_and_push(
-                    work_dir,
-                    commit_msg
-                )
+                self.github_manager.commit_and_push(work_dir, commit_msg)
 
                 print(f"\n🎉 Results published to GitHub!")
                 if github_url:
@@ -850,7 +1169,7 @@ https://github.com/ChicagoHAI/neurico
                 print("   Results are available locally")
 
         # Update idea status
-        self.idea_manager.update_status(idea_id, 'completed')
+        self.idea_manager.update_status(idea_id, "completed")
 
         print()
         print(f"✅ Research completed!")
@@ -866,6 +1185,7 @@ def main():
     # Load environment variables from .env.local or .env
     try:
         from dotenv import load_dotenv
+
         project_root = Path(__file__).parent.parent.parent
         env_local = project_root / ".env.local"
         env_file = project_root / ".env"
@@ -883,128 +1203,143 @@ def main():
     parser = argparse.ArgumentParser(
         description="Run research experiments with AI agents (with GitHub integration)"
     )
-    parser.add_argument(
-        "idea_id",
-        help="ID of the idea to run"
-    )
+    parser.add_argument("idea_id", help="ID of the idea to run")
     parser.add_argument(
         "--provider",
         default="claude",
         choices=["claude", "gemini", "codex"],
-        help="AI provider to use (default: claude)"
+        help="AI provider to use (default: claude)",
     )
     parser.add_argument(
         "--no-hash",
         action="store_true",
-        help="Skip random hash in repo name if creating a new repo (use {slug}-{provider} instead of {slug}-{hash}-{provider})"
+        help="Skip random hash in repo name if creating a new repo (use {slug}-{provider} instead of {slug}-{hash}-{provider})",
     )
     parser.add_argument(
-        "--timeout",
-        type=int,
-        default=3600,
-        help="Timeout in seconds (default: 3600)"
+        "--timeout", type=int, default=3600, help="Timeout in seconds (default: 3600)"
     )
     parser.add_argument(
-        "--no-github",
-        action="store_true",
-        help="Disable GitHub integration (run locally only)"
+        "--no-github", action="store_true", help="Disable GitHub integration (run locally only)"
     )
     parser.add_argument(
         "--github-org",
-        default=os.getenv('GITHUB_ORG', ''),
-        help="GitHub organization name (default: from GITHUB_ORG env var, or personal account if not set)"
+        default=os.getenv("GITHUB_ORG", ""),
+        help="GitHub organization name (default: from GITHUB_ORG env var, or personal account if not set)",
     )
     parser.add_argument(
-        "--private",
-        action="store_true",
-        help="Create private GitHub repository (default: public)"
+        "--private", action="store_true", help="Create private GitHub repository (default: public)"
     )
     parser.add_argument(
         "--full-permissions",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="Allow full permissions to CLI agents (codex/gemini: --yolo, claude: --dangerously-skip-permissions) (default: True, use --no-full-permissions to disable)"
+        help="Allow full permissions to CLI agents (codex/gemini: --yolo, claude: --dangerously-skip-permissions) (default: True, use --no-full-permissions to disable)",
     )
     parser.add_argument(
         "--legacy-mode",
         action="store_true",
-        help="Use legacy monolithic agent (single agent for all phases including literature review)"
+        help="Use legacy monolithic agent (single agent for all phases including literature review)",
     )
     parser.add_argument(
         "--pause-after-resources",
         action="store_true",
-        help="Pause for human review after resource finding stage (only with multi-agent mode)"
+        help="Pause for human review after resource finding stage (only with multi-agent mode)",
     )
     parser.add_argument(
         "--skip-resource-finder",
         action="store_true",
-        help="Skip resource finding stage (assumes resources already gathered)"
+        help="Skip resource finding stage (assumes resources already gathered)",
     )
     parser.add_argument(
         "--resource-finder-timeout",
         type=int,
         default=2700,
-        help="Timeout for resource finder in seconds (default: 2700 = 45 min)"
+        help="Timeout for resource finder in seconds (default: 2700 = 45 min)",
     )
     parser.add_argument(
         "--use-scribe",
         action="store_true",
-        help="Use scribe for Jupyter notebook integration (default: raw CLI without notebooks)"
+        help="Use scribe for Jupyter notebook integration (default: raw CLI without notebooks)",
     )
     parser.add_argument(
         "--write-paper",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="Generate paper draft after experiments complete (default: True, use --no-write-paper to disable)"
+        help="Generate paper draft after experiments complete (default: True, use --no-write-paper to disable)",
     )
     parser.add_argument(
         "--paper-style",
         default=None,
         choices=["neurips", "icml", "acl", "ams"],
-        help="Paper style template (default: auto-detect from domain, or neurips)"
+        help="Paper style template (default: auto-detect from domain, or neurips)",
     )
     parser.add_argument(
         "--paper-timeout",
         type=int,
         default=3600,
-        help="Timeout for paper writing in seconds (default: 3600 = 60 min)"
+        help="Timeout for paper writing in seconds (default: 3600 = 60 min)",
     )
     parser.add_argument(
         "--force-fresh",
         action="store_true",
-        help="Ignore existing local workspace and start a new run from scratch"
+        help="Ignore existing local workspace and start a new run from scratch",
     )
     parser.add_argument(
         "--comment-mode",
         action="store_true",
-        help="Run in comment mode: make targeted improvements based on comments in the idea file"
+        help="Run in comment mode: make targeted improvements based on comments in the idea file",
     )
     parser.add_argument(
         "--enable-scoring",
         action="store_true",
         help="Run in scoring mode: insert rule_maker stage before the runner, "
-             "seal scoring/ inputs from the runner, and run scorer after. "
-             "Requires rule_maker agent + scoring/eval.py protocol."
+        "seal scoring/ inputs from the runner, and run scorer after. "
+        "Requires rule_maker agent + scoring/eval.py protocol.",
     )
     parser.add_argument(
         "--rule-maker-timeout",
         type=int,
         default=1800,
-        help="Timeout for rule_maker stage in seconds (default: 1800 = 30 min, scoring mode only)"
+        help="Timeout for rule_maker stage in seconds (default: 1800 = 30 min, scoring mode only)",
     )
     parser.add_argument(
         "--scorer-timeout",
         type=int,
         default=600,
-        help="Timeout for scorer stage in seconds (default: 600 = 10 min, scoring mode only)"
+        help="Timeout for scorer stage in seconds (default: 600 = 10 min, scoring mode only)",
+    )
+    parser.add_argument(
+        "--autoresearch",
+        action="store_true",
+        help="Run AutoResearch after the initial scored experiment and before paper writing",
+    )
+    parser.add_argument(
+        "--continue-autoresearch",
+        action="store_true",
+        help="Continue AutoResearch from the existing scored workspace and skip upstream pipeline stages",
+    )
+    parser.add_argument(
+        "--autoresearch-iterations",
+        type=int,
+        default=1,
+        help="Number of AutoResearch iterations to run (default: 1)",
+    )
+    parser.add_argument(
+        "--autoresearch-history-dir",
+        type=Path,
+        default=None,
+        help="Directory for AutoResearch attempt history "
+        "(default: logs/experiment-autoresearch inside the research workspace)",
     )
 
     args = parser.parse_args()
+    if args.autoresearch and args.continue_autoresearch:
+        parser.error(
+            "Use either --autoresearch for a full pipeline run or "
+            "--continue-autoresearch for an existing scored workspace, not both."
+        )
 
-    runner = ResearchRunner(
-        use_github=not args.no_github,
-        github_org=args.github_org
-    )
+    runner = ResearchRunner(use_github=not args.no_github, github_org=args.github_org)
 
     # Handle comment mode separately
     if args.comment_mode:
@@ -1013,14 +1348,14 @@ def main():
                 idea_id=args.idea_id,
                 provider=args.provider,
                 timeout=args.timeout,
-                full_permissions=args.full_permissions
+                full_permissions=args.full_permissions,
             )
 
             print()
             print("=" * 80)
             print("SUCCESS! Comment mode completed.")
             print(f"Location: {result['work_dir']}")
-            if result.get('github_url'):
+            if result.get("github_url"):
                 print(f"GitHub: {result['github_url']}")
             print("=" * 80)
             return
@@ -1048,14 +1383,18 @@ def main():
             force_fresh=args.force_fresh,
             scoring_enabled=args.enable_scoring,
             rule_maker_timeout=args.rule_maker_timeout,
-            scorer_timeout=args.scorer_timeout
+            scorer_timeout=args.scorer_timeout,
+            autoresearch=args.autoresearch,
+            autoresearch_iterations=args.autoresearch_iterations,
+            autoresearch_history_dir=args.autoresearch_history_dir,
+            continue_autoresearch=args.continue_autoresearch,
         )
 
         print()
         print("=" * 80)
         print("SUCCESS! Research execution completed.")
         print(f"Location: {result['work_dir']}")
-        if result.get('github_url'):
+        if result.get("github_url"):
             print(f"GitHub: {result['github_url']}")
         print("=" * 80)
 

--- a/src/core/scorer.py
+++ b/src/core/scorer.py
@@ -1,0 +1,185 @@
+"""
+Scorer Stage
+
+Executes scoring/eval.py (written by the rule_maker agent) against the
+artifact produced by experiment_runner. Captures structured results in
+scoring/results.json and stdout/stderr in scoring/eval_log.txt.
+
+The scorer is mechanical: no agent invocation, no LLM call. It simply
+runs the per-run evaluation script as a subprocess and surfaces the JSON
+it writes.
+"""
+
+from pathlib import Path
+from typing import Optional, Dict, Any
+import subprocess
+import json
+import sys
+import time
+
+
+# Files the scorer reads / writes (relative to <workspace>/scoring/)
+EVAL_SCRIPT_NAME = "eval.py"
+RESULTS_FILE_NAME = "results.json"
+LOG_FILE_NAME = "eval_log.txt"
+
+
+def _resolve_python_executable(work_dir: Path) -> str:
+    """
+    Pick the Python interpreter to invoke eval.py with.
+
+    The experiment_runner creates <workspace>/.venv during its setup phase
+    and installs all task-specific dependencies there. eval.py typically
+    imports those same dependencies (numpy, torch, sklearn, etc.), so it
+    must run under the workspace's interpreter rather than the
+    orchestrator's. Falls back to sys.executable if the workspace has no
+    .venv yet (e.g., during a scorer-only smoke test).
+    """
+    posix = work_dir / ".venv" / "bin" / "python"
+    if posix.exists() and posix.is_file():
+        return str(posix)
+    windows = work_dir / ".venv" / "Scripts" / "python.exe"
+    if windows.exists() and windows.is_file():
+        return str(windows)
+    return sys.executable
+
+
+def run_scorer(
+    work_dir: Path,
+    timeout: int = 600,
+    python_executable: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Execute scoring/eval.py against the runner's artifact.
+
+    Args:
+        work_dir: Workspace root containing scoring/eval.py and the
+                  runner's outputs.
+        timeout: Max execution time for eval.py in seconds.
+        python_executable: Python binary to use. Defaults to the workspace's
+                  own .venv interpreter (where the runner installed deps),
+                  falling back to sys.executable.
+
+    Returns:
+        Dict with:
+          - success: bool -- eval.py exited 0 AND results.json parsed cleanly
+          - return_code: int | None -- eval.py's exit code (None on timeout)
+          - results: dict | None -- parsed results.json contents
+          - results_path: str -- absolute path to results.json
+          - log_path: str -- absolute path to eval_log.txt
+          - elapsed_time: float
+          - error: str | None -- error message if anything failed
+    """
+    work_dir = Path(work_dir)
+    scoring_dir = work_dir / "scoring"
+    eval_script = scoring_dir / EVAL_SCRIPT_NAME
+    results_path = scoring_dir / RESULTS_FILE_NAME
+    log_path = scoring_dir / LOG_FILE_NAME
+
+    if not eval_script.exists():
+        return {
+            'success': False,
+            'return_code': None,
+            'results': None,
+            'results_path': str(results_path),
+            'log_path': str(log_path),
+            'elapsed_time': 0.0,
+            'error': f"scoring/eval.py not found at {eval_script}",
+        }
+
+    # Clear stale results so we never read leftover values from a prior run
+    if results_path.exists():
+        results_path.unlink()
+
+    python_executable = python_executable or _resolve_python_executable(work_dir)
+    cmd = [python_executable, str(eval_script)]
+
+    print(f"📊 Running scorer: {' '.join(cmd)}")
+    print(f"   Working dir: {work_dir}")
+    print(f"   Python: {python_executable}")
+    print(f"   Log: {log_path}")
+
+    start_time = time.time()
+    return_code: Optional[int] = None
+    error: Optional[str] = None
+
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=str(work_dir),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+            text=True,
+            encoding='utf-8',
+        )
+        log_path.write_text(completed.stdout or "", encoding='utf-8')
+        return_code = completed.returncode
+        if return_code != 0:
+            error = f"eval.py exited with non-zero code {return_code}"
+    except subprocess.TimeoutExpired as e:
+        error = f"scorer timed out after {timeout}s"
+        print(f"⏱️  {error}")
+        partial = ""
+        if e.stdout:
+            partial = (
+                e.stdout
+                if isinstance(e.stdout, str)
+                else e.stdout.decode('utf-8', errors='replace')
+            )
+        log_path.write_text(
+            f"{partial}\n[TIMEOUT after {timeout}s]\n", encoding='utf-8'
+        )
+    except Exception as e:
+        error = f"scorer exception: {e}"
+        print(f"❌ {error}")
+
+    elapsed = time.time() - start_time
+
+    results: Optional[Dict[str, Any]] = None
+    if results_path.exists():
+        try:
+            results = json.loads(results_path.read_text(encoding='utf-8'))
+        except json.JSONDecodeError as e:
+            json_err = f"results.json is not valid JSON: {e}"
+            error = f"{error}; {json_err}" if error else json_err
+
+    success = return_code == 0 and results is not None and error is None
+
+    if success:
+        print(f"✅ Scorer completed in {elapsed:.1f}s")
+    else:
+        print(
+            f"⚠️  Scorer finished with issues "
+            f"(return_code={return_code}, error={error})"
+        )
+
+    return {
+        'success': success,
+        'return_code': return_code,
+        'results': results,
+        'results_path': str(results_path),
+        'log_path': str(log_path),
+        'elapsed_time': elapsed,
+        'error': error,
+    }
+
+
+def load_scoring_results(work_dir: Path) -> Optional[Dict[str, Any]]:
+    """
+    Read scoring/results.json from a workspace.
+
+    Convenience for downstream consumers (paper_writer, supervisor) that
+    only need the score, not the full scorer-run dict.
+
+    Returns:
+        Parsed results.json contents, or None if the file is missing or
+        unparseable.
+    """
+    results_path = Path(work_dir) / "scoring" / RESULTS_FILE_NAME
+    if not results_path.exists():
+        return None
+    try:
+        return json.loads(results_path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError:
+        return None

--- a/src/core/scoring_seal.py
+++ b/src/core/scoring_seal.py
@@ -1,0 +1,139 @@
+"""
+Shared helpers for sealing hidden scoring files.
+
+Rule-maker/scoring mode keeps scoring/interface.md visible but moves evaluator
+internals out of the workspace while an agent is modifying experiment artifacts.
+"""
+
+from pathlib import Path
+from typing import Optional
+import shutil
+
+
+SEALED_PATHS: list[str] = [
+    "scoring/eval.py",
+    "scoring/targets.json",
+    "scoring/rule_maker_log.md",
+    "data/.test/",
+]
+
+
+def sealed_dir_for(work_dir: Path) -> Path:
+    """
+    Return the sibling directory where sealed scoring files live.
+
+    For a workspace at <workspaces>/<name>/, the sealed directory is at
+    <workspaces>/.scoring_sealed/<name>/.
+    """
+    work_dir = Path(work_dir)
+    return work_dir.parent / ".scoring_sealed" / work_dir.name
+
+
+def seal_scoring_files(work_dir: Path) -> Optional[Path]:
+    """
+    Move hidden scoring files out of the workspace.
+
+    Returns the sealed directory path when files were moved, otherwise None.
+    """
+    work_dir = Path(work_dir)
+    sealed_dir = sealed_dir_for(work_dir)
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+
+    moved = []
+    for rel in SEALED_PATHS:
+        normalized_rel = rel.rstrip("/")
+        src = work_dir / normalized_rel
+        if not src.exists():
+            continue
+        dst = sealed_dir / normalized_rel
+        if dst.exists():
+            if dst.is_dir():
+                shutil.rmtree(dst)
+            else:
+                dst.unlink()
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(dst))
+        moved.append(rel)
+
+    if not moved:
+        try:
+            sealed_dir.rmdir()
+            sealed_dir.parent.rmdir()
+        except OSError:
+            pass
+        print("🔒 Nothing to seal (rule_maker outputs not found).")
+        return None
+
+    print(f"🔒 Sealed {len(moved)} scoring files to {sealed_dir}:")
+    for rel in moved:
+        print(f"     - {rel}")
+    print(
+        f"   (manual recovery if orchestrator crashes: "
+        f"move files from {sealed_dir} back into {work_dir})"
+    )
+    return sealed_dir
+
+
+def unseal_scoring_files(work_dir: Path, sealed_dir: Optional[Path]) -> None:
+    """
+    Move hidden scoring files back to the workspace.
+
+    Best-effort: logs failures but does not raise, so unseal problems do not
+    mask the original agent failure.
+    """
+    if sealed_dir is None:
+        return
+
+    work_dir = Path(work_dir)
+    sealed_dir = Path(sealed_dir)
+
+    if not sealed_dir.exists():
+        print(f"⚠️  Sealed dir disappeared: {sealed_dir}")
+        return
+
+    restored = []
+    errors = []
+    for rel in SEALED_PATHS:
+        normalized_rel = rel.rstrip("/")
+        src = sealed_dir / normalized_rel
+        if not src.exists():
+            continue
+        dst = work_dir / normalized_rel
+        try:
+            if dst.exists():
+                if dst.is_dir():
+                    shutil.rmtree(dst)
+                else:
+                    dst.unlink()
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dst))
+            restored.append(rel)
+        except OSError as e:
+            errors.append(f"{rel}: {e}")
+
+    if restored:
+        print(f"🔓 Restored {len(restored)} scoring files from {sealed_dir}")
+
+    if errors:
+        print(f"⚠️  Unseal errors -- sealed dir kept at {sealed_dir} for manual recovery:")
+        for error in errors:
+            print(f"     - {error}")
+        return
+
+    try:
+        has_files = (
+            any(path.is_file() for path in sealed_dir.rglob("*")) if sealed_dir.exists() else False
+        )
+        if sealed_dir.exists() and not has_files:
+            shutil.rmtree(sealed_dir)
+            parent = sealed_dir.parent
+            try:
+                parent.rmdir()
+            except OSError:
+                pass
+        elif has_files:
+            print(
+                f"ℹ️  Unexpected files remain in {sealed_dir}; leaving the directory for inspection."
+            )
+    except OSError as e:
+        print(f"⚠️  Could not clean up {sealed_dir}: {e}")

--- a/src/templates/prompt_generator.py
+++ b/src/templates/prompt_generator.py
@@ -110,7 +110,8 @@ class PromptGenerator:
         return template.render(**variables)
 
     def generate_research_prompt(self, idea: Dict[str, Any],
-                                 root_dir: Optional[Path] = None) -> str:
+                                 root_dir: Optional[Path] = None,
+                                 scoring_enabled: bool = False) -> str:
         """
         Generate the main research prompt from an idea specification.
 
@@ -118,10 +119,14 @@ class PromptGenerator:
         1. Base researcher template
         2. Domain-specific template
         3. Idea-specific content (hypothesis, constraints, etc.)
+        4. (scoring mode) Scoring protocol / output-adherence addendum
 
         Args:
             idea: Idea specification (parsed from YAML)
             root_dir: Root directory for the research project (for paths)
+            scoring_enabled: If True, append base/researcher_scoring_addendum.txt
+                             as an extra banner-delimited section. Default False
+                             preserves bit-identical behavior to the legacy mode.
 
         Returns:
             Complete research prompt string
@@ -190,6 +195,26 @@ class PromptGenerator:
                 domain_template,
                 ""
             ])
+
+        # Scoring-mode addendum: when the rule_maker has written a per-run
+        # artifact protocol under scoring/, append the corresponding
+        # instructions so the runner reads interface.md and conforms to it.
+        # In default (non-scoring) mode this block is skipped and the prompt
+        # is bit-identical to the legacy version.
+        if scoring_enabled:
+            try:
+                addendum = self.load_template('base/researcher_scoring_addendum.txt')
+            except FileNotFoundError:
+                print("⚠️  scoring_enabled=True but "
+                      "templates/base/researcher_scoring_addendum.txt not found; "
+                      "continuing without scoring addendum")
+                addendum = ""
+            if addendum:
+                prompt_parts.extend([
+                    "=" * 80,
+                    addendum,
+                    ""
+                ])
 
         # Join all parts
         full_prompt = "\n".join(prompt_parts)

--- a/templates/agents/autoresearch_proposer.txt
+++ b/templates/agents/autoresearch_proposer.txt
@@ -1,0 +1,80 @@
+You are the AutoResearch proposal generator for NeuriCo.
+
+Your job is to write one structured proposal for the next experiment-stage
+attempt. You are a planner only. Do not modify the research workspace.
+
+═══════════════════════════════════════════════════════════════════════════════
+                              WORKSPACE
+═══════════════════════════════════════════════════════════════════════════════
+
+Research title: {{ title }}
+{% if domain %}Domain: {{ domain }}{% endif %}
+Workspace: {{ work_dir }}
+Parent node: {{ parent_sha }}
+Attempt directory: {{ attempt_dir }}
+Proposal output path: {{ proposal_path }}
+
+═══════════════════════════════════════════════════════════════════════════════
+                              BOUNDARIES
+═══════════════════════════════════════════════════════════════════════════════
+
+You must write exactly one file: {{ proposal_path }}
+
+Do not edit files in the research workspace.
+Do not rerun resource finding.
+Do not run the scorer.
+Do not read, mention, modify, or infer from hidden scoring internals:
+- scoring/eval.py
+- scoring/targets.json
+- scoring/rule_maker_log.md
+- .scoring_sealed/
+
+The existing NeuriCo comment handler will inspect and edit source files later.
+Your proposal should tell comment mode what targeted experiment-stage change to
+try next.
+
+═══════════════════════════════════════════════════════════════════════════════
+                              PUBLIC CONTEXT
+═══════════════════════════════════════════════════════════════════════════════
+
+The context below was curated by AutoResearch. It contains only public protocol,
+public score output, public reports/artifacts, current-node attempt history, and
+a src/ file tree. The src/ listing intentionally contains no source contents.
+
+```json
+{{ public_context | tojson(indent=2) }}
+```
+
+═══════════════════════════════════════════════════════════════════════════════
+                              OUTPUT FORMAT
+═══════════════════════════════════════════════════════════════════════════════
+
+Write {{ proposal_path }} in exactly this markdown structure:
+
+# AutoResearch Proposal
+
+## Target
+Experiment-stage modification only.
+
+## Current state summary
+Summarize the public current state and current score/result.
+
+## Previous attempts from this node
+Summarize relevant attempts from this parent node only. If none exist, say so.
+
+## Proposed modification
+Describe one concrete modification for comment mode to implement. Keep the
+proposal focused enough for one targeted comment-mode pass.
+
+## Keep fixed
+- Do not rerun resource finding.
+- Do not modify scoring/interface.md.
+- Do not read or modify hidden scoring files.
+- Keep the research question fixed.
+
+## Expected artifacts to update
+List files or artifact categories comment mode should update.
+
+## Success expectation
+Describe how this proposal is expected to improve scoring/results.json using
+only public property names and public score information.

--- a/templates/agents/rule_maker.txt
+++ b/templates/agents/rule_maker.txt
@@ -1,0 +1,634 @@
+You are a specialized agent focused on writing per-run evaluation harnesses for automated research pipelines.
+
+Your goal is to take a research idea and a set of pre-gathered resources, decide what success looks like for THIS run, and write a small, self-contained scoring harness that the post-run scorer will execute against the experiment_runner's artifact. You do not run experiments, you do not write the solution, and you do not interpret the final score.
+
+This prompt guides you through a systematic harness-authoring workflow. Complete all phases and create the deliverables listed below before exiting.
+
+═══════════════════════════════════════════════════════════════════════════════
+                    CRITICAL: WORKSPACE SETUP AND DIRECTORY SAFETY
+═══════════════════════════════════════════════════════════════════════════════
+
+You are running in the project workspace directory. All files you create
+must land under {scoring_dir}.
+
+WORKING DIRECTORY VERIFICATION:
+Before writing any files, ALWAYS verify your location:
+
+1. Run `pwd` to check your current directory.
+2. You should be in the WORKSPACE root: {workspace}
+3. The scoring directory ({scoring_dir}) already exists — do NOT recreate it.
+
+MANDATORY VERIFICATION POINTS — run `pwd` and confirm:
+✓ Before each `Write` to scoring/
+✓ After any `cd` command — ALWAYS return to workspace root afterward
+✓ When starting a new phase
+
+SAFE PATTERN FOR DIRECTORY CHANGES:
+  pwd                              # Verify starting location
+  cd scoring && ls && cd -         # cd back using "cd -"
+  pwd                              # Verify you're back in workspace root
+
+⚠️  DO NOT create files outside {scoring_dir}.
+⚠️  DO NOT modify anything under src/, data/, papers/, datasets/, or code/.
+⚠️  DO NOT execute scoring/eval.py — the runner's artifact does not exist
+   yet. Running it would fail and pollute scoring/ with stale results.json.
+
+═══════════════════════════════════════════════════════════════════════════════
+                          RULE MAKER METHODOLOGY
+═══════════════════════════════════════════════════════════════════════════════
+
+MISSION:
+Given a research idea and the resource_finder's outputs, you will:
+1. Identify the quantifiable properties that define success for THIS run.
+2. Write a protocol (scoring/interface.md) telling the experiment_runner
+   exactly what artifact to produce.
+3. Write a self-contained Python scorer (scoring/eval.py) that measures
+   those properties on the runner's artifact.
+4. Write numeric targets (scoring/targets.json) and the success rule.
+5. Document your reasoning (scoring/rule_maker_log.md) so the user can
+   read, refine, and re-run.
+
+INPUTS YOU SEE:
+
+The research idea:
+{idea_yaml}
+
+Workspace root:    {workspace}
+Scoring directory: {scoring_dir}
+
+Resources pre-gathered by the resource_finder stage:
+{resource_listing}
+
+(Read these from disk: literature_review.md, resources.md, papers/,
+datasets/, code/. Use them only to inform your design choices; do not
+copy raw resource contents into scoring/ files.)
+
+OUTPUT DELIVERABLES (all under {scoring_dir}):
+
+{output_files}
+
+Each file's format is specified in the corresponding phase below. Conform
+EXACTLY to the schemas — downstream code parses these files mechanically.
+
+WHAT YOU MUST NOT DO:
+
+✗ Do NOT invent numeric targets. Extract them from the idea's
+  `evaluation_criteria` (or the idea's stated goal). If the user gave no
+  concrete number, propose a defensible one and document the rationale.
+✗ Do NOT run experiments. You are not the experiment_runner.
+✗ Do NOT execute scoring/eval.py. The runner's artifact does not exist
+  yet — running eval.py would fail and pollute scoring/.
+✗ Do NOT read or reference files under data/.test/. Their contents are
+  sealed; only scoring/eval.py touches them at scorer-execution time.
+✗ Do NOT mention targets, test inputs, or the baseline in
+  scoring/interface.md. That file is visible to the runner; leaking
+  these defeats the evaluation.
+✗ Do NOT `import neurico` or any neurico helper module in eval.py. The
+  runner's venv may not have them. Use stdlib only, plus any pip
+  packages installed via the resource_finder's environment (numpy,
+  scikit-learn, etc. — only if a resource you found requires them).
+
+═══════════════════════════════════════════════════════════════════════════════
+                          PHASE 1: TASK ANALYSIS
+═══════════════════════════════════════════════════════════════════════════════
+
+Before writing any files, decide what you are measuring.
+
+STEP 1: Read the idea
+─────────────────────────────────────────────────────────────────────────────
+
+From {idea_yaml}, extract:
+- The goal (hypothesis / research question).
+- Evaluation criteria — explicit numbers if given.
+- Constraints (size budget, latency budget, dataset, etc.).
+- Domain — this shapes which metrics are conventional.
+
+STEP 2: Read resource_finder outputs
+─────────────────────────────────────────────────────────────────────────────
+
+Skim (do not deep-read):
+- literature_review.md — what metrics do prior works use?
+- resources.md — which datasets / baselines are available locally?
+- code/ — is there a baseline implementation you can call from eval.py?
+- datasets/ — is there a held-out split you can use? (look for a
+  data/.test/ subdir; if absent, plan to create one in Phase 3)
+
+STEP 3: Decide the property set
+─────────────────────────────────────────────────────────────────────────────
+
+Pick 1–4 measurable properties that, taken together, define "success"
+for this run. Each must:
+
+✓ Be a single scalar (float or int).
+✓ Have a clear "higher is better" or "lower is better" direction.
+✓ Be computable from the runner's artifact + sealed data + a baseline.
+✓ Be resistant to trivial gaming (a runner that returns 0 always
+  should NOT score well).
+
+EXAMPLE PROPERTY SETS:
+
+| Task family            | Properties                                       |
+|------------------------|--------------------------------------------------|
+| Algorithmic speedup    | correctness (max), speedup (max)                 |
+| Model compression      | accuracy (max), file_size_mb (min)               |
+| Classification         | accuracy (max), calibration_ece (min)            |
+| Optimization solver    | objective_value (min), constraint_violation (min)|
+| Latency-bounded model  | accuracy (max), p99_latency_ms (min)             |
+
+STEP 4: Identify the baseline
+─────────────────────────────────────────────────────────────────────────────
+
+Most measurements are relative to a reference (a naive implementation, a
+trained baseline, a published result). Locate or define one:
+
+✓ FIRST CHOICE: a baseline shipped in code/ by resource_finder. Locate
+  the entry point and document its path.
+✓ SECOND CHOICE: a trivial baseline you can write yourself in
+  baselines/<name>.py (e.g. a naive O(n²) DP for an algorithmic task,
+  a most-frequent-class classifier).
+✓ LAST RESORT: an absolute target with no comparison baseline. Document
+  why no baseline exists in scoring/rule_maker_log.md.
+
+If you write a baseline file, place it at <workspace>/baselines/<name>.py
+— NOT under scoring/. The runner can see baselines/ but cannot see
+scoring/eval.py, so the baseline is fair game for comparison.
+
+═══════════════════════════════════════════════════════════════════════════════
+                  PHASE 2: WRITE scoring/interface.md
+═══════════════════════════════════════════════════════════════════════════════
+
+This file is the ONE channel by which your decisions reach the runner.
+It must specify exactly what the runner must produce, with no leakage of
+targets, test inputs, or the baseline's expected outputs.
+
+WHAT TO INCLUDE:
+✓ The list of files the runner must produce (with paths).
+✓ The signature / schema of each entry point (function names, argument
+  types, return types).
+✓ Any invariants (no side effects, no I/O during the measured call,
+  deterministic given inputs).
+✓ A one-line "what is measured" pointer for context.
+
+WHAT TO EXCLUDE:
+✗ Numeric targets. (Those are in scoring/targets.json — hidden.)
+✗ The baseline's location or expected output values.
+✗ Test inputs or their distribution.
+✗ Anything that would let a runner over-fit the measurement.
+
+FORMAT TEMPLATE (mirror this structure exactly):
+
+```markdown
+# Artifact Protocol
+
+The experiment_runner must produce the artifacts below. Conform exactly to
+paths, signatures, and schemas. Any deviation will cause the post-run
+scorer to fail.
+
+## Files to produce
+
+| Path | Purpose | Required |
+|---|---|---|
+| `src/<file>.py` | <one-line purpose> | yes |
+| `<other_path>`   | <one-line purpose> | yes/no |
+
+## Entry points
+
+### `src/<file>.py`
+
+Must define a top-level function:
+
+​```python
+def <function_name>(<args>) -> <return_type>:
+    """<one-line docstring>."""
+​```
+
+- `<arg>`: <type + valid range or description>
+- Returns: <type + meaning>
+- No side effects. No I/O during the measured call. Deterministic.
+- Must be importable via `importlib.util` without command-line args.
+
+## Invocation
+
+<one paragraph: how the scorer will load + call this artifact>
+
+## What is measured (context only — do not tune)
+
+- **<property_name>** (direction: max | min, <one-line description>)
+- **<property_name>** (direction: max | min, <one-line description>)
+
+Test inputs, the baseline, and numeric targets are sealed. Do not read
+`scoring/eval.py`, `scoring/targets.json`, or anything under `data/.test/`.
+```
+
+CONCRETE EXAMPLE — for an LCS-speedup task:
+
+```markdown
+# Artifact Protocol
+
+The experiment_runner must produce the artifacts below. Conform exactly to
+paths, signatures, and schemas. Any deviation will cause the post-run
+scorer to fail.
+
+## Files to produce
+
+| Path | Purpose | Required |
+|---|---|---|
+| `src/solution.py` | Module exposing the callable being measured | yes |
+
+## Entry points
+
+### `src/solution.py`
+
+Must define a top-level function:
+
+​```python
+def lcs(s1: str, s2: str) -> int:
+    """Return length of the longest common subsequence of s1, s2."""
+​```
+
+- `s1`, `s2`: ASCII strings, length 0–4096 (inclusive).
+- Returns: non-negative `int`.
+- No side effects. No I/O. Deterministic.
+- Must be importable via `importlib.util` without command-line args.
+
+## Invocation
+
+The scorer will import `src/solution.py` and call `lcs(s1, s2)` repeatedly
+on sealed test inputs.
+
+## What is measured (context only — do not tune)
+
+- **correctness** (direction: max, fraction of inputs where the runner's
+  output equals the reference baseline's output).
+- **speedup** (direction: max, median runtime ratio of baseline / runner).
+
+Test inputs, the baseline, and numeric targets are sealed. Do not read
+`scoring/eval.py`, `scoring/targets.json`, or anything under `data/.test/`.
+```
+
+═══════════════════════════════════════════════════════════════════════════════
+                    PHASE 3: WRITE scoring/eval.py
+═══════════════════════════════════════════════════════════════════════════════
+
+This is the per-run scorer. It will be executed (as a subprocess by the
+neurico pipeline) AFTER the runner produces its artifact. It must:
+
+✓ Be self-contained — stdlib + only the libraries the runner already
+  needs (no `import neurico`).
+✓ Load the runner's artifact via importlib (NOT subprocess).
+✓ Load any test inputs from `data/.test/` (sealed; only eval.py reads).
+✓ Compute one scalar per declared property.
+✓ Load targets from `scoring/targets.json`.
+✓ Write structured results to `scoring/results.json`.
+✓ Exit 0 regardless of whether targets are met (success vs. failure of
+  a property is recorded in results.json, not the exit code).
+
+THREE-BLOCK LAYOUT (mandatory):
+
+BLOCK 1 — boilerplate: module loader, timing helper. Copy as-is unless
+the task genuinely needs different I/O.
+
+BLOCK 2 — measurement functions: ONE function per declared property.
+Each function returns `{'value': float, 'direction': 'max' | 'min'}`.
+
+BLOCK 3 — main: load artifact + baseline + test inputs + targets; call
+measurers; assemble results.json schema; write to disk.
+
+FORMAT TEMPLATE (mirror this structure exactly):
+
+```python
+"""
+Per-run scorer for: <idea title>
+Generated by rule_maker. Measures: <comma-separated property names>.
+"""
+import json, importlib.util, time
+from pathlib import Path
+from typing import Callable, Dict, Any
+
+WS = Path(__file__).resolve().parent.parent
+EVAL_VERSION = 1
+
+# === BLOCK 1: boilerplate ===================================================
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise FileNotFoundError(f"could not import {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+def _time_median(fn: Callable, args: tuple, trials: int = 5) -> float:
+    times = []
+    for _ in range(trials):
+        t0 = time.perf_counter()
+        fn(*args)
+        times.append(time.perf_counter() - t0)
+    return sorted(times)[trials // 2]
+
+# === BLOCK 2: property measurements =========================================
+# One function per declared property. Each returns:
+#   {'value': float, 'direction': 'max' | 'min'}
+
+def measure_<property_name>(<args>) -> Dict[str, Any]:
+    """<one-line description of what this measures>."""
+    value = <compute scalar>
+    return {'value': value, 'direction': '<max|min>'}
+
+# (add more measure_* functions as needed)
+
+# === BLOCK 3: main ==========================================================
+
+def main():
+    # Load runner's artifact + reference baseline
+    runner   = _load_module("solution", WS / "src" / "<runner_file>.py").<entry>
+    baseline = _load_module("baseline", WS / "baselines" / "<baseline_file>.py").<entry>
+
+    # Load sealed test inputs
+    inputs = <load from WS / "data" / ".test" / "...">
+
+    # Load targets
+    targets = json.loads((WS / "scoring" / "targets.json").read_text())
+
+    # Run measurers and assemble per-property records
+    properties: Dict[str, Dict[str, Any]] = {}
+    for name, measurer in [
+        ("<property_name>", lambda: measure_<property_name>(<args>)),
+        # ...
+    ]:
+        p = measurer()
+        tgt = targets[name]['target']
+        p['target'] = tgt
+        p['satisfied'] = (p['value'] >= tgt if p['direction'] == 'max'
+                          else p['value'] <= tgt)
+        p['gap'] = p['value'] - tgt
+        properties[name] = p
+
+    failing = [(n, p) for n, p in properties.items() if not p['satisfied']]
+    bottleneck = (min(failing, key=lambda kv: abs(kv[1]['gap']))[0]
+                  if failing else None)
+
+    out = {
+        'properties': properties,
+        'overall_satisfied': all(p['satisfied'] for p in properties.values()),
+        'bottleneck': bottleneck,
+        'eval_meta': {'eval_version': EVAL_VERSION,
+                      'generated_by': 'rule_maker'},
+    }
+    (WS / "scoring" / "results.json").write_text(json.dumps(out, indent=2))
+
+if __name__ == "__main__":
+    main()
+```
+
+CONCRETE EXAMPLE — for an LCS-speedup task (Block 2 + Block 3 only;
+Block 1 unchanged):
+
+```python
+# === BLOCK 2: property measurements =========================================
+
+def measure_correctness(runner_fn, baseline_fn, inputs) -> Dict[str, Any]:
+    hits = sum(runner_fn(s1, s2) == baseline_fn(s1, s2) for s1, s2 in inputs)
+    return {'value': hits / len(inputs), 'direction': 'max'}
+
+def measure_speedup(runner_fn, baseline_fn, inputs) -> Dict[str, Any]:
+    ratios = [_time_median(baseline_fn, (s1, s2)) /
+              _time_median(runner_fn, (s1, s2))
+              for s1, s2 in inputs]
+    return {'value': sorted(ratios)[len(ratios) // 2], 'direction': 'max'}
+
+# === BLOCK 3: main ==========================================================
+
+def main():
+    runner   = _load_module("solution", WS / "src" / "solution.py").lcs
+    baseline = _load_module("baseline", WS / "baselines" / "naive_lcs.py").lcs
+
+    inputs = [tuple(line.split("\t")) for line in
+              (WS / "data" / ".test" / "inputs.tsv").read_text().splitlines()]
+
+    targets = json.loads((WS / "scoring" / "targets.json").read_text())
+
+    properties = {}
+    for name, measurer in [
+        ("correctness", lambda: measure_correctness(runner, baseline, inputs)),
+        ("speedup",     lambda: measure_speedup(runner, baseline, inputs[:30])),
+    ]:
+        p = measurer()
+        tgt = targets[name]['target']
+        p['target'] = tgt
+        p['satisfied'] = (p['value'] >= tgt if p['direction'] == 'max'
+                          else p['value'] <= tgt)
+        p['gap'] = p['value'] - tgt
+        properties[name] = p
+
+    failing = [(n, p) for n, p in properties.items() if not p['satisfied']]
+    bottleneck = (min(failing, key=lambda kv: abs(kv[1]['gap']))[0]
+                  if failing else None)
+
+    out = {
+        'properties': properties,
+        'overall_satisfied': all(p['satisfied'] for p in properties.values()),
+        'bottleneck': bottleneck,
+        'eval_meta': {'eval_version': EVAL_VERSION,
+                      'generated_by': 'rule_maker'},
+    }
+    (WS / "scoring" / "results.json").write_text(json.dumps(out, indent=2))
+```
+
+═══════════════════════════════════════════════════════════════════════════════
+                   PHASE 4: WRITE scoring/targets.json
+═══════════════════════════════════════════════════════════════════════════════
+
+The numeric targets and the rule that decides overall success. Kept in a
+separate file (not hardcoded in eval.py) so that targets can be refined
+between iterations without touching the scoring code.
+
+FORMAT (mirror exactly):
+
+```json
+{
+  "<property_name>": {"target": <number>, "direction": "max" | "min"},
+  "<property_name>": {"target": <number>, "direction": "max" | "min"},
+  "success_rule": "ALL_PROPERTIES_SATISFIED",
+  "meta": {
+    "generated_by": "rule_maker",
+    "domain": "<domain>",
+    "rationale_ref": "scoring/rule_maker_log.md"
+  }
+}
+```
+
+SUPPORTED `success_rule` VALUES:
+
+| Value | Meaning |
+|---|---|
+| `ALL_PROPERTIES_SATISFIED` | Every property must meet its target (default). |
+| `ANY_PROPERTY_SATISFIED`   | Any one is enough (rare; exploratory runs). |
+
+(Weighted-sum rules are reserved for a future version; do not invent.)
+
+WHERE TARGETS COME FROM:
+
+1. PREFER: explicit numbers in the idea's `evaluation_criteria` field.
+2. ELSE: numbers stated in the literature for this task.
+3. ELSE: a defensible heuristic (e.g. "1.5x speedup for a known O(n²) → O(n
+   log n) reduction") — document the choice in rule_maker_log.md.
+4. NEVER invent a number to make the run easy or hard.
+
+CONCRETE EXAMPLE (LCS speedup):
+
+```json
+{
+  "correctness": {"target": 1.0, "direction": "max"},
+  "speedup":     {"target": 3.0, "direction": "max"},
+  "success_rule": "ALL_PROPERTIES_SATISFIED",
+  "meta": {
+    "generated_by": "rule_maker",
+    "domain": "machine_learning",
+    "rationale_ref": "scoring/rule_maker_log.md"
+  }
+}
+```
+
+═══════════════════════════════════════════════════════════════════════════════
+                  PHASE 5: WRITE scoring/rule_maker_log.md
+═══════════════════════════════════════════════════════════════════════════════
+
+A free-form rationale document so the user can audit your choices, edit
+them, and re-run with refined criteria.
+
+STRUCTURE (suggested; deviate as the task warrants):
+
+```markdown
+# Rule Maker Rationale
+
+## Properties chosen
+- **<property_name>**: <why this property captures success>
+- **<property_name>**: <why>
+
+## Properties considered and rejected
+- **<rejected_name>**: <why dropped; gameable, redundant, unmeasurable?>
+
+## Targets
+- **<property_name>**: <number>, source: <idea criteria | literature | heuristic>
+- **<property_name>**: <number>, source: <...>
+
+## Baseline
+- Source: <code/ path | written by rule_maker | absolute>
+- Why this baseline is fair: <one paragraph>
+
+## Metric robustness
+- <what trivial outputs would score artificially well? How does eval.py guard against that?>
+
+## Known limitations
+- <what this scoring misses; what the user should refine if they re-run>
+```
+
+This file is visible to the user (and to a supervisor agent, if later
+iterations add one). Write it for someone who has not seen your reasoning.
+
+═══════════════════════════════════════════════════════════════════════════════
+                  PHASE 6: SELF-VALIDATE BEFORE EXITING
+═══════════════════════════════════════════════════════════════════════════════
+
+Before you finish, verify the four deliverables exist and are well-formed.
+Do NOT skip this — downstream stages parse these files mechanically.
+
+CHECKS (run each from the workspace root):
+
+1. All four files exist:
+   ```bash
+   ls scoring/interface.md scoring/eval.py scoring/targets.json scoring/rule_maker_log.md
+   ```
+
+2. eval.py parses as valid Python (does NOT execute it):
+   ```bash
+   python -c "import ast; ast.parse(open('scoring/eval.py').read()); print('eval.py: OK')"
+   ```
+
+3. targets.json parses as valid JSON:
+   ```bash
+   python -c "import json; json.load(open('scoring/targets.json')); print('targets.json: OK')"
+   ```
+
+4. interface.md is non-empty and references at least one file the runner
+   must produce:
+   ```bash
+   grep -q "Files to produce" scoring/interface.md && echo "interface.md: OK"
+   ```
+
+5. eval.py does NOT contain `import neurico` or `from neurico`:
+   ```bash
+   grep -q "neurico" scoring/eval.py && echo "FAIL: eval.py must not import neurico" || echo "eval.py: no neurico imports"
+   ```
+
+⚠️  DO NOT run `python scoring/eval.py`. The runner's artifact does not
+   exist yet; eval.py will fail and leave stale state behind.
+
+═══════════════════════════════════════════════════════════════════════════════
+                            BEST PRACTICES
+═══════════════════════════════════════════════════════════════════════════════
+
+✓ DO: Pick the smallest property set that captures success (1–3 is ideal).
+✓ DO: Use stdlib in eval.py. Add imports only for libraries already in
+       the runner's venv (numpy, sklearn, etc.).
+✓ DO: Pin every target to a source (idea, literature, or documented heuristic).
+✓ DO: Consider how a trivial runner output would score. If the trivial
+       output scores well, your measurement is wrong — revise.
+✓ DO: Write rule_maker_log.md in plain language. The user will read this.
+
+✗ DON'T: Self-tune targets to match what you guess the runner will produce.
+✗ DON'T: Embed targets in eval.py. They live in targets.json.
+✗ DON'T: Add fields outside the documented results.json schema. Anything
+         extra goes under `eval_meta`.
+✗ DON'T: Reference scoring/eval.py or scoring/targets.json from interface.md.
+✗ DON'T: Reach for complex weighting schemes — `ALL_PROPERTIES_SATISFIED`
+         is the right default. If a property's importance varies, encode
+         that in the property selection, not in a weighted sum.
+
+═══════════════════════════════════════════════════════════════════════════════
+                            TROUBLESHOOTING
+═══════════════════════════════════════════════════════════════════════════════
+
+IF: the idea has no quantifiable evaluation criterion
+THEN:
+  1. Identify the closest measurable proxy (e.g. an open-ended "improve
+     summarization" → ROUGE on a held-out split).
+  2. Document the choice and its limitations in rule_maker_log.md.
+  3. Set a defensible target (literature value, or "beat baseline by X%").
+
+IF: no baseline is available in code/ and writing one is non-trivial
+THEN:
+  1. Use an absolute target with no baseline (direction max/min on the
+     raw value).
+  2. Document the absence in rule_maker_log.md.
+  3. Note that without a baseline, speedup-style ratio measurements are
+     not possible — pick a different property.
+
+IF: the resource_finder did not produce a `data/.test/` split
+THEN:
+  1. Create one in eval.py (NOT in interface.md). Hold out a fixed
+     fraction of any available data using a deterministic seed; write
+     the held-out subset to data/.test/ at scorer-execution time.
+  2. Document the split strategy in rule_maker_log.md.
+
+IF: a property is hard to measure deterministically (timing,
+    random initialization)
+THEN:
+  1. Take a median over multiple trials (≥5) using the `_time_median`
+     helper or an equivalent.
+  2. Document the trial count and aggregation method in rule_maker_log.md.
+
+IF: you are tempted to add a new field to results.json (e.g. "warnings",
+    "diagnostics")
+THEN:
+  1. Put it under `eval_meta` to keep the top-level schema fixed.
+  2. The downstream consumers (scorer.py, paper_writer, supervisor)
+     read the fixed top-level keys; anything else is informational.
+
+═══════════════════════════════════════════════════════════════════════════════
+
+Remember: you are writing the protocol that decides whether this run
+succeeded. Your code will be read by the user, executed by the scorer,
+and consulted by the next iteration's supervisor. Make every choice
+explicit and every file mechanically parseable.

--- a/templates/base/researcher_scoring_addendum.txt
+++ b/templates/base/researcher_scoring_addendum.txt
@@ -1,0 +1,52 @@
+                  SCORING MODE: ARTIFACT PROTOCOL AND ADHERENCE
+═══════════════════════════════════════════════════════════════════════════════
+
+This run is in SCORING MODE. A separate stage (the rule_maker) has written a
+per-run artifact protocol to your workspace, and a post-run scorer will
+measure your output against that protocol independently of anything you
+report.
+
+BEFORE Phase 1 planning you MUST read:
+
+- scoring/interface.md: Specifies the files you must produce, their paths,
+  function signatures, and how they will be invoked by the post-run scorer.
+
+The following files have been MOVED OUT of your workspace for the duration
+of your run. They will be restored after you finish, for the post-run
+scorer. If you somehow do see them, do NOT read them:
+
+- scoring/eval.py            (the scorer code itself)
+- scoring/targets.json       (numeric targets + success rule)
+- scoring/rule_maker_log.md  (rationale doc; contains target values)
+
+Your artifact must conform EXACTLY to scoring/interface.md -- file paths,
+function signatures, output schemas. This is a protocol, not a guideline.
+
+───────────────────────────────────────────────────────────────────────────────
+Output format adherence
+
+All artifacts your implementation produces must conform EXACTLY to the
+protocol in scoring/interface.md:
+   ✓ Produce every file listed in interface.md, at the exact path given
+   ✓ Match every function signature exactly (names, argument counts, types)
+   ✓ Match every output schema exactly (JSON shapes, return types)
+   ✗ Do NOT add fields, paths, or files not requested by interface.md
+   ✗ Do NOT improvise on the protocol -- any deviation will cause the
+     post-run scorer to fail
+
+If interface.md is ambiguous, document the ambiguity in your planning.md
+and pick the most conservative interpretation. Do NOT modify anything
+under scoring/; eval.py and targets.json are sealed.
+
+───────────────────────────────────────────────────────────────────────────────
+General principles for scoring mode
+
+   ✓ Conform EXACTLY to scoring/interface.md -- paths, signatures, schemas
+   ✓ Treat the interface as a protocol, not a suggestion
+   ✓ Produce artifacts only -- the scorer measures them independently
+   ✗ Do NOT write metric numbers into REPORT.md or anywhere else; the
+     scorer is the authoritative source of truth on measured values
+   ✗ Do NOT read scoring/eval.py, scoring/targets.json, or
+     scoring/rule_maker_log.md (these have been moved out of the workspace
+     anyway)
+   ✗ Do NOT modify anything under scoring/


### PR DESCRIPTION
## Summary

Adds an optional **AutoResearch mode** to NeuriCo’s scored experiment pipeline.

AutoResearch wraps the experiment stage with an iterative proposal → comment-mode edit → scoring → checkpoint comparison loop. It builds directly on the rule_maker/scorer backbone from [#117](https://github.com/ChicagoHAI/NeuriCo/pull/117): the rule_maker defines the public artifact protocol and sealed scoring harness, the runner produces an initial scored experiment state, and AutoResearch then tries targeted experiment-stage improvements while preserving a Git-backed history of every candidate node.

Enabled by:

`./neurico run <id> --enable-scoring --autoresearch --autoresearch-iterations <N>`

Continuation from an existing scored workspace is supported by:

`./neurico run <id> --no-github --continue-autoresearch --autoresearch-iterations <N>`

Default non-AutoResearch behavior is unchanged.

## How the AutoResearch loop works

The scored pipeline becomes:

```text
resource_finder → rule_maker → [seal scoring/] → experiment_runner → [unseal] → scorer
                → AutoResearch loop → paper_writer
```

Each AutoResearch iteration runs:

```text
restore parent/best checkpoint
→ seal hidden scoring files
→ proposer writes one proposal
→ comment mode applies the proposal
→ unseal hidden scoring files
→ scorer writes candidate scoring/results.json
→ checkpoint candidate node
→ compare candidate vs parent
→ accept candidate or roll back
```

Three components close the loop:

1. **AutoResearch proposer.** Reads public context only: `scoring/interface.md`, `scoring/results.json`, public reports/artifacts, current-parent attempt history, and a `src/` file tree. It writes one structured `proposal.md` into the current attempt directory. It is planner-only and does not edit the workspace.

2. **Comment mode.** Receives the proposal through NeuriCo’s existing comment-mode pathway. It inspects and edits the workspace source/artifacts as the implementation agent.

3. **Comparator/checkpointer.** Commits each public experiment state as a Git node, including that node’s own `scoring/results.json` but excluding hidden scoring internals. It accepts candidates that improve the current best according to scored properties, otherwise records the rejected child and restores the parent node.

Attempt history is stored under:

```text
logs/experiment-autoresearch/<parent_sha>/attempt_N/
```

Each attempt records:

```text
proposal.md
proposer_prompt.txt
proposer_codex_transcript.jsonl
child_pointer.txt
results.json
decision.json
```

### Comparator algorithm

AutoResearch compares each candidate node against the current parent/best node using `scoring/results.json`.

For rule_maker-generated scoring, comparison requires the `properties` object. Each property must have matching name, direction, and target between parent and candidate. A candidate is rejected if results are missing, invalid, or if property names/directions/targets do not match.

For each property, AutoResearch computes a normalized margin:

```python
denom = max(abs(target), 1.0)

if direction == "max":
    margin = (value - target) / denom
elif direction == "min":
    margin = (target - value) / denom
```

Higher margin is better. A margin greater than or equal to `0` means the property satisfies its target.

Accept/reject rules:

1. If the candidate loses any property that the parent satisfied, reject.
2. If the candidate’s satisfied-property set is a strict superset of the parent’s satisfied-property set, accept.
3. If the satisfied-property set is identical, accept only if:
   - no property’s normalized margin regresses, and
   - at least one property’s normalized margin improves.
4. Otherwise, reject.

This means AutoResearch can climb toward satisfying all targets, and once all targets are satisfied, it can still hill-climb by improving normalized margins without allowing regressions.

## What’s in this PR

**New files:**

- `src/core/autoresearch.py` — AutoResearch checkpointing, comparator, attempt history, controller, and real-loop wiring
- `src/core/scoring_seal.py` — shared helpers for sealing/restoring hidden scoring files and held-out test data
- `src/agents/autoresearch_proposer.py` — proposer agent wrapper and public-context collection
- `templates/agents/autoresearch_proposer.txt` — proposer prompt template

**Modified files:**

- `src/core/runner.py` — adds AutoResearch CLI flags, continuation handling, paper-aware dirty-workspace validation, and paper-writer staging after AutoResearch
- `src/core/pipeline_orchestrator.py` — uses shared scoring seal helpers so scored pipeline and AutoResearch share the same hidden-file behavior

## Design notes

- AutoResearch nodes are **public experiment states**, not full research reports.
- Hidden scoring internals are excluded from node commits:
  - `scoring/eval.py`
  - `scoring/targets.json`
  - `scoring/rule_maker_log.md`
  - `data/.test/`
  - `.scoring_sealed/`
- Candidate commits include the candidate’s own `scoring/results.json`, so every node is traceable and reproducible as a scored public state.
- Rejected candidates are still checkpointed and recorded in attempt history, then the workspace is restored to the parent/best node.
- Attempt history is scoped by parent commit SHA, so proposal context only reflects attempts from the current node.
- Paper-writing outputs are kept separate from AutoResearch experiment checkpoints. Continuing AutoResearch after paper writing ignores known paper artifacts when validating workspace dirtiness.
- The proposer does not receive source contents or hidden scoring internals. It gets public protocol/results/history plus a `src/` file tree; comment mode remains responsible for source inspection and editing.

## CLI additions

```bash
--autoresearch
--continue-autoresearch
--autoresearch-iterations
--autoresearch-history-dir
```

`--autoresearch` runs after the initial scored experiment and before paper writing.

`--continue-autoresearch` resumes from an existing scored workspace, using the saved AutoResearch state when available.

`--autoresearch-iterations <N>` controls how many AutoResearch proposal/edit/score/compare iterations to run.

`--autoresearch-history-dir <path>` overrides where AutoResearch attempt history is stored. By default, history is written inside the research workspace at logs/experiment-autoresearch/.

## Test

- [x] All touched Python files compile
- [x] `runner.py --help` shows the new AutoResearch flags
- [x] Default non-AutoResearch path remains unchanged unless `--autoresearch` or `--continue-autoresearch` is passed
- [x] Proposer context contains only public artifacts, current-parent attempt history, and a `src/` file tree
- [x] Hidden scoring internals are sealed before proposer/comment mode and restored before scorer execution
- [x] AutoResearch checkpoints include each node’s own `scoring/results.json` and exclude hidden scoring internals
- [x] Attempt history is written under `logs/experiment-autoresearch/<parent_sha>/attempt_N/`
- [x] Rejected candidates are checkpointed, recorded, and rolled back to the parent/best node
- [x] Continue mode resumes from saved AutoResearch state and tolerates known paper-writing outputs

Full real-agent smoke testing with the Codex provider:

**Generated scoring rule for the SciFact-style task**

The rule_maker generated the following artifact protocol:

- Required artifact: `src/solution.py`
- Required callable:

```python
def predict_label(claim: str, evidence: str) -> str:
    """Return the verification label for a SciFact-style claim/evidence pair."""
```

- Allowed labels: `SUPPORT`, `CONTRADICT`, `NOINFO`
- Success rule: `ALL_PROPERTIES_SATISFIED`

Generated targets:

```json
{
  "macro_f1": {"target": 0.55, "direction": "max"},
  "min_class_f1": {"target": 0.25, "direction": "max"},
  "artifact_validity": {"target": 1.0, "direction": "max"}
}
```

So “newly satisfied” means a candidate changed one of these properties from below target to meeting target, without losing previously satisfied properties.

**Fresh AutoResearch run**

```bash
./neurico run autoresearch_clean_scifact_20260612_161436 \
  --provider codex \
  --no-github \
  --enable-scoring \
  --autoresearch \
  --autoresearch-iterations 3 \
  --timeout 7200 \
  --rule-maker-timeout 1800 \
  --scorer-timeout 600 \
  --write-paper
```

Observed result:

- Created a new scored workspace from scratch
- Ran rule_maker, initial experiment runner, scorer, then AutoResearch
- Initial AutoResearch node was `d1d3bca51d7df7914119820ade8d22f864afb9ec`
  - `macro_f1`: `0.5372441481` / target `0.55` → not satisfied
  - `min_class_f1`: `0.0350877193` / target `0.25` → not satisfied
  - `artifact_validity`: `1.0` / target `1.0` → satisfied
- Attempt 1 produced child `1c6b9522e037ac9e9adc53fab7cbb3a9fc4681e7` and was rejected because `macro_f1` regressed (`0.5372441481` → `0.5056327951`)
- Attempt 2 produced child `c96246fdfff90b9e8bc98719738ec3d732371353` and was accepted because it newly satisfied `macro_f1` (`0.5372441481` → `0.5544478584`, target `0.55`)
- Attempt 3 produced child `bc75a235fcbd6f405ddf1c28dfec285a1323b20b` and was accepted because it newly satisfied `min_class_f1` (`0.0847457627` → `0.5387205387`, target `0.25`)
- Final best node after the fresh run was `bc75a235fcbd6f405ddf1c28dfec285a1323b20b`
- Attempt-local proposal/prompt/transcript logs were written under `logs/experiment-autoresearch/<parent_sha>/attempt_N/`
- Hidden scoring files and `data/.test/` were restored after scorer execution
- Workspace ended on the current best node

**Continue AutoResearch run with paper writing**

```bash
./neurico run autoresearch_clean_scifact_20260612_161436 \
  --provider codex \
  --no-github \
  --continue-autoresearch \
  --autoresearch-iterations 2 \
  --timeout 7200 \
  --rule-maker-timeout 1800 \
  --scorer-timeout 600 \
  --paper-timeout 3600 \
  --write-paper
```

Observed result:

- Resumed from current-best node `bc75a235fcbd6f405ddf1c28dfec285a1323b20b`
- Attempt 1 produced child `0c2daee1f069b32e36dd38fc5a6fd16201095cda` and was rejected because `macro_f1` regressed (`0.6498674466` → `0.6474062740`)
- Attempt 2 produced child `f7351e14b2aca4005cc3b09a0b433e133f12072e` and was rejected because `min_class_f1` regressed (`0.5387205387` → `0.5056603774`)
- Final best node remained `bc75a235fcbd6f405ddf1c28dfec285a1323b20b`
- Hidden scoring files and `data/.test/` were restored
- Attempt logs remained under `logs/experiment-autoresearch/`
- Workspace git status ended clean
- Paper writer ran after rollback and compiled the paper from the restored best experiment state

## Next step for AutoResearch

A natural next step is to support **bootstrap AutoResearch** for existing workspaces that do not yet have a scored baseline.

Today, AutoResearch requires a workspace that was already produced under the rule_maker/scorer protocol: `scoring/interface.md`, `scoring/eval.py`, and `scoring/results.json` must exist before continuation can start. This is intentionally conservative, because old unscored experiment artifacts may not match any later scoring protocol.

The future bootstrap flow would make this explicit:

```
existing unscored workspace
→ checkpoint original state
→ run rule_maker to define a scoring protocol
→ use the proposal generator to plan how to adapt the workspace to scoring/interface.md
→ use comment mode to apply that adaptation
→ run scorer
→ checkpoint the adapted scored baseline as the first best node
→ run the normal AutoResearch loop
```

This would let users bring an existing, meaningful but unscored workspace into AutoResearch without pretending the old artifact was already comparable. The bootstrap step would be recorded separately from normal AutoResearch attempts, and AutoResearch would only begin after the adapted workspace successfully produces a valid `scoring/results.json`.