### PR TITLE
Added `--provider agy` (Google Antigravity CLI) support to neurico ac…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,6 +69,11 @@ RUN uv python install 3.12
 RUN curl -fsSL https://claude.ai/install.sh | bash \
     && cp /root/.local/bin/claude /usr/local/bin/claude
 
+# Install Google Antigravity (agy) via native installer (installs to ~/.local/bin).
+# agy reuses Gemini's OAuth credentials (~/.gemini/oauth_creds.json), so no extra cred dir.
+RUN curl -fsSL https://antigravity.google/cli/install.sh | bash \
+    && cp /root/.local/bin/agy /usr/local/bin/agy
+
 # Install Codex and Gemini via npm (no native Linux installer available)
 RUN npm install -g @openai/codex \
     && npm install -g @google/gemini-cli

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -90,6 +90,7 @@ validate_env() {
     # OPENAI_API_KEY: Required for IdeaHub integration and paper-finder
     # GITHUB_TOKEN: Required for GitHub repo creation
     # Note: Claude/Codex/Gemini CLIs use OAuth credentials from ~/.claude, ~/.codex, ~/.gemini
+    # (Antigravity/agy reuses ~/.gemini/oauth_creds.json)
 
     if [ -n "$OPENAI_API_KEY" ]; then
         echo -e "  ${GREEN}[OK]${NC} OPENAI_API_KEY configured (IdeaHub, paper-finder)"
@@ -222,7 +223,7 @@ show_help() {
     echo -e "    ${GREEN}python /app/src/core/runner.py <idea_id> [options]${NC}"
     echo ""
     echo "  Options for runner.py:"
-    echo "    --provider {claude|codex|gemini}  AI provider (default: claude)"
+    echo "    --provider {claude|codex|gemini|agy}  AI provider (default: claude)"
     echo "    --full-permissions                Skip permission prompts"
     echo "    --no-github                       Run locally without GitHub"
     echo "    --timeout SECONDS                 Execution timeout (default: 3600)"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -261,9 +261,12 @@ get_cli_credential_mounts() {
         found_any=true
     fi
 
+    # Note: Antigravity (agy) shares Gemini's credential dir (~/.gemini/oauth_creds.json),
+    # so it is already covered by the ~/.gemini mount above.
+
     if [ "$found_any" = false ]; then
         echo -e "  ${YELLOW}[WARN]${NC} No CLI credentials found." >&2
-        echo -e "         Run 'claude', 'codex', or 'gemini' on host to login first." >&2
+        echo -e "         Run 'claude', 'codex', 'gemini', or 'agy' on host to login first." >&2
     fi
 
     echo ""  >&2
@@ -649,7 +652,7 @@ cmd_submit() {
 # -----------------------------------------------------------------------------
 cmd_run() {
     if [ -z "$1" ]; then
-        echo -e "${RED}Usage: $0 run <idea_id> [--provider claude|codex|gemini] [options]${NC}"
+        echo -e "${RED}Usage: $0 run <idea_id> [--provider claude|codex|gemini|agy] [options]${NC}"
         exit 1
     fi
 
@@ -759,6 +762,7 @@ cmd_login() {
     echo "  claude   # Login to Claude Code"
     echo "  codex    # Login to Codex"
     echo "  gemini   # Login to Gemini CLI"
+    echo "  agy      # Login to Antigravity CLI"
     echo ""
     echo "After logging in, exit the shell. Your credentials will be saved."
     echo ""
@@ -1319,7 +1323,7 @@ _setup_full() {
     echo -e "    ${DIM}You can set up multiple providers now, or add more later with: ./neurico login${NC}"
     echo ""
     # Detect existing credentials
-    local claude_status="" codex_status="" gemini_status=""
+    local claude_status="" codex_status="" gemini_status="" agy_status=""
     if [ -d "$HOME/.claude" ] && [ "$(ls -A "$HOME/.claude" 2>/dev/null)" ]; then
         claude_status=" ${GREEN}[already configured]${NC}"
     fi
@@ -1329,12 +1333,17 @@ _setup_full() {
     if [ -d "$HOME/.gemini" ] && [ "$(ls -A "$HOME/.gemini" 2>/dev/null)" ]; then
         gemini_status=" ${GREEN}[already configured]${NC}"
     fi
+    # agy shares Gemini's credential dir; check the specific OAuth file it writes
+    if [ -s "$HOME/.gemini/oauth_creds.json" ]; then
+        agy_status=" ${GREEN}[already configured]${NC}"
+    fi
 
     echo -e "    ${BOLD}Which providers do you want to log in to?${NC}"
     echo -e "      [1] Claude (recommended)${claude_status}"
     echo -e "      [2] Codex${codex_status}"
     echo -e "      [3] Gemini${gemini_status}"
-    echo "      [4] Skip for now"
+    echo -e "      [4] Antigravity (agy)${agy_status}"
+    echo "      [5] Skip for now"
     echo -e "    ${DIM}Enter one or more numbers, e.g. 1 2 or 1,2,3${NC}"
     echo -ne "    > "
     local login_input=""
@@ -1361,6 +1370,10 @@ _setup_full() {
                 setup_login_provider "Gemini" "gemini" "$HOME/.gemini" "/tmp/.gemini"
                 ;;
             4)
+                [ -z "$provider_choice" ] && provider_choice="4"
+                setup_login_provider "Antigravity" "agy" "$HOME/.gemini" "/tmp/.gemini"
+                ;;
+            5)
                 echo -e "    ${DIM}[SKIP]${NC} You can login later with: ./neurico login"
                 ;;
         esac
@@ -1386,6 +1399,7 @@ _setup_full() {
     case "$provider_choice" in
         2) provider_flag="codex" ;;
         3) provider_flag="gemini" ;;
+        4) provider_flag="agy" ;;
     esac
 
     # Build the run command based on user's choice
@@ -1421,7 +1435,7 @@ _setup_full() {
     echo -e "  ${BOLD}Config files:${NC}"
     echo -e "  ${DIM}  API keys & credentials .... .env${NC}"
     echo -e "  ${DIM}  Workspace config .......... config/workspace.yaml${NC}"
-    echo -e "  ${DIM}  CLI credentials ........... ~/.claude/  ~/.codex/  ~/.gemini/${NC}"
+    echo -e "  ${DIM}  CLI credentials ........... ~/.claude/  ~/.codex/  ~/.gemini/ (agy shares ~/.gemini)${NC}"
     echo ""
     echo -e "  ${DIM}To change configuration later, run: ./neurico config${NC}"
     echo ""
@@ -1757,7 +1771,7 @@ cmd_help() {
     echo "  config                    Configure API keys and settings"
     echo "  update                    Pull the latest Docker image from registry"
     echo "  build                     Build the container image locally"
-    echo "  login [provider]          Login to CLI tools (claude/codex/gemini)"
+    echo "  login [provider]          Login to CLI tools (claude/codex/gemini/agy)"
     echo "  shell                     Start an interactive shell"
     echo "  fetch <url> [--submit]    Fetch idea from IdeaHub"
     echo "  submit <idea.yaml>        Submit a research idea"

--- a/src/agents/comment_handler.py
+++ b/src/agents/comment_handler.py
@@ -29,7 +29,8 @@ from core.security import sanitize_text
 CLI_COMMANDS = {
     'claude': 'claude -p',
     'codex': 'codex exec',
-    'gemini': 'gemini'
+    'gemini': 'gemini',
+    'agy': 'agy -p'  # Google Antigravity CLI, print mode reads prompt from stdin
 }
 
 # CLI flags for verbose/structured transcript output
@@ -37,6 +38,7 @@ TRANSCRIPT_FLAGS = {
     'claude': '--verbose --output-format stream-json',
     'codex': '--json',
     'gemini': '--output-format stream-json'
+    # 'agy' has no streaming-JSON/transcript flag
 }
 
 
@@ -246,6 +248,8 @@ def run_comment_handler(
             cmd += " --dangerously-skip-permissions"
         elif provider == "gemini":
             cmd += " --yolo --skip-trust"
+        elif provider == "agy":
+            cmd += " --dangerously-skip-permissions"
 
     # Add transcript/JSON output flags
     transcript_flag = TRANSCRIPT_FLAGS.get(provider, '')

--- a/src/agents/paper_writer.py
+++ b/src/agents/paper_writer.py
@@ -22,7 +22,8 @@ if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
 CLI_COMMANDS = {
     'claude': 'claude -p',
     'codex': 'codex exec',
-    'gemini': 'gemini'
+    'gemini': 'gemini',
+    'agy': 'agy -p'  # Google Antigravity CLI, print mode reads prompt from stdin
 }
 
 
@@ -256,6 +257,8 @@ def run_paper_writer(
             cmd += " --dangerously-skip-permissions"
         elif provider == "gemini":
             cmd += " --yolo --skip-trust"
+        elif provider == "agy":
+            cmd += " --dangerously-skip-permissions"
 
     # Add streaming JSON output flags for detailed logging
     if provider == "claude":
@@ -337,7 +340,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Generate academic paper from experiment results")
     parser.add_argument("work_dir", type=Path, help="Workspace directory with experiment results")
-    parser.add_argument("--provider", default="claude", choices=["claude", "codex", "gemini"])
+    parser.add_argument("--provider", default="claude", choices=["claude", "codex", "gemini", "agy"])
     parser.add_argument("--style", default=default_style, help="Paper style (must match a directory in templates/paper_styles/)")
     parser.add_argument("--timeout", type=int, default=3600)
     parser.add_argument("--no-permissions", action="store_true", help="Require permission prompts")

--- a/src/agents/resource_finder.py
+++ b/src/agents/resource_finder.py
@@ -30,7 +30,8 @@ from core.security import sanitize_text
 CLI_COMMANDS = {
     'claude': 'claude -p',  # Print mode enables streaming JSON output with stdin
     'codex': 'codex exec',  # Non-interactive mode: read from stdin
-    'gemini': 'gemini'
+    'gemini': 'gemini',
+    'agy': 'agy -p'  # Google Antigravity CLI, print mode reads prompt from stdin
 }
 
 # CLI flags for verbose/structured transcript output
@@ -40,6 +41,7 @@ TRANSCRIPT_FLAGS = {
     'claude': '--verbose --output-format stream-json',  # Streaming JSON (requires -p and --verbose)
     'codex': '--json',  # Outputs newline-delimited JSON events (works with codex exec)
     'gemini': '--output-format stream-json'  # Outputs JSONL stream
+    # 'agy' has no streaming-JSON/transcript flag
 }
 
 
@@ -134,6 +136,8 @@ def run_resource_finder(
             cmd += " --dangerously-skip-permissions"
         elif provider == "gemini":
             cmd += " --yolo --skip-trust"
+        elif provider == "agy":
+            cmd += " --dangerously-skip-permissions"
 
     # Add transcript/JSON output flags for structured logging
     transcript_flag = TRANSCRIPT_FLAGS.get(provider, '')

--- a/src/cli/fetch_from_ideahub.py
+++ b/src/cli/fetch_from_ideahub.py
@@ -503,7 +503,7 @@ def main():
     )
     parser.add_argument(
         "--provider",
-        choices=["claude", "gemini", "codex"],
+        choices=["claude", "gemini", "codex", "agy"],
         default=None,
         help="AI provider for repo naming and --run execution"
     )

--- a/src/cli/submit.py
+++ b/src/cli/submit.py
@@ -66,7 +66,7 @@ def main():
     )
     parser.add_argument(
         "--provider",
-        choices=["claude", "gemini", "codex"],
+        choices=["claude", "gemini", "codex", "agy"],
         default=None,
         help="AI provider for repo naming (e.g., {slug}-{hash}-claude)"
     )

--- a/src/core/agent_runner.py
+++ b/src/core/agent_runner.py
@@ -42,7 +42,8 @@ from core.security import sanitize_text
 CLI_COMMANDS = {
     'claude': 'claude -p',
     'codex': 'codex exec',
-    'gemini': 'gemini'
+    'gemini': 'gemini',
+    'agy': 'agy -p'  # Google Antigravity CLI, print mode reads prompt from stdin
 }
 
 # CLI flags for verbose/structured transcript output
@@ -50,6 +51,7 @@ TRANSCRIPT_FLAGS = {
     'claude': '--verbose --output-format stream-json',
     'codex': '--json',
     'gemini': '--output-format stream-json'
+    # 'agy' has no streaming-JSON/transcript flag
 }
 
 
@@ -143,6 +145,8 @@ def _build_agent_command(provider: str, full_permissions: bool = True,
             cmd += " --dangerously-skip-permissions"
         elif provider == "gemini":
             cmd += " --yolo"
+        elif provider == "agy":
+            cmd += " --dangerously-skip-permissions"
 
     # Add transcript/JSON output flags
     transcript_flag = TRANSCRIPT_FLAGS.get(provider, '')
@@ -451,7 +455,7 @@ def main():
     parser.add_argument(
         "--provider",
         default="claude",
-        choices=["claude", "codex", "gemini"],
+        choices=["claude", "codex", "gemini", "agy"],
         help="AI provider (default: claude)"
     )
     parser.add_argument(

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -93,7 +93,8 @@ class PipelineState:
 CLI_COMMANDS = {
     'claude': 'claude -p',  # Print mode enables streaming JSON output with stdin
     'codex': 'codex exec',  # Non-interactive mode: read from stdin
-    'gemini': 'gemini'
+    'gemini': 'gemini',
+    'agy': 'agy -p'  # Google Antigravity CLI, print mode reads prompt from stdin
 }
 
 
@@ -377,6 +378,8 @@ class ResearchPipelineOrchestrator:
                     cmd += " --dangerously-skip-permissions"
                 elif provider == "gemini":
                     cmd += " --yolo --skip-trust"
+                elif provider == "agy":
+                    cmd += " --dangerously-skip-permissions"
 
             # Add streaming JSON output flags for detailed logging
             # All providers now output streaming JSON for consistent transcript format

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -46,7 +46,8 @@ except ImportError:
 CLI_COMMANDS = {
     'claude': 'claude -p',  # Print mode enables streaming JSON output with stdin
     'codex': 'codex exec',  # Non-interactive mode: read from stdin
-    'gemini': 'gemini'
+    'gemini': 'gemini',
+    'agy': 'agy -p'  # Google Antigravity CLI, print mode reads prompt from stdin
 }
 
 
@@ -456,6 +457,8 @@ class ResearchRunner:
                     cmd += " --dangerously-skip-permissions"
                 elif provider == "gemini":
                     cmd += " --yolo --skip-trust"
+                elif provider == "agy":
+                    cmd += " --dangerously-skip-permissions"
 
             # Add streaming JSON output flags for detailed logging
             if provider == "claude":
@@ -877,7 +880,7 @@ def main():
     parser.add_argument(
         "--provider",
         default="claude",
-        choices=["claude", "gemini", "codex"],
+        choices=["claude", "gemini", "codex", "agy"],
         help="AI provider to use (default: claude)"
     )
     parser.add_argument(

--- a/src/interactive/manager.py
+++ b/src/interactive/manager.py
@@ -466,7 +466,7 @@ def main():
     parser.add_argument(
         "--provider",
         default=None,
-        choices=["claude", "codex", "gemini"],
+        choices=["claude", "codex", "gemini", "agy"],
         help="AI provider for research agents (default: from config)"
     )
     parser.add_argument(


### PR DESCRIPTION
Added `--provider agy` (Google Antigravity CLI) support to neurico across the Python provider configs and Docker layer, with agy reusing Gemini's credentials. The dry-run confirmed command building, argument parsing, and a real agy launch all work.

**Reason for the action:**
<img width="1308" height="686" alt="47b9c5f61ee8426f300c6ab28b7c5897" src="https://github.com/user-attachments/assets/4792114f-9ad9-43ce-b3da-6200b8a96ce4" />

