### PR TITLE
(exploratory) feat: experience-memory — let experiment runners learn from past runs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -178,6 +178,7 @@ RUN git config --global user.email "noreply@neurico.dev" \
     && git config --global user.name "NeuriCo" \
     && git config --global init.defaultBranch main \
     && mkdir -p ~/.claude ~/.codex ~/.codex-container ~/.codex-host ~/.gemini ~/.cache/uv \
+                ~/.neurico/memories/live ~/.neurico/memories/drafts ~/.neurico/memories/archived \
     && echo 'PS1="neurico:\w\$ "' >> ~/.bashrc
 
 # Bypass Gemini CLI's trusted-folders check in headless container runs

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -144,6 +144,19 @@ show_status() {
         echo -e "    Gemini credentials .. ${YELLOW}[EMPTY]${NC} ~/.gemini exists but empty"
     fi
 
+    # Experience-memory store (~/.neurico/memories/) — extracted reflections
+    # from past runs that get injected into future runs. See
+    # docs/memory_schema.md.
+    if [ -d "$HOME/.neurico/memories/live" ]; then
+        local _live_count
+        _live_count=$(find "$HOME/.neurico/memories/live" -maxdepth 1 -name 'm_*.md' 2>/dev/null | wc -l | tr -d ' ')
+        echo -e "    Memory store ........ ${GREEN}[OK]${NC} ${_live_count} live memor$([ "$_live_count" = "1" ] && echo y || echo ies)"
+    elif [ -d "$HOME/.neurico/memories" ]; then
+        echo -e "    Memory store ........ ${DIM}[--]${NC} ~/.neurico/memories exists but no live memories"
+    else
+        echo -e "    Memory store ........ ${DIM}[--]${NC} ~/.neurico/memories will be created on first run"
+    fi
+
     echo ""
 }
 
@@ -261,6 +274,22 @@ get_cli_credential_mounts() {
         found_any=true
     fi
 
+    # Experience-memory store (~/.neurico/memories/) — READ-WRITE because the
+    # post-experiment reflection step writes new draft memories back from the
+    # container. Created on host (with the right ownership for UID 1000) so
+    # the first run doesn't need to bootstrap an empty layout from inside.
+    mkdir -p "$HOME/.neurico/memories/live" \
+             "$HOME/.neurico/memories/drafts" \
+             "$HOME/.neurico/memories/archived" 2>/dev/null || true
+    mounts="$mounts -v \"$HOME/.neurico/memories:/home/neurico/.neurico/memories\""
+    local _live_count
+    _live_count=$(find "$HOME/.neurico/memories/live" -maxdepth 1 -name 'm_*.md' 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$_live_count" -gt 0 ]; then
+        echo -e "  ${GREEN}[OK]${NC} Mounting memory store (${_live_count} live)" >&2
+    else
+        echo -e "  ${DIM}[--]${NC} Mounting memory store (empty — fills up as runs reflect)" >&2
+    fi
+
     if [ "$found_any" = false ]; then
         echo -e "  ${YELLOW}[WARN]${NC} No CLI credentials found." >&2
         echo -e "         Run 'claude', 'codex', or 'gemini' on host to login first." >&2
@@ -324,6 +353,9 @@ ensure_directories() {
     # container cannot read existing credentials or write new ones during login.
     # These contain OAuth tokens (not raw API keys), so the risk is lower than .env.
     chmod -R a+rwX "$HOME/.claude" "$HOME/.codex" "$HOME/.gemini" 2>/dev/null || true
+    # Memory store is read-write from inside the container so reflection drafts
+    # can be persisted back. No secrets in here — chmod is just about UID match.
+    chmod -R a+rwX "$HOME/.neurico/memories" 2>/dev/null || true
     # Restrict .env to owner-only since it contains raw API keys (important on shared servers)
     chmod 600 "$PROJECT_ROOT/.env" 2>/dev/null || true
 }
@@ -667,12 +699,17 @@ cmd_run() {
     echo -e "${BLUE}Running research exploration...${NC}"
     echo -e "${BLUE}Workspace:${NC} $workspace_dir -> /workspaces"
 
+    # Mount the host src/ over the image's baked-in copy so we don't need
+    # to rebuild the image to pick up local changes (same pattern as cmd in
+    # PR #104). Specifically needed for the experience-memory feature whose
+    # modules live in src/core/memory_*.
     eval "docker run $tty_flag --rm \
         $gpu_flags \
         $user_flags \
         --env-file \"$PROJECT_ROOT/.env\" \
         -e NEURICO_WORKSPACE=/workspaces \
         -v \"$workspace_dir:/workspaces\" \
+        -v \"$PROJECT_ROOT/src:/app/src:ro\" \
         -v \"$PROJECT_ROOT/ideas:/app/ideas\" \
         -v \"$PROJECT_ROOT/logs:/app/logs\" \
         -v \"$PROJECT_ROOT/config:/app/config:ro\" \

--- a/docs/memory_schema.md
+++ b/docs/memory_schema.md
@@ -1,0 +1,194 @@
+# NeuriCo Experience Memory — Schema
+
+## What a memory is
+
+A **memory** is a small markdown file capturing a piece of research-experience
+knowledge that a future experiment might benefit from but that is unlikely to
+be top-of-mind when reading a new idea.
+
+Memories are written by agents *after* an experiment run when they reflect on
+the trajectory. They are read by agents *before* a future experiment run to
+inform planning. Both halves of the loop are designed around the same schema.
+
+## What a memory is NOT
+
+- A general fact ("LSTMs have vanishing gradients"). That belongs in a skill
+  or a textbook, not a memory.
+- A specific code recipe ("set `batch_size=4` for the dolly-15k loader").
+  Memories must abstract above the original incident.
+- A first-thought heuristic the agent would write before doing the experiment.
+  Memories come from surprise, mid-course correction, or a result that didn't
+  hold up the way the agent expected.
+
+The extraction prompt's contract: **"zero memories per run is a valid answer.
+We prefer zero memories over forgettable ones."** A memory exists only when
+the writer can articulate a clear, transferable insight.
+
+## Storage layout
+
+Memories live in `~/.neurico/memories/`. The directory is mounted into the
+Docker container at `/home/neurico/.neurico/memories/` (same pattern as
+`~/.modal.toml` and `~/.claude/`).
+
+```
+~/.neurico/memories/
+├── live/                       # promoted memories — retrieval reads these
+│   ├── m_<id>_<slug>.md
+│   └── ...
+├── drafts/                     # newly extracted, not yet promoted
+│   └── run_<exp_id>/
+│       ├── A/                  # approach A: runner_self
+│       │   └── d_<id>_<slug>.md
+│       └── B/                  # approach B: manager_observer
+│           └── d_<id>_<slug>.md
+├── archived/                   # demoted from live (kept for audit)
+│   └── m_<id>_<slug>.md
+└── index.json                  # registry: id → metadata, for fast filtering
+```
+
+`index.json` is a derived cache. Rebuilding it from the files in `live/`
+and `archived/` is always safe.
+
+## File format
+
+Each memory is a Markdown file with YAML frontmatter followed by a body. The
+frontmatter is structured and machine-read; the body is prose that gets
+injected into agent context.
+
+```yaml
+---
+id: m_2026q2_classimbalance_silently_inflates_accuracy
+created_at: 2026-06-20T17:30:00Z
+extraction_approach: runner_self          # or "manager_observer"
+
+# === ABSTRACTION (drives retrieval; must NOT contain specifics) ===
+problem_class:
+  what: "classification eval over an imbalanced label distribution"
+  shape:                                  # abstract preconditions
+    - data: "labels with non-uniform distribution"
+    - metric: "accuracy (or any unweighted aggregate)"
+    - decision_to_make: "headline performance reporting"
+  signal_to_recognize:                    # what a future agent should look for
+    - "majority-class fraction > 60%"
+    - "or: an obvious 'always predict majority' baseline isn't reported"
+
+# === CORE INSIGHT (also abstract; the takeaway in 1-2 sentences) ===
+insight: |
+  Unweighted aggregates over imbalanced labels reward majority-class
+  bias. The fix is class-aware metrics (balanced accuracy, macro-F1)
+  PAIRED with the majority-class baseline as a sanity floor.
+
+# === SPECIFICITY (provenance — audit/dedup only; redacted at injection time) ===
+origin:
+  source_run: <workspace-slug>
+  source_domain: machine_learning
+  source_idea_one_liner: "Do classifiers preserve fairness under data shift?"
+  what_first_attempt_was: "reported 91% accuracy; tuned hyperparameters"
+  what_actually_worked: "added per-class F1, discovered model was near-trivial"
+
+# === TAGS (for filtering) ===
+domain_tags: [machine_learning, classification, evaluation]
+phase_tags: [eval-design, results-interpretation]
+
+confidence: medium                        # low | medium | high
+votes:
+  used: 0                                 # times this memory was injected
+  helpful: 0                              # times an agent reported it helped
+  irrelevant: 0                           # times an agent flagged it as off-topic
+---
+
+# Optional prose body — only when the abstract insight needs concrete intuition
+
+The trap is that the metric and the data distribution interact. Even a
+well-chosen model architecture cannot rescue a metric that is gaming class
+proportions. Always sanity-check by reporting a majority-class baseline
+alongside any aggregate metric.
+```
+
+## Field semantics
+
+### Required at write time
+
+| Field | Type | Rule |
+|---|---|---|
+| `id` | str | `m_<yyyy><quarter>_<slug>` for live, `d_<slug>` for drafts. Slug is lower-snake. |
+| `created_at` | ISO-8601 | UTC |
+| `extraction_approach` | enum | `runner_self` \| `manager_observer` \| `manual` |
+| `problem_class.what` | str | One sentence. The CLASS of problem, not the specific instance. |
+| `problem_class.shape` | list of `{key: str}` | 2-5 abstract preconditions |
+| `problem_class.signal_to_recognize` | list of str | 1-3 concrete things a future agent can look for |
+| `insight` | str | 1-2 sentences. Generalized takeaway, no specifics. |
+| `origin.source_run` | str | Workspace slug |
+| `origin.source_domain` | str | Matches a neurico domain |
+| `origin.what_first_attempt_was` | str | What the agent tried first. Mandatory — if the writer can't fill this in, the insight isn't memory-worthy. |
+| `origin.what_actually_worked` | str | The corrected approach |
+| `domain_tags` | list of str | Lower-snake. Must include `origin.source_domain`. |
+| `confidence` | enum | `low` \| `medium` \| `high` |
+
+### Populated by the system
+
+| Field | Source |
+|---|---|
+| `votes.used` | Incremented when retrieval selects this memory |
+| `votes.helpful` | Incremented when a downstream agent reports it helped |
+| `votes.irrelevant` | Incremented when an agent flags it as off-topic |
+
+### Optional at write time
+
+| Field | Purpose |
+|---|---|
+| `phase_tags` | `planning` \| `data-prep` \| `eval-design` \| `results-interpretation` \| etc. |
+| Body (markdown) | Free-form elaboration; one paragraph max |
+
+## Abstraction-level rubric
+
+The extraction prompt enforces this — but for human reference:
+
+| Too specific (don't write) | Right abstraction (write) | Too general (don't write) |
+|---|---|---|
+| "When loading dolly-15k with HuggingFace, set lr=1e-4" | "When fine-tuning small LMs (<2B) on instruction data <100k examples, lr=1e-4 is a safe start" | "Tune your learning rate" |
+| "F1 of 0.42 on the validation set means you're below baseline" | "When the majority-class fraction exceeds 60%, an aggregate metric without a baseline floor reward will mislead" | "Pick the right metric" |
+| "The Qwen tokenizer drops the BOS token" | "Some HF tokenizers omit BOS by default; verify before computing positional embeddings" | "Check your tokenizer" |
+
+If the writer can fill in the "Right abstraction" column for both the
+`problem_class` and `insight`, the memory is worth writing.
+
+## Retrieval contract (preview — Phase 2)
+
+When a new experiment starts, the retriever:
+
+1. Filters by `origin.source_domain` (or `domain_tags` ∩ current domain)
+2. Passes the idea brief + the filtered memories' (`id`, `problem_class.what`,
+   `problem_class.signal_to_recognize`, `insight`) to a small LLM
+3. The LLM returns up to 5 ids that look applicable, or nothing
+4. Selected memories are written to `MEMORIES_FROM_PAST_RUNS.md` in the
+   workspace with `origin.*` fields stripped
+5. The runner's prompt is augmented with one paragraph pointing at that file
+
+The `origin` redaction matters: future agents should not be allowed to lean
+on "this memory came from a similar dataset" — they have to evaluate the
+abstracted insight on its own merits.
+
+## Promotion lifecycle
+
+1. **Draft** — written by an extractor, lives in `drafts/run_<exp_id>/<approach>/`.
+2. **Promote** — moves to `live/`, gets a permanent `m_*` id. Manual via CLI
+   in Phase 1; eventually agent-driven.
+3. **Archive** — moves out of `live/` if it stops being useful. Kept under
+   `archived/` for audit; not retrieved.
+
+Archive criteria (Phase 5+): low `helpful` ratio across many `used` events,
+or replaced by a more general memory.
+
+## What changes between Phase 1 and later phases
+
+| Phase | What lives in the system | What's the gate |
+|---|---|---|
+| 1 (this one) | Storage helpers, CLI, hand-seeded memories | Schema is canon |
+| 2 | + Retrieval at experiment start | Real agents read memories |
+| 3 | + Approach A extractor (runner self) | First auto-generated drafts |
+| 4 | + Approach B extractor (manager + ResearchState) | Both approaches working |
+| 5 | + Comparison harness, vote tracking, promotion automation | Decide which extractor to keep |
+
+Phase 1 is intentionally minimal: build the data plumbing so Phases 2-5 have
+something stable to integrate against.

--- a/src/cli/memory.py
+++ b/src/cli/memory.py
@@ -1,0 +1,226 @@
+"""
+CLI for inspecting, seeding, and curating NeuriCo's experience memory.
+
+Usage:
+    python -m cli.memory list                              # list live memories
+    python -m cli.memory list --drafts                     # list draft memories
+    python -m cli.memory list --domain machine_learning    # filter by domain
+    python -m cli.memory show <memory-id>                  # print one memory
+    python -m cli.memory add path/to/draft.md              # hand-add a memory
+    python -m cli.memory promote <draft-id> --run <slug>   # draft -> live
+    python -m cli.memory archive <memory-id>               # live -> archived
+    python -m cli.memory reindex                           # rebuild index.json
+    python -m cli.memory path                              # print storage root
+
+This CLI is Phase 1 plumbing — Phases 2+ will write to the store directly
+from the pipeline, so an interactive operator rarely needs to touch this CLI
+unless they're hand-seeding memories or debugging.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+# Add parent directory to path so ``core`` resolves when invoked as a script.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.memory_store import (  # noqa: E402
+    DEFAULT_MEMORY_ROOT,
+    Memory,
+    MemoryStore,
+)
+
+
+def _store(args: argparse.Namespace) -> MemoryStore:
+    root = Path(args.root) if args.root else DEFAULT_MEMORY_ROOT
+    store = MemoryStore(root=root)
+    store.ensure_layout()
+    return store
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    store = _store(args)
+    if args.drafts:
+        memories = store.list_drafts(run_id=args.run, approach=args.approach)
+        kind = "drafts"
+    else:
+        memories = store.filter_live(
+            domain=args.domain,
+            tags_any=args.tag or None,
+        )
+        kind = "live"
+
+    if args.json:
+        print(json.dumps([m.to_dict() for m in memories], indent=2))
+        return 0
+
+    if not memories:
+        print(f"(no {kind} memories)")
+        return 0
+
+    width = max(len(m.id) for m in memories)
+    print(f"{len(memories)} {kind} memor{'y' if len(memories) == 1 else 'ies'}:")
+    print()
+    for m in memories:
+        votes = m.votes
+        score = f"u={votes['used']} h={votes['helpful']} x={votes['irrelevant']}"
+        print(f"  {m.id:<{width}}  [{m.confidence:<6}]  {score:<14}  {m.problem_class.what}")
+    return 0
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    store = _store(args)
+    m = store.get_live(args.memory_id)
+    if m is None:
+        # Maybe it's a draft — fall back to a search across drafts/
+        for d in store.list_drafts():
+            if d.id == args.memory_id:
+                m = d
+                break
+    if m is None:
+        print(f"memory {args.memory_id!r} not found", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(m.to_dict(), indent=2))
+        if m.body:
+            print()
+            print(m.body)
+    else:
+        print(m.to_markdown())
+    return 0
+
+
+def cmd_add(args: argparse.Namespace) -> int:
+    """
+    Add a hand-written memory file to either live/ or drafts/.
+
+    Reads the file at ``args.path`` (which must already be a well-formed
+    memory markdown file), validates it, and writes it into the chosen
+    location. For drafts you must supply --run; the slug is taken from the
+    memory id otherwise.
+    """
+    store = _store(args)
+    text = Path(args.path).read_text(encoding="utf-8")
+    try:
+        m = Memory.from_markdown(text)
+    except ValueError as exc:
+        print(f"could not parse {args.path}: {exc}", file=sys.stderr)
+        return 2
+
+    if args.kind == "draft":
+        if not args.run:
+            print("error: --kind draft requires --run", file=sys.stderr)
+            return 2
+        path = store.write(m, kind="draft", run_id=args.run,
+                           approach=args.approach or "manual")
+    else:
+        path = store.write(m, kind="live")
+    print(f"wrote {path}")
+    return 0
+
+
+def cmd_promote(args: argparse.Namespace) -> int:
+    store = _store(args)
+    drafts = [d for d in store.list_drafts(run_id=args.run) if d.id == args.draft_id]
+    if not drafts:
+        print(f"draft {args.draft_id!r} not found under run {args.run!r}",
+              file=sys.stderr)
+        return 1
+    promoted = store.promote(drafts[0], run_id=args.run, approach=args.approach)
+    print(f"promoted to {promoted}")
+    return 0
+
+
+def cmd_archive(args: argparse.Namespace) -> int:
+    store = _store(args)
+    new_path = store.archive(args.memory_id)
+    if new_path is None:
+        print(f"live memory {args.memory_id!r} not found", file=sys.stderr)
+        return 1
+    print(f"archived to {new_path}")
+    return 0
+
+
+def cmd_reindex(args: argparse.Namespace) -> int:
+    store = _store(args)
+    index = store.reindex()
+    print(f"reindexed: {index['count']} live memor"
+          f"{'y' if index['count'] == 1 else 'ies'}")
+    return 0
+
+
+def cmd_path(args: argparse.Namespace) -> int:
+    """Print the storage root. Handy for shell expansion + debugging."""
+    store = _store(args)
+    print(store.root)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="manage NeuriCo's experience memory store",
+    )
+    p.add_argument(
+        "--root", default=None,
+        help=f"override the storage root (default: {DEFAULT_MEMORY_ROOT})",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("list", help="list memories")
+    sp.add_argument("--drafts", action="store_true",
+                    help="list drafts instead of live memories")
+    sp.add_argument("--run", help="filter drafts by run id")
+    sp.add_argument("--approach", choices=["A", "B", "manual"],
+                    help="filter drafts by extraction approach")
+    sp.add_argument("--domain", help="filter live memories by source domain")
+    sp.add_argument("--tag", action="append", default=[],
+                    help="filter live memories by any of these tags (repeatable)")
+    sp.add_argument("--json", action="store_true",
+                    help="emit JSON instead of a table")
+    sp.set_defaults(func=cmd_list)
+
+    sp = sub.add_parser("show", help="print one memory")
+    sp.add_argument("memory_id")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_show)
+
+    sp = sub.add_parser("add", help="add a hand-written memory file")
+    sp.add_argument("path", help="path to a memory markdown file")
+    sp.add_argument("--kind", choices=["live", "draft"], default="live")
+    sp.add_argument("--run", help="run slug (required when --kind draft)")
+    sp.add_argument("--approach", default="manual",
+                    help="extraction-approach label for drafts")
+    sp.set_defaults(func=cmd_add)
+
+    sp = sub.add_parser("promote", help="move a draft into live/")
+    sp.add_argument("draft_id")
+    sp.add_argument("--run", required=True)
+    sp.add_argument("--approach", default="manual",
+                    help="extraction-approach label on the promoted memory")
+    sp.set_defaults(func=cmd_promote)
+
+    sp = sub.add_parser("archive", help="move a live memory into archived/")
+    sp.add_argument("memory_id")
+    sp.set_defaults(func=cmd_archive)
+
+    sp = sub.add_parser("reindex", help="rebuild index.json from live/")
+    sp.set_defaults(func=cmd_reindex)
+
+    sp = sub.add_parser("path", help="print the storage root")
+    sp.set_defaults(func=cmd_path)
+
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core/memory_retrieval.py
+++ b/src/core/memory_retrieval.py
@@ -1,0 +1,488 @@
+"""
+Pre-run memory retrieval and post-run feedback.
+
+This module is the bridge between the on-disk memory store and a NeuriCo
+experiment run. Two responsibilities:
+
+  1. ``retrieve_for_idea`` runs BEFORE ``experiment_runner``. It picks live
+     memories that might apply to the current idea (Phase 2: domain pre-filter
+     only — no LLM selector), bumps each chosen memory's ``used`` counter,
+     and writes ``MEMORIES_FROM_PAST_RUNS.md`` into the workspace with all
+     provenance fields stripped. The runner reads this file as part of its
+     PHASE 0 step (see ``templates/agents/session_instructions.txt``).
+
+  2. ``apply_feedback`` runs AFTER ``experiment_runner``. It parses the
+     ``MEMORY_FEEDBACK.md`` the runner produced — one acknowledgment per
+     injected memory: ``applied`` or ``not_applicable``. ``applied`` bumps
+     ``helpful``; ``not_applicable`` bumps ``irrelevant``. Missing or
+     malformed feedback is logged but never blocks the pipeline.
+
+The two halves close the loop: future retrieval can rank memories by
+hit-rate (``helpful / used``) once enough data accumulates.
+
+This module knows NOTHING about LLM providers or agent runners — it owns
+filesystem I/O only. The orchestrator wires it into the pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from core.memory_store import Memory, MemoryStore
+
+
+MEMORIES_FILENAME = "MEMORIES_FROM_PAST_RUNS.md"
+FEEDBACK_FILENAME = "MEMORY_FEEDBACK.md"
+
+# Sidecar recording which memory ids the retrieval step actually surfaced
+# in this workspace. apply_feedback() consults it so votes can only be bumped
+# for memories the runner was given a chance to see — feedback referring to
+# ids outside this set is dropped with a warning. Without this guard, a runner
+# that hallucinates ids (or two runs sharing a workspace) would pollute the
+# vote counts that the comparison harness later relies on.
+INJECTED_SIDECAR_REL = Path(".neurico") / "memories_injected.json"
+
+# Maximum number of memories ever injected into a single run. Caps the
+# runner's PHASE 0 reading cost so a thousand-memory store doesn't drown
+# a new experiment. With Phase 2's no-LLM filter, this is a hard ceiling;
+# Phase 5 can raise it once the selector ranks candidates first.
+DEFAULT_MAX_MEMORIES = 10
+
+
+# Retrieval (pre-runner)
+
+def retrieve_for_idea(
+    idea: Dict[str, Any],
+    store: MemoryStore,
+    work_dir: Path,
+    *,
+    max_memories: int = DEFAULT_MAX_MEMORIES,
+) -> Dict[str, Any]:
+    """
+    Select memories applicable to ``idea`` and write them into the workspace.
+
+    Returns a summary dict:
+
+        {
+          "injected": <int>,             # count of memories surfaced
+          "memory_ids": [<str>, ...],    # ids of the surfaced memories
+          "out_path": "<workspace>/MEMORIES_FROM_PAST_RUNS.md",
+          "skipped_reason": <str|None>,  # set when injected == 0 with reason
+        }
+
+    Behavior:
+      * Empty store or no domain match -> no file written, ``skipped_reason``
+        explains why.
+      * Domain match -> filter, cap to ``max_memories``, bump ``used``, write.
+
+    The orchestrator passes the surrounding ``idea`` dict; we read only its
+    ``domain`` field. Anything richer (an LLM-based selector) goes in Phase 5.
+    """
+    domain = (idea.get("domain") or "").strip()
+    candidates = store.filter_live(domain=domain if domain else None)
+
+    if not candidates:
+        return {
+            "injected": 0,
+            "memory_ids": [],
+            "out_path": None,
+            "skipped_reason": (
+                f"no live memories for domain {domain!r}"
+                if domain else "no live memories"
+            ),
+        }
+
+    chosen = candidates[:max_memories]
+    for m in chosen:
+        store.bump_vote(m.id, "used")
+
+    work_dir = Path(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    out_path = work_dir / MEMORIES_FILENAME
+    out_path.write_text(_render_memories_md(chosen), encoding="utf-8")
+
+    # Record which ids were actually surfaced so post-run feedback can guard
+    # against bumps for ids the runner never saw. Stored under .neurico/ so
+    # it travels with the workspace's pipeline state, not with artifacts.
+    sidecar = work_dir / INJECTED_SIDECAR_REL
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(
+        json.dumps({"injected_ids": [m.id for m in chosen]}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "injected": len(chosen),
+        "memory_ids": [m.id for m in chosen],
+        "out_path": str(out_path),
+        "skipped_reason": None,
+    }
+
+
+def _render_memories_md(memories: List[Memory]) -> str:
+    """
+    Render selected memories into the workspace-local Markdown file the
+    runner reads. All ``origin.*`` and ``votes.*`` fields are stripped — only
+    the abstract problem class + insight + optional body survive.
+
+    The header explains the acknowledgment contract so the runner does not
+    have to consult ``session_instructions.txt`` to know what to do.
+    """
+    parts: List[str] = []
+    parts.append("# Memories from past runs\n")
+    parts.append(
+        "These are insights surfaced by past experiment runs that **might** "
+        "apply to this one. Most will not. Treat each memory as a hypothesis "
+        "to evaluate against the current idea, not a directive to follow.\n"
+    )
+    parts.append("## What you must do BEFORE planning\n")
+    parts.append(
+        "Read each memory below. For each one, write an acknowledgment to "
+        f"`{FEEDBACK_FILENAME}` in this exact format:\n"
+    )
+    parts.append(
+        "```yaml\n"
+        "- memory_id: <id from below>\n"
+        "  decision: applied            # or: not_applicable\n"
+        "  reason: <one sentence — why it does or doesn't fit this idea>\n"
+        "```\n"
+    )
+    parts.append(
+        "If a memory clearly applies, prefer to **apply** it and adapt your "
+        "plan accordingly. If it does not, write `not_applicable` with a "
+        "specific reason — \"didn't seem relevant\" is not enough.\n"
+    )
+    parts.append("---\n")
+
+    for i, m in enumerate(memories, start=1):
+        pc = m.problem_class
+        parts.append(f"## Memory {i} — `{m.id}`\n")
+        parts.append(f"**Problem class.** {pc.what}\n")
+
+        if pc.shape:
+            parts.append("**Abstract preconditions:**\n")
+            for entry in pc.shape:
+                if isinstance(entry, dict):
+                    for k, v in entry.items():
+                        parts.append(f"- *{k}*: {v}\n")
+                else:
+                    parts.append(f"- {entry}\n")
+            parts.append("\n")
+
+        if pc.signal_to_recognize:
+            parts.append("**Signal to recognize:**\n")
+            for sig in pc.signal_to_recognize:
+                parts.append(f"- {sig}\n")
+            parts.append("\n")
+
+        parts.append(f"**Insight.** {m.insight.strip()}\n")
+        if m.body.strip():
+            parts.append(f"\n{m.body.strip()}\n")
+        parts.append("\n---\n")
+
+    return "".join(parts)
+
+
+# Feedback (post-runner)
+
+def apply_feedback(
+    work_dir: Path,
+    store: MemoryStore,
+) -> Dict[str, Any]:
+    """
+    Parse the runner's ``MEMORY_FEEDBACK.md`` and bump vote counters.
+
+    Returns a summary dict:
+
+        {
+          "processed": <int>,         # entries we found
+          "helpful": <int>,           # bumps applied to helpful
+          "irrelevant": <int>,        # bumps applied to irrelevant
+          "skipped": <int>,           # entries we couldn't act on
+          "errors": [<str>, ...],     # warnings (e.g. unknown id)
+          "feedback_path": <str|None>,
+        }
+
+    A missing feedback file is NOT an error — it just means the runner had
+    nothing injected, or skipped the acknowledgment phase. Either way the
+    pipeline continues.
+    """
+    fb_path = Path(work_dir) / FEEDBACK_FILENAME
+    summary: Dict[str, Any] = {
+        "processed": 0, "helpful": 0, "irrelevant": 0, "skipped": 0,
+        "errors": [], "feedback_path": str(fb_path) if fb_path.exists() else None,
+    }
+    if not fb_path.exists():
+        return summary
+
+    # Load the injected-ids sidecar. If it's absent (e.g. retrieval didn't run
+    # this workspace) we skip the guard and accept feedback for any id, since
+    # there's no way to know what was actually shown.
+    injected_ids = _load_injected_ids(Path(work_dir))
+
+    try:
+        entries = _parse_feedback_yaml(fb_path.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        summary["errors"].append(f"could not parse {fb_path.name}: {exc}")
+        return summary
+
+    for entry in entries:
+        summary["processed"] += 1
+        mid = entry.get("memory_id", "").strip()
+        decision = entry.get("decision", "").strip().lower()
+        if not mid:
+            summary["skipped"] += 1
+            summary["errors"].append("entry missing memory_id")
+            continue
+
+        # Guard: feedback about an id we never injected is dropped. Without
+        # this, hallucinated ids would pollute the vote stats the comparison
+        # harness relies on. If the sidecar is missing (None), permit all.
+        if injected_ids is not None and mid not in injected_ids:
+            summary["skipped"] += 1
+            summary["errors"].append(
+                f"{mid}: feedback for id not injected into this workspace"
+            )
+            continue
+
+        if decision == "applied":
+            kind = "helpful"
+        elif decision in ("not_applicable", "not-applicable", "n/a"):
+            kind = "irrelevant"
+        else:
+            summary["skipped"] += 1
+            summary["errors"].append(
+                f"{mid}: unknown decision {decision!r} "
+                "(expected 'applied' or 'not_applicable')"
+            )
+            continue
+
+        if store.bump_vote(mid, kind):
+            summary[kind] += 1
+        else:
+            summary["skipped"] += 1
+            summary["errors"].append(f"{mid}: not found in live store")
+
+    return summary
+
+
+def _load_injected_ids(work_dir: Path) -> Optional[set]:
+    """
+    Return the set of memory ids that retrieval recorded for this workspace,
+    or None if no sidecar exists (e.g. an older workspace, or retrieval was
+    skipped). Returning None disables the guard so callers can opt out.
+    """
+    sidecar = work_dir / INJECTED_SIDECAR_REL
+    if not sidecar.exists():
+        return None
+    try:
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+        return set(data.get("injected_ids", []))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _parse_feedback_yaml(text: str) -> List[Dict[str, str]]:
+    """
+    Parse the runner's feedback file.
+
+    The expected format is a YAML list of mappings with three keys each
+    (``memory_id``, ``decision``, ``reason``). We prefer PyYAML when
+    available; otherwise we fall back to a tiny line-based parser that
+    handles the canonical form.
+
+    Returns a list of dicts. Raises ``ValueError`` on truly unparseable input.
+    """
+    text = _strip_yaml_codefence(text)
+    try:
+        import yaml  # type: ignore
+        data = yaml.safe_load(text) or []
+        if not isinstance(data, list):
+            raise ValueError("feedback root must be a YAML list")
+        out = []
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            out.append({
+                "memory_id": str(item.get("memory_id", "")),
+                "decision": str(item.get("decision", "")),
+                "reason": str(item.get("reason", "")),
+            })
+        return out
+    except ImportError:
+        return _parse_feedback_fallback(text)
+
+
+def _strip_yaml_codefence(text: str) -> str:
+    """
+    Remove leading/trailing ```yaml ... ``` fences. The runner often pastes
+    the feedback inside a fence because that's how the prompt example shows
+    it. We accept either form.
+    """
+    text = text.strip()
+    fence = re.compile(r"^```(?:yaml)?\s*\n", re.MULTILINE)
+    text = fence.sub("", text, count=1)
+    text = re.sub(r"\n```\s*$", "", text)
+    return text
+
+
+def _parse_feedback_fallback(text: str) -> List[Dict[str, str]]:
+    """
+    Minimal line-based parser for the canonical feedback form when PyYAML is
+    unavailable. Recognizes only the three keys we care about.
+    """
+    entries: List[Dict[str, str]] = []
+    current: Optional[Dict[str, str]] = None
+
+    item_re = re.compile(r"^-\s*memory_id\s*:\s*(.+?)\s*$")
+    key_re = re.compile(r"^\s+(memory_id|decision|reason)\s*:\s*(.+?)\s*$")
+
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line.strip():
+            continue
+        m = item_re.match(line)
+        if m:
+            if current:
+                entries.append(current)
+            current = {"memory_id": m.group(1).strip(),
+                       "decision": "", "reason": ""}
+            continue
+        m = key_re.match(line)
+        if m and current is not None:
+            current[m.group(1)] = m.group(2).strip()
+    if current:
+        entries.append(current)
+    return entries
+
+
+# Draft collection (post-runner)
+
+def collect_drafts(
+    work_dir: Path,
+    store: MemoryStore,
+    *,
+    approach: str = "A",
+) -> Dict[str, Any]:
+    """
+    Find and validate memory drafts the runner wrote during reflection.
+
+    The runner writes drafts under
+    ``~/.neurico/memories/drafts/run_<EXP_ID>/<approach>/d_*.md`` per the
+    PHASE 5.5 contract in ``templates/agents/session_instructions.txt``. We
+    parse each, run the schema validator, and report counts + per-file
+    errors. Validation errors are LOGGED but never raised — a malformed
+    draft is dropped from the count, not from the disk (the operator can
+    inspect it later).
+
+    ``approach`` selects which sub-bucket to walk:
+        "A"  — runner self-reflection drafts (Phase 3)
+        "B"  — manager-observer drafts (Phase 4, not yet implemented)
+
+    Returns a summary dict suitable for ``results["stages"]["memory_drafts"]``:
+
+        {
+          "approach": "A",
+          "run_id": "<workspace-slug or None>",
+          "scanned": <int>,                 # total .md files found
+          "valid": <int>,                   # passed validation
+          "invalid": [<{"path": str, "errors": [str]}>],  # validation failures
+          "draft_ids": [<str>, ...],        # ids of valid drafts
+        }
+    """
+    work_dir = Path(work_dir)
+    run_id = work_dir.name
+    run_root = store.drafts_dir / f"run_{run_id}" / approach
+    summary: Dict[str, Any] = {
+        "approach": approach,
+        "run_id": run_id,
+        "scanned": 0,
+        "valid": 0,
+        "invalid": [],
+        "draft_ids": [],
+    }
+    if not run_root.exists():
+        return summary
+
+    for p in sorted(run_root.glob("d_*.md")):
+        summary["scanned"] += 1
+        try:
+            m = store.read(p)
+        except (ValueError, OSError) as exc:
+            summary["invalid"].append({
+                "path": str(p.relative_to(store.root)),
+                "errors": [f"unparseable: {exc}"],
+            })
+            continue
+
+        errs = m.validate()
+        if errs:
+            summary["invalid"].append({
+                "path": str(p.relative_to(store.root)),
+                "errors": errs,
+            })
+            continue
+
+        # An extra approach-specific gate: the contract requires the runner's
+        # drafts to declare extraction_approach="runner_self" (not "manual"
+        # or "manager_observer"). Drafts that get the approach wrong are
+        # almost always a copy-paste bug; flag them.
+        expected = "runner_self" if approach == "A" else "manager_observer"
+        if m.extraction_approach != expected:
+            summary["invalid"].append({
+                "path": str(p.relative_to(store.root)),
+                "errors": [
+                    f"extraction_approach must be {expected!r} for an "
+                    f"approach-{approach} draft, got {m.extraction_approach!r}"
+                ],
+            })
+            continue
+
+        summary["valid"] += 1
+        summary["draft_ids"].append(m.id)
+
+    return summary
+
+
+# Summaries for orchestrator logging
+
+def render_retrieval_summary(result: Dict[str, Any]) -> str:
+    """One-line human summary of ``retrieve_for_idea`` for orchestrator logs."""
+    if result["injected"] == 0:
+        return f"   (none — {result['skipped_reason']})"
+    return (
+        f"   Injected {result['injected']} memor"
+        f"{'y' if result['injected'] == 1 else 'ies'}: "
+        f"{', '.join(result['memory_ids'])}"
+    )
+
+
+def render_feedback_summary(result: Dict[str, Any]) -> str:
+    """One-line human summary of ``apply_feedback`` for orchestrator logs."""
+    if result["feedback_path"] is None:
+        return "   (no feedback file produced)"
+    msg = (
+        f"   helpful={result['helpful']}, "
+        f"irrelevant={result['irrelevant']}, "
+        f"skipped={result['skipped']}"
+    )
+    if result["errors"]:
+        msg += f"  ({len(result['errors'])} warning"
+        msg += "s)" if len(result["errors"]) != 1 else ")"
+    return msg
+
+
+def render_drafts_summary(result: Dict[str, Any]) -> str:
+    """One-line human summary of ``collect_drafts`` for orchestrator logs."""
+    if result["scanned"] == 0:
+        return "   (no drafts written — expected for most runs)"
+    base = (
+        f"   {result['valid']} valid / {result['scanned']} scanned "
+        f"(approach {result['approach']})"
+    )
+    if result["invalid"]:
+        base += f"  — {len(result['invalid'])} invalid (see logs)"
+    return base

--- a/src/core/memory_store.py
+++ b/src/core/memory_store.py
@@ -1,0 +1,585 @@
+"""
+Storage layer for NeuriCo's experience memory.
+
+A memory is a small markdown file with YAML frontmatter capturing a piece of
+research-experience knowledge that future experiments might benefit from.
+See ``docs/memory_schema.md`` for the schema contract.
+
+This module owns the on-disk layout and the read/write/list/filter primitives.
+It deliberately knows NOTHING about retrieval, extraction prompts, or any LLM
+machinery — those live higher up the stack so this module stays cheap to test
+and reuse.
+
+Storage root:
+    ~/.neurico/memories/
+        live/        promoted memories — retrieval reads these
+        drafts/      newly extracted, not yet promoted
+        archived/    demoted from live, kept for audit
+        index.json   derived cache: id → metadata for fast filter
+
+The index can always be rebuilt from the files on disk; ``MemoryStore.reindex()``
+is idempotent and safe to call after a crash.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+DEFAULT_MEMORY_ROOT = Path.home() / ".neurico" / "memories"
+
+# Subdirectory names under the memory root. Kept as module-level constants so
+# downstream code (Docker mount setup, CLI, retrieval) imports from one place.
+LIVE_DIR = "live"
+DRAFTS_DIR = "drafts"
+ARCHIVED_DIR = "archived"
+INDEX_FILE = "index.json"
+
+VALID_APPROACHES = ("runner_self", "manager_observer", "manual")
+VALID_CONFIDENCE = ("low", "medium", "high")
+
+# Frontmatter fences expected by the parser. We don't use a full YAML library
+# at write time (so memory files round-trip predictably), but we DO use one at
+# read time when available — falling back to a small inline parser when not.
+_FENCE = "---"
+
+
+# Schema model
+
+@dataclass
+class ProblemClass:
+    """
+    Abstracted preconditions and recognition signals for the memory.
+
+    All fields are deliberately abstract — concrete details belong in
+    ``Origin`` and are stripped before the memory is shown to a future agent.
+    """
+
+    what: str
+    shape: List[Dict[str, str]] = field(default_factory=list)
+    signal_to_recognize: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "what": self.what,
+            "shape": list(self.shape),
+            "signal_to_recognize": list(self.signal_to_recognize),
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "ProblemClass":
+        return cls(
+            what=str(d.get("what", "")),
+            shape=list(d.get("shape", [])),
+            signal_to_recognize=list(d.get("signal_to_recognize", [])),
+        )
+
+
+@dataclass
+class Origin:
+    """
+    Provenance of the memory.
+
+    Recorded for audit + dedup, NEVER injected into a future agent's context.
+    """
+
+    source_run: str
+    source_domain: str
+    source_idea_one_liner: str = ""
+    what_first_attempt_was: str = ""
+    what_actually_worked: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source_run": self.source_run,
+            "source_domain": self.source_domain,
+            "source_idea_one_liner": self.source_idea_one_liner,
+            "what_first_attempt_was": self.what_first_attempt_was,
+            "what_actually_worked": self.what_actually_worked,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "Origin":
+        return cls(
+            source_run=str(d.get("source_run", "")),
+            source_domain=str(d.get("source_domain", "")),
+            source_idea_one_liner=str(d.get("source_idea_one_liner", "")),
+            what_first_attempt_was=str(d.get("what_first_attempt_was", "")),
+            what_actually_worked=str(d.get("what_actually_worked", "")),
+        )
+
+
+@dataclass
+class Memory:
+    """
+    A single experience memory.
+
+    Constructed from a markdown file with YAML frontmatter, or programmatically
+    by an extractor / the CLI. ``Memory.to_markdown()`` round-trips the file
+    contents predictably so manual edits to live memories survive reindexing.
+    """
+
+    id: str
+    created_at: str
+    extraction_approach: str
+    problem_class: ProblemClass
+    insight: str
+    origin: Origin
+    domain_tags: List[str] = field(default_factory=list)
+    phase_tags: List[str] = field(default_factory=list)
+    confidence: str = "medium"
+    votes: Dict[str, int] = field(default_factory=lambda: {
+        "used": 0, "helpful": 0, "irrelevant": 0,
+    })
+    body: str = ""
+
+    # Schema lifecycle helpers
+
+    def validate(self) -> List[str]:
+        """
+        Return a list of validation errors. Empty list means the memory is
+        well-formed enough to write to disk. Callers decide whether to raise.
+        """
+        errs: List[str] = []
+        if not _is_well_formed_id(self.id):
+            errs.append(f"id {self.id!r} must match m_* or d_* with lower-snake slug")
+        if self.extraction_approach not in VALID_APPROACHES:
+            errs.append(
+                f"extraction_approach must be one of {VALID_APPROACHES}; "
+                f"got {self.extraction_approach!r}"
+            )
+        if self.confidence not in VALID_CONFIDENCE:
+            errs.append(
+                f"confidence must be one of {VALID_CONFIDENCE}; "
+                f"got {self.confidence!r}"
+            )
+        if not self.problem_class.what.strip():
+            errs.append("problem_class.what is required")
+        if not self.insight.strip():
+            errs.append("insight is required")
+        if not self.origin.source_run.strip():
+            errs.append("origin.source_run is required")
+        if not self.origin.source_domain.strip():
+            errs.append("origin.source_domain is required")
+        if not self.origin.what_first_attempt_was.strip():
+            errs.append(
+                "origin.what_first_attempt_was is required — if the writer "
+                "cannot describe the first (wrong) attempt, the insight isn't "
+                "memory-worthy"
+            )
+        if not self.domain_tags:
+            errs.append("domain_tags must include at least the source domain")
+        elif self.origin.source_domain not in self.domain_tags:
+            errs.append(
+                f"domain_tags must include origin.source_domain "
+                f"({self.origin.source_domain!r})"
+            )
+        return errs
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "created_at": self.created_at,
+            "extraction_approach": self.extraction_approach,
+            "problem_class": self.problem_class.to_dict(),
+            "insight": self.insight,
+            "origin": self.origin.to_dict(),
+            "domain_tags": list(self.domain_tags),
+            "phase_tags": list(self.phase_tags),
+            "confidence": self.confidence,
+            "votes": dict(self.votes),
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any], body: str = "") -> "Memory":
+        votes_default = {"used": 0, "helpful": 0, "irrelevant": 0}
+        votes_default.update(d.get("votes", {}) or {})
+        return cls(
+            id=str(d.get("id", "")),
+            created_at=str(d.get("created_at", "")),
+            extraction_approach=str(d.get("extraction_approach", "manual")),
+            problem_class=ProblemClass.from_dict(d.get("problem_class", {})),
+            insight=str(d.get("insight", "")),
+            origin=Origin.from_dict(d.get("origin", {})),
+            domain_tags=list(d.get("domain_tags", [])),
+            phase_tags=list(d.get("phase_tags", [])),
+            confidence=str(d.get("confidence", "medium")),
+            votes=votes_default,
+            body=body,
+        )
+
+    # Round-tripping with disk files
+
+    def to_markdown(self) -> str:
+        """
+        Render the memory as a Markdown file with YAML frontmatter.
+
+        We use ``json.dumps`` to encode the frontmatter rather than yaml.dump.
+        JSON is a strict subset of YAML, so any YAML parser reads it
+        unambiguously, and we avoid a runtime dependency.
+        """
+        payload = self.to_dict()
+        fm = json.dumps(payload, indent=2, ensure_ascii=False)
+        body = self.body.strip()
+        if body:
+            return f"{_FENCE}\n{fm}\n{_FENCE}\n\n{body}\n"
+        return f"{_FENCE}\n{fm}\n{_FENCE}\n"
+
+    @classmethod
+    def from_markdown(cls, text: str) -> "Memory":
+        """
+        Parse a markdown file with YAML or JSON frontmatter into a Memory.
+
+        Accepts either of:
+          - JSON-as-YAML frontmatter (what we write)
+          - True YAML frontmatter (what humans write by hand)
+        """
+        fm_text, body = _split_frontmatter(text)
+        data = _parse_frontmatter(fm_text)
+        return cls.from_dict(data, body=body.strip())
+
+    def public_view(self) -> Dict[str, Any]:
+        """
+        Return the memory as it should appear when injected into a future
+        agent's context: provenance redacted, votes elided.
+
+        Retrieval calls this when assembling ``MEMORIES_FROM_PAST_RUNS.md``.
+        """
+        return {
+            "id": self.id,
+            "problem_class": self.problem_class.to_dict(),
+            "insight": self.insight,
+            "domain_tags": list(self.domain_tags),
+            "phase_tags": list(self.phase_tags),
+            "confidence": self.confidence,
+            "body": self.body,
+        }
+
+
+# Frontmatter helpers
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    """
+    Pull the YAML/JSON frontmatter out of a markdown file.
+
+    Returns ``(frontmatter_text, body_text)``. Raises ``ValueError`` if the
+    file does not start with a fence.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != _FENCE:
+        raise ValueError("memory file must start with a '---' fence")
+    closing = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == _FENCE:
+            closing = i
+            break
+    if closing is None:
+        raise ValueError("memory file missing closing '---' fence")
+    fm = "\n".join(lines[1:closing])
+    body = "\n".join(lines[closing + 1:])
+    return fm, body
+
+
+def _parse_frontmatter(fm_text: str) -> Dict[str, Any]:
+    """
+    Parse the frontmatter into a dict.
+
+    Prefers PyYAML when available — handles every well-formed YAML the user
+    might hand-write. Falls back to ``json.loads`` for our own machine-written
+    JSON files when PyYAML isn't installed.
+    """
+    try:
+        import yaml  # type: ignore
+        data = yaml.safe_load(fm_text)
+        if not isinstance(data, dict):
+            raise ValueError("frontmatter must be a mapping")
+        return data
+    except ImportError:
+        return json.loads(fm_text)
+
+
+# ID generation
+
+def _is_well_formed_id(s: str) -> bool:
+    """Allow either live ids ``m_<slug>`` or draft ids ``d_<slug>``."""
+    return bool(re.fullmatch(r"[md]_[a-z0-9][a-z0-9_]{0,127}", s))
+
+
+def _slugify(text: str, max_len: int = 60) -> str:
+    """Reduce arbitrary text to a lower-snake slug suitable for filenames."""
+    text = re.sub(r"[^a-z0-9]+", "_", text.lower())
+    text = re.sub(r"_+", "_", text).strip("_")
+    return text[:max_len] or "memory"
+
+
+def quarter_tag(when: Optional[datetime] = None) -> str:
+    """Return a ``YYYYqN`` quarter tag for memory ids (e.g. ``2026q2``)."""
+    when = when or datetime.now(timezone.utc)
+    return f"{when.year}q{(when.month - 1) // 3 + 1}"
+
+
+def now_iso() -> str:
+    """Current UTC time as a second-precision ISO-8601 string."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def mint_live_id(insight: str, when: Optional[datetime] = None) -> str:
+    """Generate a fresh ``m_<quarter>_<slug>`` id from an insight string."""
+    return f"m_{quarter_tag(when)}_{_slugify(insight)}"
+
+
+def mint_draft_id(insight: str) -> str:
+    """Generate a fresh ``d_<slug>`` id for a draft (no quarter prefix)."""
+    return f"d_{_slugify(insight)}"
+
+
+# The store
+
+class MemoryStore:
+    """
+    On-disk store for live, draft, and archived memories.
+
+    Construction does NOT touch the filesystem aside from resolving the root
+    path. Call ``ensure_layout()`` to create the directory tree if it doesn't
+    exist yet (the CLI does this once at startup; agents shouldn't need to).
+    """
+
+    def __init__(self, root: Optional[Path] = None) -> None:
+        self.root = Path(root) if root else DEFAULT_MEMORY_ROOT
+
+    # Filesystem layout
+
+    def ensure_layout(self) -> None:
+        """Create live/, drafts/, archived/, and an empty index if missing."""
+        for sub in (LIVE_DIR, DRAFTS_DIR, ARCHIVED_DIR):
+            (self.root / sub).mkdir(parents=True, exist_ok=True)
+        idx = self.root / INDEX_FILE
+        if not idx.exists():
+            idx.write_text(json.dumps({"memories": []}, indent=2) + "\n",
+                           encoding="utf-8")
+
+    @property
+    def live_dir(self) -> Path:
+        return self.root / LIVE_DIR
+
+    @property
+    def drafts_dir(self) -> Path:
+        return self.root / DRAFTS_DIR
+
+    @property
+    def archived_dir(self) -> Path:
+        return self.root / ARCHIVED_DIR
+
+    @property
+    def index_path(self) -> Path:
+        return self.root / INDEX_FILE
+
+    # Single-memory CRUD
+
+    def write(self, memory: Memory, kind: str = "live",
+              run_id: Optional[str] = None,
+              approach: Optional[str] = None) -> Path:
+        """
+        Persist ``memory`` to disk.
+
+        ``kind`` is one of ``"live"``, ``"draft"``, or ``"archived"``. For
+        drafts, ``run_id`` is the workspace slug the draft came from, and
+        ``approach`` selects the ``A``/``B`` subdir. Raises ``ValueError`` if
+        the memory fails validation.
+        """
+        errs = memory.validate()
+        if errs:
+            raise ValueError(
+                f"memory {memory.id} is not well-formed:\n  - "
+                + "\n  - ".join(errs)
+            )
+
+        path = self._path_for(memory.id, kind, run_id, approach)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(memory.to_markdown(), encoding="utf-8")
+        if kind == "live":
+            self.reindex()
+        return path
+
+    def read(self, path: Path) -> Memory:
+        """Load a memory from a specific file path."""
+        return Memory.from_markdown(Path(path).read_text(encoding="utf-8"))
+
+    def get_live(self, memory_id: str) -> Optional[Memory]:
+        """Look up a live memory by id, or None if not present."""
+        for p in self.live_dir.glob(f"{memory_id}*.md"):
+            return self.read(p)
+        return None
+
+    # Bulk listing + filtering
+
+    def list_live(self) -> List[Memory]:
+        """Return every promoted memory."""
+        return [self.read(p) for p in sorted(self.live_dir.glob("m_*.md"))]
+
+    def list_drafts(self, run_id: Optional[str] = None,
+                    approach: Optional[str] = None) -> List[Memory]:
+        """
+        Return drafts, optionally scoped to a single run and/or approach.
+        """
+        root = self.drafts_dir
+        if run_id:
+            root = root / f"run_{run_id}"
+        if approach:
+            if not run_id:
+                raise ValueError("approach filter requires a run_id")
+            root = root / approach
+        if not root.exists():
+            return []
+        return [self.read(p) for p in sorted(root.rglob("d_*.md"))]
+
+    def filter_live(self, domain: Optional[str] = None,
+                    tags_any: Optional[Iterable[str]] = None) -> List[Memory]:
+        """
+        Return promoted memories whose ``domain_tags`` match the filter.
+
+        ``domain`` matches a memory whose ``origin.source_domain`` equals it.
+        ``tags_any`` matches memories that share at least one tag.
+        """
+        out = []
+        tags_any_set = set(tags_any or [])
+        for m in self.list_live():
+            if domain and m.origin.source_domain != domain:
+                continue
+            if tags_any_set and not (tags_any_set & set(m.domain_tags)):
+                continue
+            out.append(m)
+        return out
+
+    # State transitions
+
+    def promote(self, draft: Memory, run_id: str,
+                approach: str = "manual") -> Path:
+        """
+        Promote a draft into ``live/`` with a freshly minted ``m_*`` id.
+
+        The draft file on disk is deleted to avoid double-counting. The
+        promoted memory inherits the draft's content but gets a new id +
+        ``extraction_approach`` (defaults to ``manual`` for hand-promotion).
+        """
+        new_id = mint_live_id(draft.insight)
+        promoted = Memory(
+            id=new_id,
+            created_at=now_iso(),
+            extraction_approach=approach,
+            problem_class=draft.problem_class,
+            insight=draft.insight,
+            origin=draft.origin,
+            domain_tags=draft.domain_tags,
+            phase_tags=draft.phase_tags,
+            confidence=draft.confidence,
+            votes={"used": 0, "helpful": 0, "irrelevant": 0},
+            body=draft.body,
+        )
+        path = self.write(promoted, kind="live")
+
+        # Remove the source draft file if we can locate it
+        for p in (self.drafts_dir / f"run_{run_id}").rglob(f"{draft.id}*.md"):
+            try:
+                p.unlink()
+            except OSError:
+                pass
+
+        return path
+
+    def archive(self, memory_id: str) -> Optional[Path]:
+        """Move a live memory into ``archived/``. Returns the new path."""
+        match = next(self.live_dir.glob(f"{memory_id}*.md"), None)
+        if match is None:
+            return None
+        target = self.archived_dir / match.name
+        self.archived_dir.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(match), str(target))
+        self.reindex()
+        return target
+
+    # Vote tracking
+
+    def bump_vote(self, memory_id: str, kind: str) -> bool:
+        """
+        Increment one of ``used`` / ``helpful`` / ``irrelevant`` on a live
+        memory. Returns True if the memory was found.
+        """
+        if kind not in ("used", "helpful", "irrelevant"):
+            raise ValueError(f"unknown vote kind: {kind!r}")
+        match = next(self.live_dir.glob(f"{memory_id}*.md"), None)
+        if match is None:
+            return False
+        m = self.read(match)
+        m.votes[kind] = int(m.votes.get(kind, 0)) + 1
+        match.write_text(m.to_markdown(), encoding="utf-8")
+        self.reindex()
+        return True
+
+    # Index management
+
+    def reindex(self) -> Dict[str, Any]:
+        """
+        Rebuild ``index.json`` from the files in ``live/``.
+
+        Returns the new index dict. Always safe to call.
+        """
+        memories = []
+        for p in sorted(self.live_dir.glob("m_*.md")):
+            try:
+                m = self.read(p)
+            except (ValueError, json.JSONDecodeError, OSError):
+                continue
+            memories.append({
+                "id": m.id,
+                "path": str(p.relative_to(self.root)),
+                "created_at": m.created_at,
+                "extraction_approach": m.extraction_approach,
+                "domain": m.origin.source_domain,
+                "domain_tags": m.domain_tags,
+                "phase_tags": m.phase_tags,
+                "confidence": m.confidence,
+                "votes": m.votes,
+                "what": m.problem_class.what,
+            })
+        index = {
+            "memories": memories,
+            "rebuilt_at": now_iso(),
+            "count": len(memories),
+        }
+        self.index_path.write_text(
+            json.dumps(index, indent=2) + "\n", encoding="utf-8",
+        )
+        return index
+
+    def load_index(self) -> Dict[str, Any]:
+        """Read the index from disk, rebuilding it if absent."""
+        if not self.index_path.exists():
+            return self.reindex()
+        try:
+            return json.loads(self.index_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return self.reindex()
+
+    # Internal: path resolution
+
+    def _path_for(self, memory_id: str, kind: str,
+                  run_id: Optional[str], approach: Optional[str]) -> Path:
+        if kind == "live":
+            return self.live_dir / f"{memory_id}.md"
+        if kind == "archived":
+            return self.archived_dir / f"{memory_id}.md"
+        if kind == "draft":
+            if not run_id:
+                raise ValueError("draft kind requires run_id")
+            if not approach:
+                raise ValueError("draft kind requires approach")
+            return self.drafts_dir / f"run_{run_id}" / approach / f"{memory_id}.md"
+        raise ValueError(f"unknown kind {kind!r}")

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -31,6 +31,15 @@ from agents.resource_finder import run_resource_finder
 from agents.rule_maker import run_rule_maker
 from agents.rule_maker_bootstrap import run_bootstrap_rule_maker
 from agents.manifest_trimmer import make_trimmer_callable
+from core.memory_retrieval import (
+    apply_feedback as _apply_memory_feedback,
+    collect_drafts as _collect_memory_drafts,
+    render_drafts_summary,
+    render_feedback_summary,
+    render_retrieval_summary,
+    retrieve_for_idea as _retrieve_memories,
+)
+from core.memory_store import MemoryStore
 from core.scorer import run_scorer
 from core.scoring_seal import sealed_dir_for, seal_scoring_files, unseal_scoring_files
 from core.workspace_manifest import build_manifest, curate_manifest
@@ -292,6 +301,14 @@ class ResearchPipelineOrchestrator:
                     print("⚠️  Rule maker stage failed -- aborting.")
                     return results
 
+            # STAGE 2.75: Memory Retrieval (always; cheap on empty store)
+            # Filter live memories by idea domain, render them into the
+            # workspace as MEMORIES_FROM_PAST_RUNS.md. The runner reads this
+            # before planning and writes acknowledgments to MEMORY_FEEDBACK.md.
+            # Failures here MUST NOT abort the pipeline — a memory bug is
+            # less important than the experiment.
+            results["stages"]["memory_retrieval"] = self._retrieve_past_memories(idea)
+
             # STAGE 3: Experiment Runner
             # In scoring mode, seal eval.py / targets.json / rule_maker_log.md
             # out of the workspace for the duration of the runner stage. Always
@@ -310,6 +327,21 @@ class ResearchPipelineOrchestrator:
             finally:
                 if scoring_enabled:
                     self._unseal_runner_inputs(sealed_dir)
+
+            # STAGE 3.5a: Memory Drafts (Approach A — runner self-reflection)
+            # The runner's PHASE 5.5 may have written zero or more draft
+            # memories under ~/.neurico/memories/drafts/run_<EXP_ID>/A/.
+            # Validate them against the schema; record counts and errors.
+            # Drafts never auto-promote — that's a manual step via the
+            # `python -m cli.memory promote` command.
+            results["stages"]["memory_drafts"] = self._collect_runner_drafts()
+
+            # STAGE 3.5b: Memory Feedback
+            # Parse MEMORY_FEEDBACK.md (if the runner wrote one) and bump
+            # helpful/irrelevant vote counters on the corresponding live
+            # memories. Same fail-safe contract as retrieval — never raises
+            # past this method.
+            results["stages"]["memory_feedback"] = self._apply_memory_feedback()
 
             # STAGE 4 (scoring mode only): Scorer
             # Executes scoring/eval.py and captures results.json.
@@ -425,6 +457,84 @@ class ResearchPipelineOrchestrator:
             print("🛑 Pipeline stopped by user.")
 
         return result
+
+    def _retrieve_past_memories(self, idea: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Inject relevant past-experience memories into the workspace.
+
+        Reads live memories from ``~/.neurico/memories/``, filters by the
+        idea's domain, writes ``MEMORIES_FROM_PAST_RUNS.md`` into the work
+        directory, and bumps each surfaced memory's ``used`` counter so the
+        post-run feedback step can compute hit-rate. Returns a result dict
+        suitable for ``results["stages"]["memory_retrieval"]``.
+
+        Any failure here is logged and swallowed — a memory bug must never
+        abort an experiment run.
+        """
+        print()
+        print("─" * 80)
+        print("STAGE 2.75: MEMORY RETRIEVAL")
+        print("─" * 80)
+        try:
+            store = MemoryStore()
+            store.ensure_layout()
+            result = _retrieve_memories(idea, store, self.work_dir)
+            print(render_retrieval_summary(result))
+            result["success"] = True
+            return result
+        except Exception as exc:
+            print(f"⚠️  Memory retrieval failed (non-fatal): {exc}")
+            return {"success": False, "injected": 0, "error": str(exc)}
+
+    def _collect_runner_drafts(self) -> Dict[str, Any]:
+        """
+        Walk the Approach A drafts directory and report what the runner
+        wrote during PHASE 5.5 (Reflection).
+
+        Drafts are validated against the schema but never auto-promoted —
+        promotion is a manual step via ``python -m cli.memory promote``
+        until Phase 5 introduces an auto-promotion policy. Validation errors
+        are surfaced for inspection but never block the pipeline.
+        """
+        print()
+        print("─" * 80)
+        print("STAGE 3.5a: MEMORY DRAFTS (approach A — runner self-reflection)")
+        print("─" * 80)
+        try:
+            store = MemoryStore()
+            result = _collect_memory_drafts(self.work_dir, store, approach="A")
+            print(render_drafts_summary(result))
+            for entry in result["invalid"]:
+                print(f"   ⚠️  invalid draft: {entry['path']}")
+                for err in entry["errors"]:
+                    print(f"      - {err}")
+            result["success"] = True
+            return result
+        except Exception as exc:
+            print(f"⚠️  Memory draft collection failed (non-fatal): {exc}")
+            return {"success": False, "scanned": 0, "valid": 0,
+                    "invalid": [], "error": str(exc)}
+
+    def _apply_memory_feedback(self) -> Dict[str, Any]:
+        """
+        Read the runner's ``MEMORY_FEEDBACK.md`` (if any) and bump vote
+        counters on the corresponding live memories. Mirror error-handling
+        contract of ``_retrieve_past_memories``: never raises past this
+        method.
+        """
+        print()
+        print("─" * 80)
+        print("STAGE 3.5: MEMORY FEEDBACK")
+        print("─" * 80)
+        try:
+            store = MemoryStore()
+            result = _apply_memory_feedback(self.work_dir, store)
+            print(render_feedback_summary(result))
+            result["success"] = True
+            return result
+        except Exception as exc:
+            print(f"⚠️  Memory feedback failed (non-fatal): {exc}")
+            return {"success": False, "error": str(exc)}
 
     def _run_experiment_runner(
         self,

--- a/templates/agents/session_instructions.txt
+++ b/templates/agents/session_instructions.txt
@@ -205,6 +205,24 @@ BEFORE YOU START: Review Pre-Gathered Resources (5-10 min)
   ✓ Check datasets/ directory to see what data is ready
   ✓ Explore code/ directory for baseline implementations
 
+  ✓ IF MEMORIES_FROM_PAST_RUNS.md EXISTS in the workspace, READ IT NOW.
+    These are insights surfaced by previous runs on similar problems.
+    Most will not apply. Treat each as a HYPOTHESIS to evaluate against
+    THIS idea, not a directive to follow.
+
+    For EACH memory in MEMORIES_FROM_PAST_RUNS.md, write one entry into
+    MEMORY_FEEDBACK.md before you move to Phase 1:
+
+        - memory_id: <id from the memory>
+          decision: applied              # or: not_applicable
+          reason: <one specific sentence — why it does or doesn't fit>
+
+    "Didn't seem relevant" is NOT an acceptable reason. Say specifically
+    what differs between the memory's problem class and this idea.
+    If a memory clearly applies, prefer to apply it and adapt your plan
+    accordingly. The pipeline tracks how often memories help future runs;
+    your honest feedback is the signal that improves what gets surfaced.
+
   → WHEN COMPLETE: Immediately proceed to Phase 1 (Planning)
 
 Phase 1: Motivation & Planning (20-40 min)
@@ -258,6 +276,135 @@ Phase 5: Analysis (30-45 min)
   ✓ Create comprehensive visualizations
   ✓ Document findings incrementally
 
+  → WHEN COMPLETE: Immediately proceed to Phase 5.5 (Reflection)
+
+Phase 5.5: Reflection & Memory Extraction (5-10 min, OPTIONAL — WRITING ZERO IS THE NORMAL OUTCOME)
+
+  THE POINT OF THIS PHASE. Before you write the final report, while the
+  trajectory of this run is still fresh, look back honestly and ask: did
+  anything surface that would meaningfully help a FUTURE run on a SIMILAR
+  problem — something I would NOT have thought of going in, and that a
+  textbook in this domain does NOT already cover? If yes, write it down
+  as a memory draft. If not — and this is the usual answer — write nothing
+  and proceed to Phase 6.
+
+  THE FOUR FILTERS. A candidate insight is worth writing as a memory ONLY IF
+  all four are true:
+
+    1. CLASS, NOT INSTANCE. The insight describes a CLASS of problems, not
+       just this experiment. You can state the problem class without
+       mentioning the specific dataset / model / library you used.
+
+    2. NOT FIRST-THOUGHT. You did NOT have this insight when you read the
+       idea. It emerged from a mid-run correction — a wrong first attempt,
+       a misleading result, a metric that turned out to mean something
+       different than you assumed.
+
+    3. NOT TEXTBOOK. A standard textbook in this domain would NOT make this
+       point. "Use cross-validation", "watch for overfitting", "tune your
+       learning rate" — these are textbook and do NOT belong here.
+
+    4. NOT DUPLICATE. If your insight is essentially the same as one of the
+       memories you applied from MEMORIES_FROM_PAST_RUNS.md, do NOT write a
+       new draft — that pattern is already captured.
+
+  If you cannot honestly say YES to all four, write nothing.
+
+  PRESSURE TO PRODUCE IS THE FAILURE MODE. You are not being graded on the
+  count of memories you write. You are being graded on whether the memories
+  you DO write actually help future runs. Empty draft directories are the
+  most common outcome and the safest answer.
+
+  FILE FORMAT. If — and only if — a candidate passes all four filters,
+  write a draft to:
+
+      ~/.neurico/memories/drafts/run_$(basename {{ work_dir }})/A/d_<short_slug>.md
+
+  Use this exact markdown structure (JSON in the frontmatter — parser is
+  strict about commas, braces, and matching quotes; copy the example
+  carefully):
+
+      ---
+      {
+        "id": "d_<lower_snake_slug_of_the_insight>",
+        "created_at": "<ISO 8601 UTC timestamp>",
+        "extraction_approach": "runner_self",
+        "problem_class": {
+          "what": "<one sentence: the CLASS of problems this applies to>",
+          "shape": [
+            {"<aspect>": "<abstract precondition>"},
+            {"<aspect>": "<abstract precondition>"}
+          ],
+          "signal_to_recognize": [
+            "<concrete thing a future agent can check>",
+            "<concrete thing a future agent can check>"
+          ]
+        },
+        "insight": "<one or two sentences: the abstract takeaway and the fix>",
+        "origin": {
+          "source_run": "<basename of your workspace>",
+          "source_domain": "<your domain>",
+          "source_idea_one_liner": "<this run's idea title>",
+          "what_first_attempt_was": "<a specific action you tried first that failed>",
+          "what_actually_worked": "<the correction that fixed it>"
+        },
+        "domain_tags": ["<domain>", "<sub-area>"],
+        "phase_tags": ["<phase like eval-design or data-prep>"],
+        "confidence": "low" | "medium" | "high",
+        "votes": {"used": 0, "helpful": 0, "irrelevant": 0}
+      }
+      ---
+
+      <optional 1-paragraph body — only if it adds evidence the insight doesn't>
+
+  Hard requirements enforced by the loader (a malformed draft is silently
+  dropped — verify yours):
+    - id MUST start with `d_` and use lower_snake.
+    - extraction_approach MUST be the string `runner_self`.
+    - what_first_attempt_was MUST be a specific failed action — not "I
+      struggled with X" or "it was hard". If you can't name an action,
+      the insight isn't memory-worthy: write NOTHING.
+    - domain_tags MUST include the value you put in origin.source_domain.
+
+  AN EXAMPLE THAT PASSES ALL FILTERS.
+
+      Suppose during eval you noticed that your "97% accurate" classifier
+      was actually below the majority-class baseline because the test set
+      was 88% one class. You tried hyperparameter tuning first chasing
+      accuracy; it didn't change the underlying problem. You corrected by
+      reporting balanced accuracy + majority-class baseline. The draft:
+
+      ---
+      {
+        "id": "d_majority_class_baseline_first",
+        "created_at": "2026-06-20T22:00:00+00:00",
+        "extraction_approach": "runner_self",
+        "problem_class": {
+          "what": "classification eval over imbalanced labels",
+          "shape": [
+            {"data": "labels with non-uniform distribution"},
+            {"metric": "unweighted aggregate"}
+          ],
+          "signal_to_recognize": [
+            "majority-class fraction > 60%",
+            "no majority-class baseline reported alongside accuracy"
+          ]
+        },
+        "insight": "Unweighted aggregates over imbalanced labels reward majority-class bias. Always report a majority baseline as the floor and prefer balanced-accuracy or macro-F1 as the headline.",
+        "origin": {
+          "source_run": "<your workspace basename>",
+          "source_domain": "machine_learning",
+          "source_idea_one_liner": "<the idea title from this run>",
+          "what_first_attempt_was": "Reported plain accuracy as the headline; tuned hyperparameters for two iterations chasing accuracy delta.",
+          "what_actually_worked": "Switched to balanced accuracy + per-class F1; majority baseline exposed that the 'good' model was barely above trivial."
+        },
+        "domain_tags": ["machine_learning", "classification"],
+        "phase_tags": ["eval-design"],
+        "confidence": "high",
+        "votes": {"used": 0, "helpful": 0, "irrelevant": 0}
+      }
+      ---
+
   → WHEN COMPLETE: Immediately proceed to Phase 6 (Documentation)
 
 Phase 6: Final Documentation (20-30 min) - MANDATORY BEFORE ENDING SESSION
@@ -270,7 +417,8 @@ Phase 6: Final Documentation (20-30 min) - MANDATORY BEFORE ENDING SESSION
   → WHEN COMPLETE: Session is finished
 
 CRITICAL REMINDERS:
-- This is a SINGLE CONTINUOUS SESSION covering all 6 phases
+- This is a SINGLE CONTINUOUS SESSION covering all phases (1-6, plus the
+  optional Phase 5.5 reflection step between Analysis and Documentation)
 - Resources have been PRE-GATHERED for you - use them!
 - Never stop between phases waiting for user input
 - If you encounter issues, document them and continue


### PR DESCRIPTION
**(exploratory — not for merge.)** This PR is opened for experiment and discussion purposes only. The feature is a primitive first-cut of an "experience-memory" system that lets NeuriCo accumulate insights across runs, and I want to share the surface area / get feedback before any of it gets near `main`. Please do **not** merge.

## What this adds

A local, file-backed memory system at `~/.neurico/memories/{live,drafts,archived}/` that:

1. **Reads** at STAGE 2.75 — `pipeline_orchestrator` calls `memory_retrieval.retrieve_for_idea(...)`, filters live memories by `domain`, and writes `MEMORIES_FROM_PAST_RUNS.md` into the workspace with the `origin` block redacted. A sidecar `~/.neurico/memories_injected.json` records which IDs were exposed so feedback can't be forged for un-injected memories.
2. **Asks the agent to react** — `templates/agents/session_instructions.txt` PHASE 0 instructs the experiment runner to emit `MEMORY_FEEDBACK.md` (`decision: applied | not_applicable`, one-sentence `reason`).
3. **Asks the agent to extract** — new "Phase 5.5: Reflection & Memory Extraction" with four self-gating filters (CLASS NOT INSTANCE / NOT FIRST-THOUGHT / NOT TEXTBOOK / NOT DUPLICATE). Output goes to `drafts/run_<EXP_ID>/runner_self/`.
4. **Collects + applies feedback** at STAGE 3.5a/3.5b — `collect_drafts(...)` validates drafts and `apply_feedback(...)` bumps `helpful`/`irrelevant` vote counts (sidecar-guarded).

Two extraction approaches are planned; this PR only ships **Approach A (runner self-reflection)**. Approach B (manager-observer over `ResearchState`) is sketched in `docs/memory_schema.md` and deferred.

## Schema highlights (see `docs/memory_schema.md`)

- `problem_class` — `what` / `shape` / `signal_to_recognize` (the part the workspace agent sees)
- `insight` — the abstract lesson (the actionable part)
- `origin` — `source_run` / `source_domain` / `source_idea_one_liner` / `what_first_attempt_was` / `what_actually_worked` (REDACTED at injection time)
- `domain_tags`, `phase_tags`, `confidence`, `votes`

## Files

| File | Purpose |
|---|---|
| `src/core/memory_store.py` | Dataclasses + `MemoryStore` (read/write/promote/archive/reindex/bump_vote) |
| `src/core/memory_retrieval.py` | `retrieve_for_idea` / `apply_feedback` / `collect_drafts` + sidecar guard |
| `src/core/pipeline_orchestrator.py` | Inline hooks at STAGE 2.75 / 3.5a / 3.5b — sentinel-gated, exceptions swallowed |
| `src/cli/memory.py` | `neurico memory {list,show,add,promote,archive,reindex,path}` |
| `templates/agents/session_instructions.txt` | PHASE 0 ack contract + Phase 5.5 extraction prompt |
| `docker/{run.sh,Dockerfile}` | RW bind mount of `~/.neurico/memories/` + scaffolding |
| `docs/memory_schema.md` | Schema reference + abstraction rubric |

## What's been live-tested

Four end-to-end runs on a Mac via Docker, using a src bind-mount (PR #104 pattern) so image rebuild wasn't required:

- **Test 0** — seeded one live memory, ran an idea in the same problem class → retrieval injected it, agent emitted `MEMORY_FEEDBACK.md` correctly, sidecar guard worked. Read+apply+feedback path verified.
- **Test 1, 2** — strict prompt: agent produced **zero drafts**. High precision, low recall.
- **Test 3** — relaxed prompt: agent produced one high-quality draft (`d_cv_seed_flip_from_gap_to_std_ratio`) with the correct CLASS-NOT-INSTANCE abstraction level.

The prompt was reverted to the strict version before commit. **Prompt calibration is the most obvious next dial** — somewhere between the two versions.
