### PR TITLE
feat(interactive): v3 world-model data model

### DIFF
--- a/src/interactive/research_state.py
+++ b/src/interactive/research_state.py
@@ -1,25 +1,36 @@
 """
-Shared Research State — the manager's world model.
+Shared Research State — the world model.
 
-This is the load-bearing primitive for treating the manager as a research
-*expert* (a PI / co-author) rather than a tool dispatcher. Instead of reasoning
-only over its last tool call, the manager reads and writes a structured picture
-of the whole investigation: the hypotheses in play (alive / uncertain /
-supported / dead), the experiments run and their results, the current best
-result, the decisive open question (the *crux*), open questions, decisions made
-(with rationale), and an append-only log of the manager's own per-cycle
-*assessments* (what's happening, what's uncertain, whether the human should be
-pulled in — and why).
+This is the load-bearing primitive for treating the research as a structured,
+inspectable object rather than a transcript. Originally the *manager's* private
+view (a PI / co-author that reasons over the whole investigation), it is evolving
+into **shared memory for multi-agent cooperation**: a single world model that the
+manager and the research sub-agents read for context and write their findings,
+decisions, experiments, and incidents into.
 
-Borrowed in spirit from AutoScientists' shared state `S` (champion, experiment
-log, dead-end registry, research insights), but here it serves a *human-in-the-
-loop* manager: it is what makes the manager legibly omniscient, what the
-dashboard renders as a shared whiteboard, and what an annotator (or the model
-itself) grades to find failures in the manager's judgement.
+The data model follows the log-visualizer's **v3** design:
+
+  * **findings are the spine.** A finding is the unit of insight the run produced
+    (or failed to produce) — and is itself gradeable.
+  * **everything is a decision.** Every consequential choice is a decision tagged
+    with the ``finding`` it serves (an ``F-id``, or ``"global"`` for a project-wide
+    fork tied to no single finding) and the ``layer`` of that finding's lifecycle
+    it sits in (hypothesis / method / experiment_design / interpretation).
+
+Several v3 fields are *review-time* or *interaction-time* and are intentionally
+left empty by the live write path — they are filled later by separate agents:
+
+  * ``importance`` / ``sequence`` — a review subagent (needs the full decision set;
+    unreliable to self-assign live).
+  * ``should_engage`` / ``should_engage_reason`` — a human-interactor subagent.
+  * ``author`` — set by whichever agent wrote the node (wiring is owned elsewhere);
+    the field exists now so provenance is available once multiple agents write.
 
 Persisted to ``<workspace>/.neurico/research_state.json``. The web server polls
 that file to render the live "Research" pane, so writes are atomic (temp file +
-os.replace) to avoid torn reads.
+os.replace) to avoid torn reads. NOTE: the current ``_save`` is last-writer-wins —
+safe for a single writer (the manager) but not for concurrent multi-agent writes;
+concurrency-safe merging is a separate, later change, gated on sub-agents writing.
 """
 
 from __future__ import annotations
@@ -30,7 +41,27 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-HYP_STATUSES = ("alive", "uncertain", "supported", "dead")
+SCHEMA_VERSION = 3
+
+# v3 adds `refuted` (a hypothesis the evidence argues against) as distinct from
+# `dead` (abandoned / no longer pursued).
+HYP_STATUSES = ("alive", "uncertain", "supported", "refuted", "dead")
+
+# Where in a finding's lifecycle a decision's fork sits.
+DECISION_LAYERS = ("hypothesis", "method", "experiment_design", "interpretation")
+
+FINDING_KINDS = ("result", "dead_end", "note")
+
+# How an investigation gathered evidence — the domain discriminator for an
+# experiment node (kept domain-general, not tied to a NeuriCo pipeline stage).
+EXPERIMENT_MODES = ("empirical_experiment", "computational_analysis",
+                    "formal_derivation", "literature_synthesis",
+                    "qualitative_analysis", "simulation", "observation", "other")
+
+# Reasons a good PI would pause to involve the human at a decision. Left unset by
+# the live writer; a future human-interactor subagent assigns it.
+SHOULD_ENGAGE_REASONS = ("scope_choice", "validity_risk", "cost_risk",
+                         "human_preference", "irreversible_action", "routine_no")
 
 # Level 2 "PI designs the panel": the manager may declare custom whiteboard
 # sections per run, each rendered from a small, safe block vocabulary. Keeping
@@ -42,15 +73,26 @@ BLOCK_KINDS = ("text", "bullet_list", "key_value", "table", "status_list")
 # of these renders the corresponding core section; any other id is looked up in
 # the custom `sections` map.
 BUILTIN_SECTIONS = ("crux", "current_best", "narrative", "assessment",
-                    "hypotheses", "open_questions", "decisions", "experiments")
+                    "hypotheses", "open_questions", "decisions", "experiments",
+                    "findings")
 
 
 def _now() -> str:
     return datetime.now().isoformat(timespec="seconds")
 
 
+def _set_defaults(d: Dict[str, Any], defaults: Dict[str, Any]) -> bool:
+    """setdefault every key in `defaults`; return True if any was added."""
+    changed = False
+    for k, v in defaults.items():
+        if k not in d:
+            d[k] = v
+            changed = True
+    return changed
+
+
 class ResearchState:
-    """Structured, persistent model of the research-in-progress."""
+    """Structured, persistent model of the research-in-progress (v3)."""
 
     def __init__(self, work_dir: Path):
         self.work_dir = Path(work_dir)
@@ -68,6 +110,9 @@ class ResearchState:
             # Level 2 panel fields) so callers can assume every key is present.
             for k, v in self._blank().items():
                 self.state.setdefault(k, v)
+            # Backfill v3 per-item shape on pre-v3 nodes (flat findings, decisions
+            # with no finding/layer, [str] options, etc.).
+            self._migrate()
         else:
             self.state = self._blank()
             self._save()
@@ -75,23 +120,62 @@ class ResearchState:
     @staticmethod
     def _blank() -> Dict[str, Any]:
         return {
+            "schema_version": SCHEMA_VERSION,
             "updated_at": _now(),
             "narrative": "",        # short rolling summary of where things stand
             "current_best": "",     # champion / best result so far
             "crux": "",             # the single most decision-relevant open issue
-            "hypotheses": [],       # {id, statement, status, evidence, updated_at}
-            "experiments": [],      # {id, agent, run_id, rationale, hypothesis, status, result, ts}
-            "findings": [],         # {text, kind, ts}   kind: result | dead_end | note
+            "hypotheses": [],       # {id, statement, status, evidence, links, author, updated_at}
+            "experiments": [],      # {id, name, mode, design, agent, ranBy, run_id, rationale, hypothesis, status, result, ts}
+            "findings": [],         # {id, text, insight, kind, evidence, links, author, ts}  — the SPINE
             "open_questions": [],   # [str]
-            "decisions": [],        # {id, question, options, chosen, rationale, by, ts}
-            "assessments": [],      # {ts, situation, uncertainty, crux, decision_pending, engage_user, rationale}
-            "incidents": [],        # {ts, kind, detail} — auto-logged tool errors + self-reported struggle
+            # Every decision belongs to a finding (an F-id) or to "global"; `layer`
+            # is one of DECISION_LAYERS. Review/interaction fields (importance,
+            # should_engage*) are left empty for later agents.
+            "decisions": [],        # {id, finding, layer, question, options[{text,status}], chosen, rationale, by, author, evidence, links, importance, should_engage, should_engage_reason, sequence, ts}
+            "assessments": [],      # DEPRECATED (removed with the `assess` tool in a later PR) — {ts, situation, uncertainty, crux, decision_pending, engage_user, rationale}
+            "incidents": [],        # {ts, kind, detail, author} — auto-logged tool errors + self-reported struggle
             # Level 2 — the PI-designed panel. `panel_layout` is an ordered list
             # of section ids (built-in or custom); empty → default order. Each
             # custom section in `sections` is {title, kind, data, updated_at}.
             "panel_layout": [],     # [section_id, ...]
             "sections": {},         # {id: {title, kind, data, updated_at}}
         }
+
+    # ----------------------------------------------------------- migration
+    def _migrate(self) -> None:
+        """Backfill the v3 per-item shape on nodes written by an older version so
+        every caller can assume the keys are present. Idempotent."""
+        changed = False
+        for f in self.state.get("findings", []):
+            if not str(f.get("id", "")).startswith("F"):
+                f["id"] = self._next_id("findings", "F")
+                changed = True
+            changed |= _set_defaults(
+                f, {"insight": "", "kind": "result", "evidence": [],
+                    "links": [], "author": "", "ts": _now()})
+        for d in self.state.get("decisions", []):
+            if not d.get("finding"):
+                d["finding"] = "global"
+                changed = True
+            opts = d.get("options")
+            if isinstance(opts, list) and opts and isinstance(opts[0], str):
+                d["options"] = self._normalize_options(opts, d.get("chosen", ""))
+                changed = True
+            changed |= _set_defaults(
+                d, {"layer": None, "options": [], "evidence": [], "links": [],
+                    "author": "", "importance": "", "should_engage": None,
+                    "should_engage_reason": "", "sequence": None})
+        for e in self.state.get("experiments", []):
+            changed |= _set_defaults(
+                e, {"name": "", "mode": "", "design": "",
+                    "ranBy": e.get("agent", "")})
+        for inc in self.state.get("incidents", []):
+            changed |= _set_defaults(inc, {"author": ""})
+        for h in self.state.get("hypotheses", []):
+            changed |= _set_defaults(h, {"links": [], "author": ""})
+        if changed:
+            self._save()
 
     # ------------------------------------------------------------------ io
     def _save(self) -> None:
@@ -114,8 +198,44 @@ class ResearchState:
                 and x["id"][len(prefix):].isdigit()]
         return f"{prefix}{(max(nums) + 1) if nums else 1}"
 
+    @staticmethod
+    def _normalize_options(options: Optional[List[Any]],
+                           chosen: str = "") -> List[Dict[str, str]]:
+        """Coerce options to the v3 shape ``[{text, status}]``. Accepts a list of
+        bare strings (legacy / convenience) or a list of dicts. Each option's
+        ``status`` is ``chosen`` or ``alternative``; the one matching ``chosen``
+        (case-insensitive) is marked chosen when none is explicitly flagged."""
+        norm: List[Dict[str, str]] = []
+        for o in options or []:
+            if isinstance(o, dict):
+                text = str(o.get("text", "")).strip()
+                status = o.get("status")
+                status = status if status in ("chosen", "alternative") else None
+            else:
+                text = str(o).strip()
+                status = None
+            if not text:
+                continue
+            norm.append({"text": text, "status": status})
+
+        ch = (chosen or "").strip().lower()
+        saw_chosen = any(o["status"] == "chosen" for o in norm)
+        for o in norm:
+            if o["status"] is None:
+                if ch and o["text"].lower() == ch and not saw_chosen:
+                    o["status"] = "chosen"
+                    saw_chosen = True
+                else:
+                    o["status"] = "alternative"
+        # If the chosen path wasn't among the listed options, add it so the
+        # decision is self-contained (you can always see what was picked).
+        if ch and not saw_chosen and (chosen or "").strip():
+            norm.append({"text": (chosen or "").strip(), "status": "chosen"})
+        return norm
+
     def upsert_hypothesis(self, statement: str, status: str = "alive",
-                          evidence: str = "", hid: Optional[str] = None) -> str:
+                          evidence: str = "", hid: Optional[str] = None,
+                          links: Optional[List[Dict[str, Any]]] = None) -> str:
         statement = (statement or "").strip()
         if not statement:
             return ""
@@ -126,27 +246,51 @@ class ResearchState:
                 h["status"] = status
                 if evidence:
                     h["evidence"] = evidence
+                if links:
+                    h["links"] = links
                 h["updated_at"] = _now()
                 self._save()
                 return h["id"]
         new_id = hid or self._next_id("hypotheses", "H")
         self.state["hypotheses"].append({
             "id": new_id, "statement": statement, "status": status,
-            "evidence": evidence, "updated_at": _now(),
+            "evidence": evidence, "links": links or [], "author": "",
+            "updated_at": _now(),
         })
         self._save()
         return new_id
 
-    def add_finding(self, text: str, kind: str = "result") -> None:
+    def add_finding(self, text: str, kind: str = "result",
+                    insight: str = "", evidence: Optional[List[Any]] = None,
+                    links: Optional[List[Dict[str, Any]]] = None,
+                    author: str = "") -> str:
+        """Add (or dedup) a finding — the spine node decisions hang off. Returns
+        the finding's ``F-id`` (existing id when it dedups by text), so the caller
+        can tag decisions with ``finding=<that id>``."""
         text = (text or "").strip()
         if not text:
-            return
-        if kind not in ("result", "dead_end", "note"):
+            return ""
+        if kind not in FINDING_KINDS:
             kind = "note"
-        if any(f["text"].lower() == text.lower() for f in self.state["findings"]):
-            return
-        self.state["findings"].append({"text": text, "kind": kind, "ts": _now()})
+        for f in self.state["findings"]:
+            if f["text"].lower() == text.lower():
+                # Enrich an existing finding rather than duplicating it.
+                if insight and not f.get("insight"):
+                    f["insight"] = insight.strip()
+                if evidence:
+                    f["evidence"] = evidence
+                if links:
+                    f["links"] = links
+                self._save()
+                return f["id"]
+        new_id = self._next_id("findings", "F")
+        self.state["findings"].append({
+            "id": new_id, "text": text, "insight": (insight or "").strip(),
+            "kind": kind, "evidence": evidence or [], "links": links or [],
+            "author": author, "ts": _now(),
+        })
         self._save()
+        return new_id
 
     def set_fields(self, narrative: Optional[str] = None,
                    current_best: Optional[str] = None,
@@ -183,10 +327,12 @@ class ResearchState:
             self._save()
         return removed
 
-    def add_incident(self, kind: str, detail: str) -> None:
+    def add_incident(self, kind: str, detail: str, author: str = "") -> None:
         """Record something that went wrong — an auto-detected tool error/unknown-
         tool call, or a self-reported struggle. This is what keeps the world model
-        honest: failures leave a trace instead of being silently smoothed over."""
+        honest: failures leave a trace instead of being silently smoothed over. As
+        shared multi-agent memory it doubles as coordination state (a peer can see
+        what already failed and not blindly retry it)."""
         detail = (detail or "").strip()
         if not detail:
             return
@@ -194,33 +340,74 @@ class ResearchState:
         # Skip consecutive duplicates (a confused loop shouldn't spam the board).
         if inc and inc[-1].get("kind") == kind and inc[-1].get("detail") == detail:
             return
-        inc.append({"ts": _now(), "kind": kind, "detail": detail})
+        inc.append({"ts": _now(), "kind": kind, "detail": detail, "author": author})
         # Bound growth — keep the most recent 50.
         if len(inc) > 50:
             self.state["incidents"] = inc[-50:]
         self._save()
 
     def add_decision(self, question: str, chosen: str = "", rationale: str = "",
-                     options: Optional[List[str]] = None, by: str = "manager") -> None:
+                     options: Optional[List[Any]] = None, by: str = "manager",
+                     finding: str = "global", layer: Optional[str] = None,
+                     evidence: Optional[List[Any]] = None,
+                     links: Optional[List[Dict[str, Any]]] = None,
+                     author: str = "") -> str:
+        """Record a decision (a fork the run faced). ``finding`` is the F-id it
+        serves, or ``"global"`` for a project-wide fork (e.g. orchestration: which
+        agent to dispatch, when to stop) tied to no single finding. ``layer`` is
+        one of DECISION_LAYERS. Review/interaction fields are left empty for later
+        agents. Returns the new ``D-id``."""
         question = (question or "").strip()
         if not question:
-            return
+            return ""
+        layer = layer if layer in DECISION_LAYERS else None
+        finding = (finding or "global").strip() or "global"
+        new_id = self._next_id("decisions", "D")
         self.state["decisions"].append({
-            "id": self._next_id("decisions", "D"), "question": question,
-            "options": options or [], "chosen": (chosen or "").strip(),
-            "rationale": (rationale or "").strip(), "by": by, "ts": _now(),
+            "id": new_id, "finding": finding, "layer": layer,
+            "question": question,
+            "options": self._normalize_options(options, chosen),
+            "chosen": (chosen or "").strip(),
+            "rationale": (rationale or "").strip(), "by": by, "author": author,
+            "evidence": evidence or [], "links": links or [],
+            # Review-time / interaction-time — filled by later agents, not live.
+            "importance": "", "should_engage": None, "should_engage_reason": "",
+            "sequence": None, "ts": _now(),
         })
         self._save()
+        return new_id
+
+    def reparent_decision(self, decision_id: str, finding: str) -> bool:
+        """Move a decision from ``global`` (or any finding) onto ``finding`` — used
+        when a decision was recorded before the finding it serves existed. Returns
+        True if a decision was updated."""
+        finding = (finding or "").strip()
+        if not finding:
+            return False
+        for d in self.state["decisions"]:
+            if d["id"] == decision_id:
+                d["finding"] = finding
+                self._save()
+                return True
+        return False
 
     def add_experiment(self, agent: str, run_id: str, rationale: str = "",
-                       hypothesis: str = "") -> None:
+                       hypothesis: str = "", name: str = "", mode: str = "",
+                       design: str = "") -> str:
+        """Record an investigation. ``name``/``mode``/``design`` describe what it IS
+        (domain-general); ``agent`` is the NeuriCo pipeline stage that ran it, kept
+        as provenance under ``ranBy`` (``agent`` retained for back-compat)."""
+        mode = mode if mode in EXPERIMENT_MODES else ""
+        new_id = self._next_id("experiments", "E")
         self.state["experiments"].append({
-            "id": self._next_id("experiments", "E"), "agent": agent,
+            "id": new_id, "name": (name or "").strip(), "mode": mode,
+            "design": (design or "").strip(), "agent": agent, "ranBy": agent,
             "run_id": run_id, "rationale": (rationale or "").strip(),
             "hypothesis": (hypothesis or "").strip(), "status": "running",
             "result": "", "ts": _now(),
         })
         self._save()
+        return new_id
 
     def update_experiment(self, run_id: str, status: Optional[str] = None,
                           result: Optional[str] = None) -> None:
@@ -244,6 +431,10 @@ class ResearchState:
     def add_assessment(self, situation: str = "", uncertainty: str = "",
                        crux: str = "", decision_pending: str = "",
                        engage_user: bool = False, rationale: str = "") -> None:
+        """DEPRECATED. The manager's per-cycle metacognition log — kept working so
+        the existing `assess` tool doesn't break, but slated for removal: with the
+        world model now multi-agent shared memory, the engage signal moves onto
+        each decision (``should_engage``), owned by a human-interactor subagent."""
         self.state["assessments"].append({
             "ts": _now(), "situation": (situation or "").strip(),
             "uncertainty": (uncertainty or "").strip(), "crux": (crux or "").strip(),
@@ -293,6 +484,13 @@ class ResearchState:
     def latest_assessment(self) -> Optional[Dict[str, Any]]:
         return self.state["assessments"][-1] if self.state["assessments"] else None
 
+    def decisions_for(self, finding_id: str) -> List[Dict[str, Any]]:
+        """All decisions tagged with `finding_id` (use 'global' for project-wide),
+        in layer order so a reader sees a finding's forks hypothesis→interpretation."""
+        order = {l: i for i, l in enumerate(DECISION_LAYERS)}
+        ds = [d for d in self.state["decisions"] if d.get("finding") == finding_id]
+        return sorted(ds, key=lambda d: order.get(d.get("layer"), len(order)))
+
     def consistency_warnings(self) -> List[str]:
         """Detect drift between the world model and reality — the failures we saw
         in real runs (a hypothesis left 'alive' after its experiment finished;
@@ -320,7 +518,7 @@ class ResearchState:
                 warns.append(
                     f"Hypothesis {h['id']} was tested by {e['run_id']} "
                     f"({e['status']}) but is still '{h['status']}' — set it to "
-                    f"supported/dead (with evidence) based on the result.")
+                    f"supported/refuted/dead (with evidence) based on the result.")
         # Resolved-but-stale open questions: if work has clearly progressed
         # (a result/decision exists) yet questions are still listed, nudge a prune.
         if self.state["open_questions"] and (self.state["current_best"]
@@ -337,6 +535,7 @@ class ResearchState:
         alive = sum(1 for h in s["hypotheses"] if h["status"] in ("alive", "uncertain"))
         return {
             "event": "research",
+            "schema_version": s.get("schema_version", SCHEMA_VERSION),
             "updated_at": s["updated_at"],
             "narrative": s["narrative"],
             "current_best": s["current_best"],
@@ -345,7 +544,7 @@ class ResearchState:
             "experiments": s["experiments"][-12:],
             "findings": s["findings"][-12:],
             "open_questions": s["open_questions"],
-            "decisions": s["decisions"][-8:],
+            "decisions": s["decisions"][-12:],
             "latest_assessment": self.latest_assessment,
             "incidents": s.get("incidents", [])[-10:],
             "warnings": self.consistency_warnings(),
@@ -354,6 +553,7 @@ class ResearchState:
             "counts": {
                 "hypotheses_alive": alive,
                 "hypotheses_total": len(s["hypotheses"]),
+                "findings": len(s["findings"]),
                 "experiments": len(s["experiments"]),
                 "decisions": len(s["decisions"]),
             },
@@ -369,7 +569,7 @@ class ResearchState:
         s = self.state
         if not any([s["narrative"], s["current_best"], s["crux"], s["hypotheses"],
                     s["open_questions"], s["decisions"], s["experiments"],
-                    s.get("sections")]):
+                    s["findings"], s.get("sections")]):
             return ("\n\n## Current Research State\n"
                     "(empty — you have not recorded any state yet. As you learn "
                     "things, call update_research_state to populate this.)")
@@ -389,11 +589,18 @@ class ResearchState:
                 ev = f" — {h['evidence']}" if h.get("evidence") else ""
                 lines.append(f"  [{h['status']}] {h['id']}: {h['statement']}{ev}")
 
+        if s["findings"]:
+            lines.append("Findings (the spine — decisions hang off these):")
+            for f in s["findings"][-max_items:]:
+                ins = f" — {f['insight']}" if f.get("insight") else ""
+                lines.append(f"  [{f['kind']}] {f.get('id', '?')}: {f['text']}{ins}")
+
         if s["experiments"]:
             lines.append("Experiments:")
             for e in s["experiments"][-max_items:]:
                 why = f" ({e['rationale']})" if e.get("rationale") else ""
-                lines.append(f"  {e['run_id']} {e['agent']} [{e['status']}]{why}")
+                label = e.get("name") or e.get("agent", "")
+                lines.append(f"  {e['run_id']} {label} [{e['status']}]{why}")
 
         if s["open_questions"]:
             lines.append("Open questions:")
@@ -401,10 +608,11 @@ class ResearchState:
                 lines.append(f"  - {q}")
 
         if s["decisions"]:
-            lines.append("Decisions made:")
+            lines.append("Decisions made (finding/layer):")
             for d in s["decisions"][-max_items:]:
                 ch = f" → {d['chosen']}" if d.get("chosen") else ""
-                lines.append(f"  - {d['question']}{ch}")
+                tag = f" [{d.get('finding', 'global')}/{d.get('layer') or '-'}]"
+                lines.append(f"  - {d['question']}{ch}{tag}")
 
         la = self.latest_assessment
         if la:

--- a/tests/test_research_state.py
+++ b/tests/test_research_state.py
@@ -1,0 +1,225 @@
+"""Unit tests for the v3 world-model data model (ResearchState).
+
+Covers the PR-1 storage layer: findings-as-spine, layered decisions, structured
+options, the new experiment/hypothesis/incident fields, and — critically —
+forward-migration of a pre-v3 state file so the running manager never crashes on
+an old `research_state.json`.
+
+Run: python -m pytest tests/test_research_state.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from interactive.research_state import (  # noqa: E402
+    DECISION_LAYERS, HYP_STATUSES, ResearchState, SCHEMA_VERSION,
+)
+
+
+def _fresh(tmp_path) -> ResearchState:
+    return ResearchState(tmp_path)
+
+
+# ---------------------------------------------------------------- findings
+
+def test_add_finding_returns_f_id_and_dedups(tmp_path):
+    r = _fresh(tmp_path)
+    f1 = r.add_finding("CoT lifts GSM8K by 12pts", kind="result", insight="prompting matters")
+    assert f1 == "F1"
+    # Same text dedups to the same id; insight backfills.
+    f1b = r.add_finding("cot lifts gsm8k by 12pts")
+    assert f1b == "F1"
+    assert len(r.state["findings"]) == 1
+    f2 = r.add_finding("baseline overfits", kind="dead_end")
+    assert f2 == "F2"
+    fnode = r.state["findings"][0]
+    assert fnode["kind"] == "result"
+    assert fnode["insight"] == "prompting matters"
+    assert fnode["evidence"] == [] and fnode["links"] == []
+
+
+def test_add_finding_bad_kind_falls_back_to_note(tmp_path):
+    r = _fresh(tmp_path)
+    fid = r.add_finding("something", kind="bogus")
+    assert r.state["findings"][0]["kind"] == "note"
+    assert fid == "F1"
+
+
+# --------------------------------------------------------------- decisions
+
+def test_decision_defaults_to_global_and_normalizes_options(tmp_path):
+    r = _fresh(tmp_path)
+    did = r.add_decision(
+        question="Which benchmark?", chosen="GSM8K",
+        options=["GSM8K", "MATH", "SVAMP"], layer="experiment_design")
+    assert did == "D1"
+    d = r.state["decisions"][0]
+    assert d["finding"] == "global"
+    assert d["layer"] == "experiment_design"
+    # legacy [str] options become [{text,status}] with the chosen one flagged
+    statuses = {o["text"]: o["status"] for o in d["options"]}
+    assert statuses["GSM8K"] == "chosen"
+    assert statuses["MATH"] == "alternative"
+    # review/interaction fields left empty for later agents
+    assert d["importance"] == "" and d["should_engage"] is None
+    assert d["sequence"] is None and d["author"] == ""
+
+
+def test_decision_chosen_added_when_not_in_options(tmp_path):
+    r = _fresh(tmp_path)
+    r.add_decision(question="Q", chosen="surprise", options=["a", "b"])
+    opts = r.state["decisions"][0]["options"]
+    assert {"text": "surprise", "status": "chosen"} in opts
+
+
+def test_decision_invalid_layer_becomes_none(tmp_path):
+    r = _fresh(tmp_path)
+    r.add_decision(question="Q", layer="not_a_layer")
+    assert r.state["decisions"][0]["layer"] is None
+    for layer in DECISION_LAYERS:
+        r.add_decision(question=f"Q-{layer}", layer=layer)
+    assert {d["layer"] for d in r.state["decisions"][1:]} == set(DECISION_LAYERS)
+
+
+def test_reparent_decision(tmp_path):
+    r = _fresh(tmp_path)
+    fid = r.add_finding("a finding")
+    did = r.add_decision(question="made before the finding existed")
+    assert r.state["decisions"][0]["finding"] == "global"
+    assert r.reparent_decision(did, fid) is True
+    assert r.state["decisions"][0]["finding"] == fid
+    assert r.reparent_decision("D999", fid) is False
+
+
+def test_decisions_for_returns_layer_ordered(tmp_path):
+    r = _fresh(tmp_path)
+    fid = r.add_finding("f")
+    r.add_decision(question="interp", finding=fid, layer="interpretation")
+    r.add_decision(question="hyp", finding=fid, layer="hypothesis")
+    r.add_decision(question="global one", finding="global", layer="method")
+    got = [d["question"] for d in r.decisions_for(fid)]
+    assert got == ["hyp", "interp"]  # hypothesis before interpretation; global excluded
+
+
+# ------------------------------------------------------- hypotheses / exp
+
+def test_refuted_is_a_valid_status(tmp_path):
+    r = _fresh(tmp_path)
+    assert "refuted" in HYP_STATUSES
+    hid = r.upsert_hypothesis("H stmt", status="refuted")
+    assert r.state["hypotheses"][0]["status"] == "refuted"
+    # upsert by statement updates in place
+    assert r.upsert_hypothesis("h stmt", status="supported") == hid
+    assert r.state["hypotheses"][0]["status"] == "supported"
+
+
+def test_experiment_carries_domain_general_fields(tmp_path):
+    r = _fresh(tmp_path)
+    eid = r.add_experiment(agent="experiment_runner", run_id="run-1",
+                           name="GSM8K eval", mode="empirical_experiment",
+                           design="vary prompt across 200 items")
+    e = r.state["experiments"][0]
+    assert eid == "E1"
+    assert e["name"] == "GSM8K eval" and e["mode"] == "empirical_experiment"
+    assert e["ranBy"] == "experiment_runner"  # provenance mirrors agent
+    # bad mode is dropped to ""
+    r.add_experiment(agent="x", run_id="run-2", mode="telepathy")
+    assert r.state["experiments"][1]["mode"] == ""
+
+
+def test_incident_records_author_and_dedups(tmp_path):
+    r = _fresh(tmp_path)
+    r.add_incident("tool_error", "boom", author="experiment_runner")
+    r.add_incident("tool_error", "boom", author="experiment_runner")  # consecutive dup
+    assert len(r.state["incidents"]) == 1
+    assert r.state["incidents"][0]["author"] == "experiment_runner"
+
+
+# ------------------------------------------------------------- migration
+
+def test_blank_state_has_v3_shape(tmp_path):
+    r = _fresh(tmp_path)
+    assert r.state["schema_version"] == SCHEMA_VERSION
+    assert "assessments" in r.state  # retained (removed with the tool in a later PR)
+
+
+def test_forward_migration_from_pre_v3_state(tmp_path):
+    """A research_state.json written before v3: flat findings (no id), decisions
+    with [str] options and no finding/layer, experiments without name/mode. Loading
+    it must not crash and must backfill the v3 shape."""
+    legacy = {
+        "updated_at": "2026-01-01T00:00:00",
+        "narrative": "old run", "current_best": "", "crux": "",
+        "hypotheses": [{"id": "H1", "statement": "h", "status": "alive",
+                        "evidence": "", "updated_at": "2026-01-01T00:00:00"}],
+        "experiments": [{"id": "E1", "agent": "experiment_runner", "run_id": "r1",
+                         "rationale": "", "hypothesis": "", "status": "done",
+                         "result": "ok", "ts": "2026-01-01T00:00:00"}],
+        "findings": [{"text": "a flat finding", "kind": "result",
+                      "ts": "2026-01-01T00:00:00"}],
+        "open_questions": [],
+        "decisions": [{"id": "D1", "question": "old?", "options": ["x", "y"],
+                       "chosen": "x", "rationale": "", "by": "manager",
+                       "ts": "2026-01-01T00:00:00"}],
+        "incidents": [{"ts": "2026-01-01T00:00:00", "kind": "tool_error",
+                       "detail": "old boom"}],
+    }
+    neurico = tmp_path / ".neurico"
+    neurico.mkdir(parents=True)
+    (neurico / "research_state.json").write_text(json.dumps(legacy))
+
+    r = ResearchState(tmp_path)
+
+    # finding gained an F-id + v3 fields
+    f = r.state["findings"][0]
+    assert f["id"].startswith("F")
+    assert f["insight"] == "" and f["evidence"] == [] and f["links"] == []
+    # decision gained finding/layer + normalized options + empty review fields
+    d = r.state["decisions"][0]
+    assert d["finding"] == "global" and d["layer"] is None
+    assert {o["text"]: o["status"] for o in d["options"]}["x"] == "chosen"
+    assert d["importance"] == "" and d["should_engage"] is None
+    # experiment gained name/mode/design/ranBy
+    e = r.state["experiments"][0]
+    assert e["ranBy"] == "experiment_runner" and e["mode"] == ""
+    # incident gained author; hypothesis gained links
+    assert r.state["incidents"][0]["author"] == ""
+    assert r.state["hypotheses"][0]["links"] == []
+    # migration is persisted and idempotent
+    r2 = ResearchState(tmp_path)
+    assert r2.state["findings"][0]["id"] == f["id"]
+
+
+def test_migration_is_idempotent_no_duplicate_ids(tmp_path):
+    r = _fresh(tmp_path)
+    r.add_finding("one")
+    r.add_finding("two")
+    ids = [f["id"] for f in r.state["findings"]]
+    r2 = ResearchState(tmp_path)
+    assert [f["id"] for f in r2.state["findings"]] == ids == ["F1", "F2"]
+
+
+# --------------------------------------------------------- read / render
+
+def test_snapshot_and_digest_include_findings(tmp_path):
+    r = _fresh(tmp_path)
+    fid = r.add_finding("key result", insight="so what")
+    r.add_decision(question="why?", finding=fid, layer="interpretation", chosen="because")
+    snap = r.snapshot()
+    assert snap["schema_version"] == SCHEMA_VERSION
+    assert snap["counts"]["findings"] == 1
+    assert any(f["id"] == fid for f in snap["findings"])
+    digest = r.digest_section()
+    assert "Findings (the spine" in digest
+    assert fid in digest
+    assert f"[{fid}/interpretation]" in digest
+
+
+def test_empty_digest_message(tmp_path):
+    r = _fresh(tmp_path)
+    assert "empty" in r.digest_section()


### PR DESCRIPTION
## Summary

First PR in a series bringing NeuriCo's **live** world model up to the log-visualizer's **v3** design, and repurposing it as **shared memory for multi-agent cooperation** (not just the manager's human-facing whiteboard).

This PR is the **data-model layer only** — `src/interactive/research_state.py`. It is **additive and back-compatible**: every existing `tools.py`/`manager.py` call site keeps working, so the running manager is unaffected.

## What changed

- **Findings are the spine.** `add_finding` now assigns an `F-id`, carries `insight/evidence/links/author`, and **returns the id** so decisions can attach to the finding they produced.
- **Every decision is layered.** `add_decision` gains `finding` (defaults to `"global"` for project-wide/orchestration forks), `layer` (`hypothesis | method | experiment_design | interpretation`), structured `options [{text, status}]` (auto-flagging the chosen one), and `evidence/links/author`.
- **Review/interaction fields are present but left empty** for later agents: `importance`, `should_engage`, `should_engage_reason`, `sequence`.
- **`reparent_decision(id, finding)`** — move a `global` decision onto a finding once it exists (handles the live authoring order, where a decision is often made before its finding).
- Hypotheses gain the `refuted` status + `links`; experiments gain domain-general `name/mode/design` + `ranBy` provenance; incidents are **kept** (against v3's dormancy — useful as multi-agent coordination state) and gain `author`.
- `schema_version = 3`; findings are surfaced in `snapshot()` and `digest_section()` (decisions now render with their `[finding/layer]` tag).
- **Forward-migration.** A pre-v3 `research_state.json` (flat findings with no id, `[str]` options, decisions with no finding/layer) loads without crashing and backfills the v3 shape — idempotently.

## Deliberately deferred

- **`assess` / `add_assessment` kept working.** The assessments node + tool removal lands in **PR 2** (with the manager-authoring changes) so each PR leaves the tree non-broken.
- **Concurrency-safe multi-writer storage** → a later, gated PR, done right before sub-agents start writing. Today the manager is the only writer, so last-writer-wins `_save` is fine.

## Testing

- New `tests/test_research_state.py` — **15 tests, all passing**: findings, layered decisions, option normalization, reparenting, layer-ordered reads, new statuses/fields, and the pre-v3 → v3 migration path.
- `py_compile` clean across `research_state.py`, `tools.py`, `manager.py`, `web_server.py`.
- Smoke test replays `tools.py`'s exact call patterns (incl. `add_assessment`, `add_experiment`) — options normalize, decisions default to `global`.

## Scope

Only `src/interactive/research_state.py` + new `tests/` — within PR #113's footprint. No changes to auto-mode, core, Docker, or CLI.

## Follow-ups (separate PRs)

- **PR 2** — manager authoring: `tools.yaml` / `tools.py` / `system_prompt.txt` teach the manager the new shape; remove the `assess` tool + assessments node.
- **PR 3** — whiteboard rendering: decisions grouped by finding/layer.
- **PR 4** — concurrency-safe storage (gated on multi-agent writes).
- **Future** — human-interactor subagent (`should_engage`) and review subagent (`importance`).
