### PR TITLE
feat(interactive): manager authoring for v3 world model; remove assess tool

### DIFF
--- a/src/interactive/manager.py
+++ b/src/interactive/manager.py
@@ -101,8 +101,6 @@ def friendly_tool_echo(name: str, args: Dict[str, Any]) -> Optional[str]:
         return "📝 Updated session notes"
     if name == "update_research_state":
         return None  # silent — the Research whiteboard reflects this live
-    if name == "assess":
-        return None  # silent — surfaced on the whiteboard, not as chat noise
     if name == "design_panel":
         return None  # silent — the whiteboard re-renders to reflect the layout
     if name == "run_agent":

--- a/src/interactive/research_state.py
+++ b/src/interactive/research_state.py
@@ -72,7 +72,7 @@ BLOCK_KINDS = ("text", "bullet_list", "key_value", "table", "status_list")
 # Reserved ids for the built-in sections. A panel_layout entry that matches one
 # of these renders the corresponding core section; any other id is looked up in
 # the custom `sections` map.
-BUILTIN_SECTIONS = ("crux", "current_best", "narrative", "assessment",
+BUILTIN_SECTIONS = ("crux", "current_best", "narrative",
                     "hypotheses", "open_questions", "decisions", "experiments",
                     "findings")
 
@@ -133,7 +133,6 @@ class ResearchState:
             # is one of DECISION_LAYERS. Review/interaction fields (importance,
             # should_engage*) are left empty for later agents.
             "decisions": [],        # {id, finding, layer, question, options[{text,status}], chosen, rationale, by, author, evidence, links, importance, should_engage, should_engage_reason, sequence, ts}
-            "assessments": [],      # DEPRECATED (removed with the `assess` tool in a later PR) — {ts, situation, uncertainty, crux, decision_pending, engage_user, rationale}
             "incidents": [],        # {ts, kind, detail, author} — auto-logged tool errors + self-reported struggle
             # Level 2 — the PI-designed panel. `panel_layout` is an ordered list
             # of section ids (built-in or custom); empty → default order. Each
@@ -428,24 +427,6 @@ class ResearchState:
         if changed:
             self._save()
 
-    def add_assessment(self, situation: str = "", uncertainty: str = "",
-                       crux: str = "", decision_pending: str = "",
-                       engage_user: bool = False, rationale: str = "") -> None:
-        """DEPRECATED. The manager's per-cycle metacognition log — kept working so
-        the existing `assess` tool doesn't break, but slated for removal: with the
-        world model now multi-agent shared memory, the engage signal moves onto
-        each decision (``should_engage``), owned by a human-interactor subagent."""
-        self.state["assessments"].append({
-            "ts": _now(), "situation": (situation or "").strip(),
-            "uncertainty": (uncertainty or "").strip(), "crux": (crux or "").strip(),
-            "decision_pending": (decision_pending or "").strip(),
-            "engage_user": bool(engage_user), "rationale": (rationale or "").strip(),
-        })
-        # The crux from the latest assessment is the live crux.
-        if crux and crux.strip():
-            self.state["crux"] = crux.strip()
-        self._save()
-
     # --------------------------------------------------------- panel (L2)
     def set_panel_layout(self, layout: List[str]) -> None:
         """Set the ordered list of section ids the whiteboard renders. Entries
@@ -480,10 +461,6 @@ class ResearchState:
         return sid
 
     # ------------------------------------------------------- read / render
-    @property
-    def latest_assessment(self) -> Optional[Dict[str, Any]]:
-        return self.state["assessments"][-1] if self.state["assessments"] else None
-
     def decisions_for(self, finding_id: str) -> List[Dict[str, Any]]:
         """All decisions tagged with `finding_id` (use 'global' for project-wide),
         in layer order so a reader sees a finding's forks hypothesis→interpretation."""
@@ -545,7 +522,6 @@ class ResearchState:
             "findings": s["findings"][-12:],
             "open_questions": s["open_questions"],
             "decisions": s["decisions"][-12:],
-            "latest_assessment": self.latest_assessment,
             "incidents": s.get("incidents", [])[-10:],
             "warnings": self.consistency_warnings(),
             "panel_layout": s.get("panel_layout", []),
@@ -613,13 +589,6 @@ class ResearchState:
                 ch = f" → {d['chosen']}" if d.get("chosen") else ""
                 tag = f" [{d.get('finding', 'global')}/{d.get('layer') or '-'}]"
                 lines.append(f"  - {d['question']}{ch}{tag}")
-
-        la = self.latest_assessment
-        if la:
-            lines.append(
-                f"Your last assessment: {la.get('situation', '')} "
-                f"| uncertainty: {la.get('uncertainty', '')} "
-                f"| engage_user={la.get('engage_user')}")
 
         recent_incidents = self.state.get("incidents", [])[-3:]
         if recent_incidents:

--- a/src/interactive/tools.py
+++ b/src/interactive/tools.py
@@ -68,7 +68,6 @@ class ToolExecutor:
             "ask_user": self._ask_user,
             "update_session": self._update_session,
             "update_research_state": self._update_research_state,
-            "assess": self._assess,
             "design_panel": self._design_panel,
         }
 
@@ -419,8 +418,15 @@ class ToolExecutor:
         if hyps:
             updates.append(f"{len(hyps)} hypothesis(es)")
 
+        # Findings are the spine: accept rich objects {text, insight, kind} or bare
+        # strings. dead_ends remain a convenience shorthand for kind="dead_end".
         for f in self._as_list(args.get("findings")):
-            r.add_finding(str(f), kind="result")
+            if isinstance(f, dict):
+                r.add_finding(str(f.get("text", "")),
+                              kind=str(f.get("kind", "result")),
+                              insight=str(f.get("insight", "")))
+            else:
+                r.add_finding(str(f), kind="result")
         for d in self._as_list(args.get("dead_ends")):
             r.add_finding(str(d), kind="dead_end")
         n_find = len(self._as_list(args.get("findings"))) + len(self._as_list(args.get("dead_ends")))
@@ -452,39 +458,21 @@ class ToolExecutor:
                 chosen=str(decision.get("chosen", "")),
                 rationale=str(decision.get("rationale", "")),
                 options=[str(o) for o in self._as_list(decision.get("options"))],
+                finding=str(decision.get("finding", "global") or "global"),
+                layer=decision.get("layer"),
                 by="manager",
             )
             updates.append("decision")
 
+        # Honest self-report of struggle (formerly carried by assess(issue=...)).
+        # Tool/unknown-tool errors are still auto-logged in execute().
+        incident = args.get("incident")
+        if incident is not None and str(incident).strip():
+            r.add_incident("self_reported", str(incident))
+            updates.append("incident")
+
         return "Research state updated: " + ", ".join(updates) if updates else \
                "No changes (provide narrative/current_best/crux/hypotheses/findings/open_questions/decision)"
-
-    def _assess(self, args: Dict[str, Any]) -> str:
-        """Record the manager's read of the situation right now: what changed,
-        what's uncertain, the crux, any pending decision, and whether a human
-        expert would pull the user in (with rationale). This is reflection, not
-        action — if engage_user is true, you still call ask_user to actually ask."""
-        engage = args.get("engage_user", False)
-        if isinstance(engage, str):
-            engage = engage.strip().lower() in ("true", "yes", "1")
-        self.research.add_assessment(
-            situation=str(args.get("situation", "")),
-            uncertainty=str(args.get("uncertainty", "")),
-            crux=str(args.get("crux", "")),
-            decision_pending=str(args.get("decision_pending", "")),
-            engage_user=bool(engage),
-            rationale=str(args.get("rationale", "")),
-        )
-        # Honest self-report: if the manager hit confusion, an error, or recovered
-        # from a mistake, it logs an incident so the failure leaves a trace.
-        issue = str(args.get("issue", "")).strip()
-        if issue:
-            self.research.add_incident("self_reported", issue)
-        if engage:
-            return ("Assessment recorded. You judged the human should be engaged — "
-                    "now call ask_user with a concise, crux-focused question.")
-        return ("Assessment recorded. You judged no human input is needed now — "
-                "proceed autonomously.")
 
     # Block kinds the manager may use for custom panel sections. Kept in sync
     # with research_state.BLOCK_KINDS — these are the data shapes the whiteboard
@@ -497,8 +485,8 @@ class ToolExecutor:
         vocabulary (text, bullet_list, key_value, table, status_list). Decide the
         layout once near the start; afterwards call this only to refresh a custom
         section's `data`. Built-in sections (crux, current_best, narrative,
-        assessment, hypotheses, open_questions, decisions, experiments) keep
-        flowing from update_research_state/assess — list their ids in `layout`
+        findings, hypotheses, open_questions, decisions, experiments) keep
+        flowing from update_research_state — list their ids in `layout`
         to position them."""
         r = self.research
         updates = []

--- a/templates/manager/system_prompt.txt
+++ b/templates/manager/system_prompt.txt
@@ -15,16 +15,16 @@ The human provides domain expertise, taste, and the decisions only they can make
 You think like a PI by keeping an explicit, structured picture of the research using `update_research_state`. This is not optional bookkeeping — it IS how you reason, and the human sees it as a live "Research" whiteboard. The current state is given to you each turn under "## Current Research State".
 
 Keep it current the way a real PI's mental model updates:
-- Register a **hypothesis** when you form one; mark it `supported` or `dead` as evidence lands.
-- Record **findings** (results) and **dead_ends** (so nothing unproductive is retried).
+- Register a **hypothesis** when you form one; mark it `supported`, `refuted`, or `dead` as evidence lands.
+- Record **findings** (results) and **dead_ends** (so nothing unproductive is retried) — these are the spine (see "Findings Are the Spine" below).
 - Keep the **crux** set to the single most decision-relevant open issue right now.
 - Update **current_best** when a stronger result appears, and the **narrative** as the story moves.
-- Log **decisions** (with rationale) when you or the human commit to a direction.
+- Log **decisions** (with rationale) when you or the human commit to a direction — tag each with the `finding` it serves and its `layer`.
 
 **Keep the model consistent with reality — this is where it usually drifts:**
 - When an experiment finishes, immediately update the hypothesis it tested:
-  flip its status to `supported` or `dead` (with the evidence). Never leave a
-  hypothesis `alive` once a completed run has settled it.
+  flip its status to `supported`, `refuted`, or `dead` (with the evidence). Never
+  leave a hypothesis `alive` once a completed run has settled it.
 - When a question gets answered, remove it with
   `update_research_state(resolved_questions=[...])`. Don't let answered
   questions linger in `open_questions`.
@@ -33,11 +33,17 @@ Keep it current the way a real PI's mental model updates:
 
 A turn where you learned something but did not update the world model is a mistake.
 
-## Assess Before You Act
+## Findings Are the Spine — and Everything Is a Decision
 
-At every meaningful juncture — after an agent completes, before launching an expensive run, and before deciding whether to involve the human — call `assess` to record your read: what changed, what's uncertain, the crux, any pending decision, and whether a human expert in your seat would pull the user in (with your reasoning). `assess` is reflection, not action: if you conclude the human should be engaged, you then call `ask_user`. Your assessments are shown to the human and are how your judgement is reviewed, so be honest and specific.
+The research exists to produce **findings** (units of insight: a `result`, a `dead_end`, or a `note`). Record each finding with `update_research_state(findings=[...])`; give it an `insight` (the so-what) when there is one. Findings are the backbone the rest of the model hangs off.
 
-**Be honest about struggle.** If you get confused, hit an error, call a tool that doesn't exist, or recover from a mistake, say so — pass `assess(issue="...")` to record it. The system also auto-logs tool errors and unknown-tool calls as incidents on the whiteboard, so they are visible whether or not you report them; do not pretend a failure didn't happen or quietly paper over it. An honest record of what went wrong is more valuable than a clean-looking one.
+Around each finding sits the chain of **decisions** that produced it. Log a decision when you (or the human) faced a fork and picked a path: `update_research_state(decision={...})`. Tag every decision with:
+- **`finding`** — the finding id it serves (e.g. `"F2"`), or `"global"` for a project-wide fork tied to no single finding (orchestration choices: which agent to run, how to scope, when to stop). If you make a decision before its finding exists, use `"global"` for now.
+- **`layer`** — where in the finding's lifecycle the fork sits: `hypothesis` (what to test), `method` (the way — library, metric, threshold, prompt), `experiment_design` (dataset/baseline/scope/seed), or `interpretation` (what the result means / whether it counts as a finding).
+
+Don't grade your own decisions for importance or whether to engage the human — those are filled in later by separate review. Your job is to record the fork honestly: the question, the options, what you chose, and why.
+
+**Be honest about struggle.** If you get confused, hit an error, call a tool that doesn't exist, or recover from a mistake, say so — pass `update_research_state(incident="...")` to record it. The system also auto-logs tool errors and unknown-tool calls as incidents on the whiteboard, so they are visible whether or not you report them; do not pretend a failure didn't happen or quietly paper over it. An honest record of what went wrong is more valuable than a clean-looking one.
 
 ## Design Your Research Panel
 
@@ -47,7 +53,7 @@ but before launching real compute — call `design_panel` to tailor the board:
 
 - **Order the sections.** Put what matters most for THIS investigation on top via
   `layout` (a list of section ids). Built-in ids you can position:
-  `crux`, `current_best`, `narrative`, `assessment`, `hypotheses`,
+  `crux`, `current_best`, `narrative`, `findings`, `hypotheses`,
   `open_questions`, `decisions`, `experiments`.
 - **Add custom sections** that fit the domain, using a block `kind`:
   `text`, `bullet_list`, `key_value`, `table`, `status_list`. Examples: a
@@ -58,19 +64,18 @@ but before launching real compute — call `design_panel` to tailor the board:
 Decide the layout ONCE; after that, call `design_panel` only to refresh a custom
 section's `data` as results come in (pass the same section id with new data).
 You supply DATA, never markup. Built-in sections keep updating through
-`update_research_state`/`assess` regardless of layout. If the default board fits
+`update_research_state` regardless of layout. If the default board fits
 the run, you may skip this entirely.
 
 ## Your Tools — READ THIS CAREFULLY
 
-Your ONLY available tools are exactly these eight:
+Your ONLY available tools are exactly these seven:
 - `run_agent` — launch a research agent inside Docker (always include a `rationale`: which hypothesis it tests and why the compute is worth it)
 - `check_workspace` — list or read files in the workspace (use action="read" to read a file)
 - `read_agent_logs` — read logs and status for a running or completed agent run
 - `ask_user` — present a message or question to the human and wait for their response
 - `update_session` — save key findings, open questions, or phase to session state
-- `update_research_state` — update your world model (hypotheses, findings, dead-ends, crux, current best, narrative, decisions)
-- `assess` — record your read of the situation and whether to engage the human
+- `update_research_state` — update your world model (findings, hypotheses, crux, current best, narrative, decisions, incidents)
 - `design_panel` — shape the Research whiteboard for this run: order the sections and define custom ones (see "Design Your Research Panel" below)
 
 You do NOT have access to `Bash`, `Read`, `Write`, `Edit`, `Grep`, `Glob`, `Agent`, `ToolSearch`, `AskUserQuestion`, or any other Claude Code built-in tool. Do not call them — they will always fail with an error.

--- a/templates/manager/tools.yaml
+++ b/templates/manager/tools.yaml
@@ -166,8 +166,13 @@ tools:
       findings:
         type: array
         items:
-          type: string
-        description: Confirmed results/observations to record (append, deduped).
+          type: object
+        description: |
+          The SPINE of the world model: each finding is a unit of insight the run
+          produced. Append, deduped by text. An item may be a bare string or an
+          object: {"text": "...", "insight": "the so-what / implication"(optional),
+          "kind": "result|dead_end|note"(optional, default result)}. Record a
+          finding, then attach the decisions that produced it via decision.finding.
         required: false
       dead_ends:
         type: array
@@ -196,55 +201,27 @@ tools:
       decision:
         type: object
         description: |
-          A decision just made, to log with its reasoning:
+          A decision just made, to log with its reasoning. Every decision belongs
+          to the finding it helped produce, or to "global" for a project-wide fork
+          (e.g. orchestration: which agent to run, how to scope, when to stop):
           {"question": "...", "chosen": "...", "rationale": "...",
-           "options": ["...", "..."](optional)}.
+           "options": ["...", "..."](optional),
+           "finding": "F2 | global"(the finding id this fork serves; default global),
+           "layer": "hypothesis|method|experiment_design|interpretation"(optional)}.
+          Layers: hypothesis = what to test; method = the way (library, metric,
+          threshold, prompt); experiment_design = dataset/baseline/scope/seed;
+          interpretation = what the result means / whether it counts as a finding.
+          A decision made before its finding exists may use "global" for now.
+        required: false
+      incident:
+        type: string
+        description: |
+          Self-reported struggle — if you got confused, hit an error, called a
+          tool that doesn't exist, or recovered from a mistake, describe it here.
+          Recorded on the whiteboard as a self_reported incident. Tool errors are
+          also auto-logged; don't paper over what went wrong.
         required: false
     returns: Confirmation of what was updated.
-
-  - name: assess
-    description: |
-      Record YOUR READ of the situation at this moment — the reflection a good
-      PI does before acting. Call this at meaningful junctures: after an agent
-      completes, before launching an expensive run, and before deciding whether
-      to involve the human. It is reflection, not action: if you conclude the
-      human should be engaged, you still call ask_user afterward. These
-      assessments are shown to the human and are how your judgement is reviewed.
-    parameters:
-      situation:
-        type: string
-        description: What is happening / what just changed.
-        required: true
-      uncertainty:
-        type: string
-        description: What you are unsure about right now.
-        required: false
-      crux:
-        type: string
-        description: The decisive factor — what most affects the next decision.
-        required: false
-      decision_pending:
-        type: string
-        description: The decision on the table, if any (else leave empty).
-        required: false
-      engage_user:
-        type: boolean
-        description: |
-          Whether a human expert in your seat would pull the user in right now.
-        required: true
-      rationale:
-        type: string
-        description: Why you would or would not engage the user.
-        required: false
-      issue:
-        type: string
-        description: |
-          If you hit a problem at this juncture — confusion, an error, a tool
-          that didn't work, or a mistake you recovered from — describe it
-          honestly. It is recorded as an incident on the whiteboard. Don't hide
-          struggle; a faithful record of what went wrong is the point.
-        required: false
-    returns: Confirmation, with a nudge to call ask_user if you chose to engage.
 
   - name: design_panel
     description: |
@@ -252,9 +229,9 @@ tools:
       the investigation: choose the ORDER of sections and define CUSTOM sections
       from a fixed block vocabulary. Do this ONCE near the start (after you
       understand the idea); afterwards call it only to refresh a custom section's
-      data. The built-in sections (crux, current_best, narrative, assessment,
+      data. The built-in sections (crux, current_best, narrative, findings,
       hypotheses, open_questions, decisions, experiments) still come from
-      update_research_state/assess — list their ids in `layout` to position them
+      update_research_state — list their ids in `layout` to position them
       among your custom ones. A molecule-screening run might add a "candidates"
       table; an ML run a "leaderboard"; a proof a "lemmas" status_list. Supply
       DATA, never markup — all text is escaped before display.
@@ -265,7 +242,7 @@ tools:
           type: string
         description: |
           Ordered list of section ids to render, top to bottom. May mix built-in
-          ids (crux, current_best, narrative, assessment, hypotheses,
+          ids (crux, current_best, narrative, findings, hypotheses,
           open_questions, decisions, experiments) and your custom section ids.
           Omit or leave empty to keep the default order. Any custom section not
           listed is appended at the end.

--- a/tests/test_research_state.py
+++ b/tests/test_research_state.py
@@ -145,7 +145,10 @@ def test_incident_records_author_and_dedups(tmp_path):
 def test_blank_state_has_v3_shape(tmp_path):
     r = _fresh(tmp_path)
     assert r.state["schema_version"] == SCHEMA_VERSION
-    assert "assessments" in r.state  # retained (removed with the tool in a later PR)
+    # assessments node removed in PR 2 (engage signal moved onto decisions).
+    assert "assessments" not in r.state
+    assert not hasattr(r, "add_assessment")
+    assert not hasattr(r, "latest_assessment")
 
 
 def test_forward_migration_from_pre_v3_state(tmp_path):
@@ -223,3 +226,58 @@ def test_snapshot_and_digest_include_findings(tmp_path):
 def test_empty_digest_message(tmp_path):
     r = _fresh(tmp_path)
     assert "empty" in r.digest_section()
+
+
+# ------------------------------------------- manager authoring (PR 2 wiring)
+
+def _executor(tmp_path):
+    """A standalone ToolExecutor backed by a fresh ResearchState — enough to
+    exercise the update_research_state authoring path without a live session."""
+    from interactive.tools import ToolExecutor
+    from interactive.channel import TerminalChannel
+    return ToolExecutor(
+        work_dir=tmp_path, session=None, idea_file=tmp_path,
+        provider="claude", project_root=tmp_path,
+        channel=TerminalChannel(), research=ResearchState(tmp_path))
+
+
+def test_update_research_state_writes_rich_findings_and_decisions(tmp_path):
+    ex = _executor(tmp_path)
+    out = ex._update_research_state({
+        "findings": [
+            {"text": "CoT lifts GSM8K +12pts", "insight": "prompting matters",
+             "kind": "result"},
+            "a bare-string finding",
+        ],
+        "decision": {
+            "question": "Which benchmark?", "chosen": "GSM8K",
+            "rationale": "most standard", "options": ["GSM8K", "MATH"],
+            "finding": "F1", "layer": "experiment_design",
+        },
+        "incident": "hit a transient docker error, retried",
+    })
+    assert "finding" in out and "decision" in out and "incident" in out
+    r = ex.research
+    f = r.state["findings"][0]
+    assert f["id"] == "F1" and f["insight"] == "prompting matters"
+    d = r.state["decisions"][0]
+    assert d["finding"] == "F1" and d["layer"] == "experiment_design"
+    assert {o["text"]: o["status"] for o in d["options"]}["GSM8K"] == "chosen"
+    assert r.state["incidents"][0]["kind"] == "self_reported"
+
+
+def test_update_research_state_decision_defaults_to_global(tmp_path):
+    ex = _executor(tmp_path)
+    ex._update_research_state({"decision": {"question": "dispatch which agent?",
+                                            "chosen": "experiment_runner"}})
+    d = ex.research.state["decisions"][0]
+    assert d["finding"] == "global" and d["layer"] is None
+
+
+def test_assess_tool_is_gone(tmp_path):
+    ex = _executor(tmp_path)
+    assert not hasattr(ex, "_assess")
+    # Unknown tool is auto-logged as an incident rather than dispatched.
+    out = ex.execute("assess", {"situation": "x", "engage_user": True})
+    assert "Unknown tool" in out
+    assert any(i["kind"] == "unknown_tool" for i in ex.research.state["incidents"])


### PR DESCRIPTION
## Summary

**PR 2 of the v3 world-model series.** Teaches the manager to *author* the richer model introduced in PR 1, and retires the `assessments` node now that the world model is **shared multi-agent memory** rather than the manager's human-facing metacognition log.

> **Stacked on [PR #128](https://github.com/ChicagoHAI/NeuriCo/pull/128)** — base is `feat/world-model-v3-data-model`, so merge PR 1 first. This PR's diff is just the authoring layer.

## Authoring (`update_research_state`)

- **findings** accept rich objects `{text, insight, kind}` (or bare strings) — the spine other nodes hang off.
- **decision** gains `finding` (an `F-id`, or `"global"` for a project-wide/orchestration fork) and `layer` (`hypothesis | method | experiment_design | interpretation`).
- new **`incident`** field for self-reported struggle (replaces `assess(issue=...)`); tool/unknown-tool errors are still auto-logged in `execute()`.

## Assessments removed

- Drop the `assess` tool (`tools.yaml` + dispatch), `_assess`, `add_assessment`, `latest_assessment`, the snapshot/digest references, and the `assessment` builtin section.
- The engage signal moves onto each decision as `should_engage` — left **empty** for now; a future human-interactor subagent will own it.
- The whiteboard's now-dormant assessment renderer is left for **PR 3** (it already no-ops when no assessment data is present, so nothing breaks).

## Prompt

`system_prompt.txt`: replaced "Assess Before You Act" with **"Findings Are the Spine"** (+ the four layers and when to use `global`), tool list eight→seven, added the `refuted` hypothesis status.

## Testing

- **18/18 pass** (`pytest tests/test_research_state.py`) — PR 1's 15 + 3 new `ToolExecutor` authoring tests (rich findings, layered decision with normalized options, self-reported incident, `assess` tool gone).
- `py_compile` clean across `research_state.py` / `tools.py` / `manager.py` / `web_server.py`.
- `tools.yaml` validates: 7 tools, no `assess`.
- End-to-end smoke through the real `ToolExecutor` confirms the full authoring path and that `latest_assessment` is gone from the snapshot.

## Scope

`src/interactive/{research_state,tools,manager}.py`, `templates/manager/{tools.yaml,system_prompt.txt}`, tests — within PR #113's footprint.

## Follow-ups

- **PR 3** — whiteboard rendering: decisions grouped by finding/layer; remove the dormant assessment pane.
- **PR 4** — concurrency-safe multi-writer storage (gated on sub-agents writing).
- **Future** — human-interactor subagent (`should_engage`) and review subagent (`importance`).
