### PR TITLE
feat: add runtime compute backend selection and DSI Slurm skill

### DIFF
--- a/src/agents/autoresearch_proposer.py
+++ b/src/agents/autoresearch_proposer.py
@@ -19,6 +19,7 @@ import time
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from core.compute_backend import get_runtime_compute_backend
 from core.security import sanitize_text
 
 
@@ -35,12 +36,81 @@ TRANSCRIPT_FLAGS = {
 }
 
 
+def _skill_root_for_provider(provider: str) -> str:
+    return f".{provider}/skills"
+
+
+def _generate_compute_backend_section(idea_spec: Dict[str, Any], provider: str = "claude") -> str:
+    """Return proposer-only backend constraints for explicit remote backends."""
+    backend = get_runtime_compute_backend(idea_spec)
+    skill_root = _skill_root_for_provider(provider)
+    dsi_skill_path = f"{skill_root}/dsi-slurm/SKILL.md"
+    if backend == "dsi-slurm":
+        return f"""
+═══════════════════════════════════════════════════════════════════════════════
+                              COMPUTE BACKEND: dsi-slurm
+═══════════════════════════════════════════════════════════════════════════════
+
+Runtime execution is pinned to DSI Slurm by `--compute-backend dsi-slurm`.
+Any proposal that requires cluster training, evaluation, or batch execution
+must tell comment mode to use `{skill_root}/dsi-slurm/` by reading
+`{dsi_skill_path}` and following that skill's guidance.
+
+The proposal must preserve this compute invariant: the local workspace is for
+orchestration and reporting only. Comment mode must not run training,
+evaluation, model selection, benchmarking, scored-output generation, smoke
+tests, or result-changing validation locally. Local commands may inspect files,
+edit code, prepare scripts, package inputs, and verify already-copied results
+only. DSI Slurm is the only allowed compute surface for experiment workload.
+
+The proposal should preserve the backend lifecycle contract: setup/discovery
+checks first, use only the runtime-provided remote workspace, cheap smoke job
+when possible, explicit resource requests, and copy-back of all required
+results from the remote workspace to the same relative local paths. Comment
+mode must also copy each terminal job's `dsi-slurm-artifacts/<JOB_ID>/` bundle
+back to the local workspace. NeuriCo runtime creates/removes the remote
+workspace and archives local `dsi-slurm-artifacts/`; comment mode must not
+remove the remote workspace itself.
+
+Do not propose Modal, local GPU fallback, or any other off-machine backend. If
+missing DSI Slurm configuration or access would block the proposed change, make
+that blocker explicit in the proposal rather than suggesting a backend switch.
+
+"""
+    if backend == "modal":
+        return """
+═══════════════════════════════════════════════════════════════════════════════
+                              COMPUTE BUDGET
+═══════════════════════════════════════════════════════════════════════════════
+
+If your proposal would require GPU model training, fine-tuning, or LLM serving
+that exceeds the local container, the workspace may have a compute-backend
+skill available. Do not propose a backend by name. Instead, scope your proposal
+so that:
+
+1. If a compute backend is available, you state the proposal's compute needs
+   (model size, GPU memory, expected wall time) and note that an off-machine
+   backend may be required — the experiment_runner agent will discover and
+   pick the appropriate skill.
+2. If no compute backend is available, propose only changes that fit on the
+   local container (smaller models, fewer steps, eval-only paths).
+
+Treat compute-backend availability as a constraint to scope around, not as a
+licence to propose unbounded training jobs.
+
+═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    return ""
+
+
 def generate_autoresearch_proposal_prompt(
     idea: Dict[str, Any],
     work_dir: Path,
     parent_sha: str,
     attempt_dir: Path,
     templates_dir: Path,
+    provider: str = "claude",
     attempt_history: Optional[list[Dict[str, Any]]] = None,
 ) -> str:
     """
@@ -81,6 +151,7 @@ def generate_autoresearch_proposal_prompt(
         attempt_dir=str(attempt_dir),
         proposal_path=str(attempt_dir / "proposal.md"),
         public_context=context,
+        compute_backend_section=_generate_compute_backend_section(idea_spec, provider=provider),
     )
 
 
@@ -154,6 +225,7 @@ def run_autoresearch_proposer(
         parent_sha=parent_sha,
         attempt_dir=attempt_dir,
         templates_dir=Path(templates_dir),
+        provider=provider,
         attempt_history=attempt_history,
     )
 

--- a/src/agents/comment_handler.py
+++ b/src/agents/comment_handler.py
@@ -140,7 +140,8 @@ def resolve_workspace(
 def generate_comment_prompt(
     idea: Dict[str, Any],
     work_dir: Path,
-    templates_dir: Path
+    templates_dir: Path,
+    provider: str = "claude",
 ) -> str:
     """
     Generate the comment handler prompt by combining template with idea comments.
@@ -156,7 +157,7 @@ def generate_comment_prompt(
     from templates.prompt_generator import PromptGenerator
 
     generator = PromptGenerator(templates_dir)
-    return generator.generate_comment_prompt(idea, work_dir)
+    return generator.generate_comment_prompt(idea, work_dir, provider=provider)
 
 
 def run_comment_handler(
@@ -219,9 +220,34 @@ def run_comment_handler(
     print("-" * 40)
     print()
 
+    from core.dsi_slurm_remote import dsi_slurm_remote_workspace
+
+    with dsi_slurm_remote_workspace(idea, work_dir) as dsi_remote_info:
+        if dsi_remote_info is not None:
+            print(f"DSI remote workspace: {dsi_remote_info['remote_root']}")
+        return _run_comment_handler_with_remote_workspace(
+            idea=idea,
+            work_dir=work_dir,
+            provider=provider,
+            templates_dir=templates_dir,
+            timeout=timeout,
+            full_permissions=full_permissions,
+            dsi_remote_info=dsi_remote_info,
+        )
+
+
+def _run_comment_handler_with_remote_workspace(
+    idea: Dict[str, Any],
+    work_dir: Path,
+    provider: str,
+    templates_dir: Path,
+    timeout: int,
+    full_permissions: bool,
+    dsi_remote_info: Optional[Dict[str, str]],
+) -> Dict[str, Any]:
     # Generate prompt
     print("Generating comment handler prompt...")
-    prompt = generate_comment_prompt(idea, work_dir, templates_dir)
+    prompt = generate_comment_prompt(idea, work_dir, templates_dir, provider=provider)
 
     # Save prompt for reference
     logs_dir = work_dir / "logs"
@@ -267,6 +293,9 @@ def run_comment_handler(
     # Set environment variables
     env = os.environ.copy()
     env['PYTHONUNBUFFERED'] = '1'
+    if dsi_remote_info is not None:
+        env["NEURICO_DSI_REMOTE_ROOT"] = dsi_remote_info["remote_root"]
+        env["NEURICO_DSI_RSYNC_REMOTE_ROOT"] = dsi_remote_info["rsync_remote_root"]
 
     if provider == "gemini":
         env['GEMINI_CLI_IDE_DISABLE'] = '1'

--- a/src/core/agent_runner.py
+++ b/src/core/agent_runner.py
@@ -35,6 +35,7 @@ from datetime import datetime
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from core.compute_backend import attach_runtime_compute_backend
 from core.security import sanitize_text
 
 
@@ -154,7 +155,8 @@ def _build_agent_command(provider: str, full_permissions: bool = True,
 
 def _run_cli_agent(cmd: str, prompt: str, work_dir: Path,
                    log_file: Path, transcript_file: Path,
-                   tracker: RunTracker) -> Dict[str, Any]:
+                   tracker: RunTracker,
+                   env_extra: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
     """
     Execute a CLI agent with streaming output capture.
 
@@ -162,6 +164,8 @@ def _run_cli_agent(cmd: str, prompt: str, work_dir: Path,
     """
     env = os.environ.copy()
     env['PYTHONUNBUFFERED'] = '1'
+    if env_extra:
+        env.update(env_extra)
 
     # Disable IDE integration for Gemini CLI
     if 'gemini' in cmd:
@@ -276,43 +280,70 @@ def run_experiment_runner(idea: Dict[str, Any], work_dir: Path, provider: str,
     print(f"   Provider: {provider}")
     print(f"   Work dir: {work_dir}")
 
-    # Generate research prompt
-    prompt_generator = PromptGenerator(templates_dir)
-    prompt = prompt_generator.generate_research_prompt(idea, root_dir=work_dir)
+    from core.dsi_slurm_remote import dsi_slurm_remote_workspace
 
-    # Save prompt
-    prompt_file = work_dir / "logs" / "research_prompt.txt"
-    prompt_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(prompt_file, 'w', encoding='utf-8') as f:
-        f.write(prompt)
+    with dsi_slurm_remote_workspace(idea, work_dir) as dsi_remote_info:
+        env_extra = None
+        if dsi_remote_info is not None:
+            env_extra = {
+                "NEURICO_DSI_REMOTE_ROOT": dsi_remote_info["remote_root"],
+                "NEURICO_DSI_RSYNC_REMOTE_ROOT": dsi_remote_info["rsync_remote_root"],
+            }
+            print(f"   DSI remote workspace: {dsi_remote_info['remote_root']}")
 
-    # Generate session instructions
-    domain = idea.get('idea', {}).get('domain', 'general')
-    session_instructions = generate_instructions(
-        prompt=prompt,
-        work_dir=str(work_dir),
-        use_scribe=use_scribe,
-        domain=domain
-    )
+        # Generate research prompt
+        prompt_generator = PromptGenerator(templates_dir)
+        prompt = prompt_generator.generate_research_prompt(idea, root_dir=work_dir)
 
-    # Save session instructions
-    session_file = work_dir / "logs" / "session_instructions.txt"
-    with open(session_file, 'w', encoding='utf-8') as f:
-        f.write(session_instructions)
+        # Save prompt
+        prompt_file = work_dir / "logs" / "research_prompt.txt"
+        prompt_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(prompt_file, 'w', encoding='utf-8') as f:
+            f.write(prompt)
 
-    # Build and run command
-    cmd = _build_agent_command(provider, full_permissions, use_scribe)
-    if use_scribe:
-        env_extra = {'SCRIBE_RUN_DIR': str(work_dir)}
-        os.environ.update(env_extra)
+        # Generate session instructions
+        domain = idea.get('idea', {}).get('domain', 'general')
+        session_instructions = generate_instructions(
+            prompt=prompt,
+            work_dir=str(work_dir),
+            use_scribe=use_scribe,
+            domain=domain,
+            idea_spec=idea.get('idea', {}),
+            provider=provider,
+        )
 
-    log_file = work_dir / "logs" / f"execution_{provider}.log"
-    transcript_file = work_dir / "logs" / f"execution_{provider}_transcript.jsonl"
+        # Save session instructions
+        session_file = work_dir / "logs" / "session_instructions.txt"
+        with open(session_file, 'w', encoding='utf-8') as f:
+            f.write(session_instructions)
 
-    # Experiment runner uses session_instructions (not raw prompt) as input
-    result = _run_cli_agent(cmd, session_instructions, work_dir, log_file, transcript_file, tracker)
+        # Build and run command
+        cmd = _build_agent_command(provider, full_permissions, use_scribe)
+        if use_scribe:
+            env_extra = env_extra or {}
+            env_extra['SCRIBE_RUN_DIR'] = str(work_dir)
 
-    return result
+        log_file = work_dir / "logs" / f"execution_{provider}.log"
+        transcript_file = work_dir / "logs" / f"execution_{provider}_transcript.jsonl"
+
+        # Experiment runner uses session_instructions (not raw prompt) as input
+        result = _run_cli_agent(
+            cmd,
+            session_instructions,
+            work_dir,
+            log_file,
+            transcript_file,
+            tracker,
+            env_extra=env_extra,
+        )
+        if result.get("success") and dsi_remote_info is not None:
+            from core.dsi_slurm_artifacts import archive_dsi_slurm_artifacts
+
+            archived_dsi_artifacts = archive_dsi_slurm_artifacts(work_dir)
+            if archived_dsi_artifacts is not None:
+                result["dsi_slurm_artifacts"] = str(archived_dsi_artifacts)
+
+        return result
 
 
 def run_paper_writer(idea: Dict[str, Any], work_dir: Path, provider: str,
@@ -361,16 +392,35 @@ def run_comment_handler(idea: Dict[str, Any], work_dir: Path, provider: str,
     if not comments:
         return {'success': False, 'error': 'No comments found in idea file'}
 
-    prompt = generate_comment_prompt(idea, work_dir, templates_dir)
+    from core.dsi_slurm_remote import dsi_slurm_remote_workspace
 
-    # Build and run command
-    cmd = _build_agent_command(provider, full_permissions)
-    log_file = work_dir / "logs" / f"comment_handler_{provider}.log"
-    transcript_file = work_dir / "logs" / f"comment_handler_{provider}_transcript.jsonl"
+    with dsi_slurm_remote_workspace(idea, work_dir) as dsi_remote_info:
+        env_extra = None
+        if dsi_remote_info is not None:
+            env_extra = {
+                "NEURICO_DSI_REMOTE_ROOT": dsi_remote_info["remote_root"],
+                "NEURICO_DSI_RSYNC_REMOTE_ROOT": dsi_remote_info["rsync_remote_root"],
+            }
+            print(f"   DSI remote workspace: {dsi_remote_info['remote_root']}")
 
-    result = _run_cli_agent(cmd, prompt, work_dir, log_file, transcript_file, tracker)
+        prompt = generate_comment_prompt(idea, work_dir, templates_dir, provider=provider)
 
-    return result
+        # Build and run command
+        cmd = _build_agent_command(provider, full_permissions)
+        log_file = work_dir / "logs" / f"comment_handler_{provider}.log"
+        transcript_file = work_dir / "logs" / f"comment_handler_{provider}_transcript.jsonl"
+
+        result = _run_cli_agent(
+            cmd,
+            prompt,
+            work_dir,
+            log_file,
+            transcript_file,
+            tracker,
+            env_extra=env_extra,
+        )
+
+        return result
 
 
 # Agent dispatch table
@@ -455,6 +505,12 @@ def main():
         help="AI provider (default: claude)"
     )
     parser.add_argument(
+        "--compute-backend",
+        default="local",
+        choices=["local", "dsi-slurm", "modal"],
+        help="Compute backend for experiment/comment agents (default: local)"
+    )
+    parser.add_argument(
         "--run-id",
         required=True,
         help="Unique identifier for this invocation"
@@ -488,6 +544,7 @@ def main():
     import yaml
     with open(args.idea_file, 'r') as f:
         idea = yaml.safe_load(f)
+    attach_runtime_compute_backend(idea, args.compute_backend)
 
     work_dir = Path(args.workspace)
 

--- a/src/core/autoresearch.py
+++ b/src/core/autoresearch.py
@@ -21,6 +21,7 @@ from datetime import datetime
 
 from core.scorer import load_scoring_results
 from core.scoring_seal import seal_scoring_files, unseal_scoring_files
+from core.dsi_slurm_artifacts import DSI_SLURM_ARTIFACTS_DIR, move_dsi_slurm_artifacts
 
 try:
     from git import Repo, InvalidGitRepositoryError, NoSuchPathError
@@ -1599,6 +1600,7 @@ class AutoResearchController:
             unseal_scoring_files(self.work_dir, sealed_dir)
 
         if pre_scoring_error is not None:
+            self._move_dsi_slurm_artifacts_to_attempt(attempt_dir)
             candidate_summary = ScoreSummary(
                 valid=False,
                 source="candidate",
@@ -1685,6 +1687,7 @@ class AutoResearchController:
             stage="candidate",
             scorer_result=scorer_result,
         )
+        self._move_dsi_slurm_artifacts_to_attempt(attempt_dir)
 
         candidate_checkpoint: Optional[Checkpoint] = None
         child_sha: Optional[str] = None
@@ -1805,6 +1808,12 @@ class AutoResearchController:
         results_path = self.work_dir / "scoring" / "results.json"
         if results_path.exists():
             results_path.unlink()
+
+    def _move_dsi_slurm_artifacts_to_attempt(self, attempt_dir: Path) -> None:
+        move_dsi_slurm_artifacts(
+            self.work_dir,
+            Path(attempt_dir) / DSI_SLURM_ARTIFACTS_DIR,
+        )
 
     def _record_failed_before_checkpoint(
         self,

--- a/src/core/compute_backend.py
+++ b/src/core/compute_backend.py
@@ -1,0 +1,55 @@
+"""Runtime compute backend selection."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, Optional
+
+
+VALID_COMPUTE_BACKENDS = ("local", "dsi-slurm", "modal")
+RUNTIME_COMPUTE_BACKEND_KEY = "_runtime_compute_backend"
+
+
+def normalize_compute_backend(value: Optional[str]) -> str:
+    if value in (None, ""):
+        return "local"
+    if value not in VALID_COMPUTE_BACKENDS:
+        raise ValueError(
+            f"Invalid compute backend: {value}. "
+            f"Must be one of: {', '.join(VALID_COMPUTE_BACKENDS)}"
+        )
+    return value
+
+
+def attach_runtime_compute_backend(idea: Dict[str, Any], backend: Optional[str]) -> Dict[str, Any]:
+    """Attach the CLI-selected backend to this in-memory idea only."""
+    normalized = normalize_compute_backend(backend)
+    # Runtime code sometimes passes the full idea object, while prompt builders
+    # often receive only idea["idea"]. Store the transient marker in both
+    # places so both call shapes agree; strip it before persisting idea YAML.
+    idea[RUNTIME_COMPUTE_BACKEND_KEY] = normalized
+    idea_spec = idea.get("idea")
+    if isinstance(idea_spec, dict):
+        idea_spec[RUNTIME_COMPUTE_BACKEND_KEY] = normalized
+    return idea
+
+
+def get_runtime_compute_backend(idea_or_spec: Dict[str, Any]) -> str:
+    """Read the CLI-selected backend. Missing means local."""
+    if not isinstance(idea_or_spec, dict):
+        return "local"
+    value = idea_or_spec.get(RUNTIME_COMPUTE_BACKEND_KEY)
+    if value is None and isinstance(idea_or_spec.get("idea"), dict):
+        value = idea_or_spec["idea"].get(RUNTIME_COMPUTE_BACKEND_KEY)
+    return normalize_compute_backend(value)
+
+
+def without_runtime_compute_backend(idea: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy with transient backend markers removed before persistence."""
+    cleaned = copy.deepcopy(idea)
+    if isinstance(cleaned, dict):
+        cleaned.pop(RUNTIME_COMPUTE_BACKEND_KEY, None)
+        idea_spec = cleaned.get("idea")
+        if isinstance(idea_spec, dict):
+            idea_spec.pop(RUNTIME_COMPUTE_BACKEND_KEY, None)
+    return cleaned

--- a/src/core/dsi_slurm_artifacts.py
+++ b/src/core/dsi_slurm_artifacts.py
@@ -1,0 +1,59 @@
+"""Runtime handling for DSI Slurm artifact bundles."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+
+DSI_SLURM_ARTIFACTS_DIR = "dsi-slurm-artifacts"
+
+
+def move_dsi_slurm_artifacts(work_dir: Path, destination: Path) -> Optional[Path]:
+    """Move transient DSI artifacts to destination and remove the source on success."""
+    work_dir = Path(work_dir)
+    source = work_dir / DSI_SLURM_ARTIFACTS_DIR
+    if not source.exists():
+        return None
+
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    temp_parent = Path(
+        tempfile.mkdtemp(
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+            dir=destination.parent,
+        )
+    )
+    temp_destination = temp_parent / destination.name
+    shutil.copytree(source, temp_destination)
+
+    if not temp_destination.exists() or not any(temp_destination.iterdir()):
+        shutil.rmtree(temp_parent, ignore_errors=True)
+        shutil.rmtree(source)
+        return None
+
+    destination.mkdir(parents=True, exist_ok=True)
+    for child in temp_destination.iterdir():
+        target = destination / child.name
+        if target.exists():
+            if target.is_dir():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
+        child.replace(target)
+    shutil.rmtree(temp_parent, ignore_errors=True)
+    shutil.rmtree(source)
+    return destination
+
+
+def archive_dsi_slurm_artifacts(work_dir: Path) -> Optional[Path]:
+    """Move transient DSI artifacts into the normal logs archive."""
+    work_dir = Path(work_dir)
+    return move_dsi_slurm_artifacts(
+        work_dir,
+        work_dir / "logs" / DSI_SLURM_ARTIFACTS_DIR,
+    )

--- a/src/core/dsi_slurm_remote.py
+++ b/src/core/dsi_slurm_remote.py
@@ -1,0 +1,158 @@
+"""Runtime lifecycle shell for dsi-cluster remote workspaces."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import json
+from pathlib import Path
+import re
+import shlex
+import subprocess
+from typing import Any, Callable, Dict, Iterator, Optional
+
+from core.compute_backend import get_runtime_compute_backend
+
+
+REMOTE_WORKSPACE_INFO = "dsi_slurm_remote_workspace.json"
+_VALID_WORKSPACE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def is_dsi_slurm_backend(idea: Dict[str, Any]) -> bool:
+    """Return True only when the runtime flag selects dsi-slurm compute."""
+    return get_runtime_compute_backend(idea) == "dsi-slurm"
+
+
+def remote_workspace_info_path(work_dir: Path) -> Path:
+    return Path(work_dir) / ".neurico" / REMOTE_WORKSPACE_INFO
+
+
+def _remote_workspace_name(work_dir: Path) -> str:
+    name = Path(work_dir).name.strip()
+    if not name:
+        raise ValueError("Cannot create dsi-cluster workspace for an unnamed local workspace")
+    if not _VALID_WORKSPACE_NAME.fullmatch(name) or name in {".", ".."}:
+        raise ValueError(
+            "Invalid dsi-cluster workspace name: "
+            f"{name!r}. Use only letters, numbers, '.', '_', and '-'."
+        )
+    return name
+
+
+def build_remote_workspace_info(work_dir: Path) -> Dict[str, str]:
+    """Build the provider-neutral remote workspace contract for the agent."""
+    workspace_name = _remote_workspace_name(work_dir)
+    remote_root = f"$HOME/neurico_workspaces/{workspace_name}"
+    return {
+        "backend": "dsi-slurm",
+        "ssh_host": "login.ds",
+        "workspace_name": workspace_name,
+        "remote_root": remote_root,
+        "rsync_remote_root": f"login.ds:~/neurico_workspaces/{workspace_name}/",
+    }
+
+
+def write_remote_workspace_info(work_dir: Path, info: Dict[str, str]) -> Path:
+    path = remote_workspace_info_path(work_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(info, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def clear_remote_workspace_info(work_dir: Path) -> None:
+    remote_workspace_info_path(work_dir).unlink(missing_ok=True)
+
+
+def create_remote_workspace(
+    work_dir: Path,
+    *,
+    run: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> Dict[str, str]:
+    """
+    Create the dsi-cluster remote workspace and record its location locally.
+
+    Each dsi-slurm stage starts from a fresh runtime-owned remote root. If a
+    previous stage left the deterministic root behind, remove it first and
+    verify that it is gone before creating the new empty workspace.
+    """
+    info = build_remote_workspace_info(work_dir)
+    quoted_name = shlex.quote(info["workspace_name"])
+    command = (
+        "set -euo pipefail; "
+        'base="$HOME/neurico_workspaces"; '
+        'mkdir -p "$base"; '
+        f'root="$base"/{quoted_name}; '
+        'rm -rf -- "$root"; '
+        'if [ -e "$root" ]; then '
+        'echo "Failed to remove stale dsi-cluster remote workspace before create: $root" >&2; '
+        'find "$root" -maxdepth 3 -print >&2 || true; '
+        "exit 18; "
+        "fi; "
+        'mkdir -p "$root"'
+    )
+    run(
+        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=20", info["ssh_host"], command],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    write_remote_workspace_info(work_dir, info)
+    return info
+
+
+def remove_remote_workspace(
+    work_dir: Path,
+    *,
+    run: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> Optional[Dict[str, str]]:
+    """Remove the recorded dsi-cluster remote workspace, then clear the record."""
+    path = remote_workspace_info_path(work_dir)
+    if not path.exists():
+        return None
+
+    info = json.loads(path.read_text(encoding="utf-8"))
+    quoted_name = shlex.quote(info["workspace_name"])
+    command = (
+        "set -euo pipefail; "
+        'base="$HOME/neurico_workspaces"; '
+        f'root="$base"/{quoted_name}; '
+        'rm -rf -- "$root"; '
+        'if [ -e "$root" ]; then '
+        'echo "Failed to remove dsi-cluster remote workspace after stage: $root" >&2; '
+        'find "$root" -maxdepth 3 -print >&2 || true; '
+        "exit 18; "
+        "fi"
+    )
+    run(
+        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=20", info["ssh_host"], command],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    clear_remote_workspace_info(work_dir)
+    return info
+
+
+@contextmanager
+def dsi_slurm_remote_workspace(
+    idea: Dict[str, Any],
+    work_dir: Path,
+    *,
+    run: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> Iterator[Optional[Dict[str, str]]]:
+    """
+    Runtime lifecycle shell for dsi-slurm stages.
+
+    No-op unless --compute-backend is exactly dsi-slurm.
+    """
+    if not is_dsi_slurm_backend(idea):
+        yield None
+        return
+
+    info = create_remote_workspace(work_dir, run=run)
+    try:
+        yield info
+    finally:
+        try:
+            remove_remote_workspace(work_dir, run=run)
+        except Exception as exc:
+            print(f"Warning: failed to remove dsi-cluster remote workspace: {exc}")

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -530,7 +530,18 @@ class ResearchPipelineOrchestrator:
         import os
         from core.security import sanitize_text
 
+        dsi_remote_info = None
         try:
+            from core.dsi_slurm_remote import (
+                create_remote_workspace,
+                is_dsi_slurm_backend,
+                remove_remote_workspace,
+            )
+
+            if is_dsi_slurm_backend(idea):
+                dsi_remote_info = create_remote_workspace(self.work_dir)
+                print(f"DSI remote workspace: {dsi_remote_info['remote_root']}")
+
             # Generate prompt (without Phase 0, resource-aware)
             from templates.prompt_generator import PromptGenerator
 
@@ -552,7 +563,12 @@ class ResearchPipelineOrchestrator:
             # Generate session instructions (resource-aware version)
             domain = idea.get("idea", {}).get("domain", "general")
             session_instructions = generate_instructions(
-                prompt=prompt, work_dir=str(self.work_dir), use_scribe=use_scribe, domain=domain
+                prompt=prompt,
+                work_dir=str(self.work_dir),
+                use_scribe=use_scribe,
+                domain=domain,
+                idea_spec=idea.get("idea", {}),
+                provider=provider,
             )
 
             # Save session instructions
@@ -601,6 +617,9 @@ class ResearchPipelineOrchestrator:
             # Set environment
             env = os.environ.copy()
             env["PYTHONUNBUFFERED"] = "1"
+            if dsi_remote_info is not None:
+                env["NEURICO_DSI_REMOTE_ROOT"] = dsi_remote_info["remote_root"]
+                env["NEURICO_DSI_RSYNC_REMOTE_ROOT"] = dsi_remote_info["rsync_remote_root"]
             if use_scribe:
                 env["SCRIBE_RUN_DIR"] = str(self.work_dir)
 
@@ -661,6 +680,12 @@ class ResearchPipelineOrchestrator:
                 "log_file": str(log_file),
                 "transcript_file": str(transcript_file),
             }
+            if success and dsi_remote_info is not None:
+                from core.dsi_slurm_artifacts import archive_dsi_slurm_artifacts
+
+                archived_dsi_artifacts = archive_dsi_slurm_artifacts(self.work_dir)
+                if archived_dsi_artifacts is not None:
+                    result["dsi_slurm_artifacts"] = str(archived_dsi_artifacts)
 
             self.state.complete_stage("experiment_runner", success, result)
 
@@ -678,6 +703,15 @@ class ResearchPipelineOrchestrator:
             result = {"success": False, "error": str(e)}
             self.state.complete_stage("experiment_runner", False, result)
             raise
+        finally:
+            if dsi_remote_info is not None:
+                try:
+                    remove_remote_workspace(self.work_dir)
+                except Exception as cleanup_error:
+                    print(
+                        "⚠️  Failed to remove dsi-cluster remote workspace: "
+                        f"{cleanup_error}"
+                    )
 
     # ---- Scoring-mode helpers (rule_maker / scorer / seal) ---------------
     # These methods are only invoked when run_pipeline(scoring_enabled=True).

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -35,6 +35,11 @@ sys.path.insert(0, str(_PROJECT_ROOT))
 from core.idea_manager import IdeaManager
 from core.config_loader import ConfigLoader
 from core.security import sanitize_text
+from core.compute_backend import (
+    attach_runtime_compute_backend,
+    normalize_compute_backend,
+    without_runtime_compute_backend,
+)
 from templates.prompt_generator import PromptGenerator
 from templates.research_agent_instructions import generate_instructions
 
@@ -140,6 +145,7 @@ class ResearchRunner:
         continue_autoresearch: bool = False,
         bootstrap_autoresearch_baseline: bool = False,
         proposer_timeout: int = 900,
+        compute_backend: str = "local",
     ) -> Dict[str, Any]:
         """
         Execute research for a given idea.
@@ -174,6 +180,8 @@ class ResearchRunner:
         print(f"🚀 Starting research: {idea_id}")
         print(f"   Provider: {provider}")
         print(f"   GitHub: {'Enabled' if self.use_github else 'Disabled'}")
+        compute_backend = normalize_compute_backend(compute_backend)
+        print(f"   Compute backend: {compute_backend}")
         autoresearch_modes = [
             name
             for name, enabled in (
@@ -200,6 +208,7 @@ class ResearchRunner:
         idea = self.idea_manager.get_idea(idea_id)
         if idea is None:
             raise ValueError(f"Idea not found: {idea_id}")
+        attach_runtime_compute_backend(idea, compute_backend)
 
         idea_spec = idea.get("idea", {})
         title = idea_spec.get("title", "Untitled Research")
@@ -279,7 +288,12 @@ class ResearchRunner:
                     # Save updated metadata
                     idea_path = self.idea_manager.ideas_dir / "submitted" / f"{idea_id}.yaml"
                     with open(idea_path, "w", encoding="utf-8") as f:
-                        yaml.dump(idea, f, default_flow_style=False, sort_keys=False)
+                        yaml.dump(
+                            without_runtime_compute_backend(idea),
+                            f,
+                            default_flow_style=False,
+                            sort_keys=False,
+                        )
 
                     # Clone repository
                     repo = self.github_manager.clone_repo(
@@ -287,7 +301,10 @@ class ResearchRunner:
                     )
 
                     # Add research metadata
-                    self.github_manager.add_research_metadata(repo_info["local_path"], idea)
+                    self.github_manager.add_research_metadata(
+                        repo_info["local_path"],
+                        without_runtime_compute_backend(idea),
+                    )
 
                     # Commit metadata
                     self.github_manager.commit_and_push(
@@ -324,7 +341,12 @@ class ResearchRunner:
                 )
                 idea_path = self.idea_manager.get_idea_path(idea_id)
                 with open(idea_path, "w", encoding="utf-8") as f:
-                    yaml.dump(idea, f, default_flow_style=False, sort_keys=False)
+                    yaml.dump(
+                        without_runtime_compute_backend(idea),
+                        f,
+                        default_flow_style=False,
+                        sort_keys=False,
+                    )
 
                 print(f"📁 Working directory: {work_dir}\n")
 
@@ -335,6 +357,9 @@ class ResearchRunner:
         # Only create notebooks/ when using scribe
         if use_scribe:
             (work_dir / "notebooks").mkdir(parents=True, exist_ok=True)
+
+        # Copy helper scripts and backend-selected skills to workspace.
+        self._copy_workspace_resources(work_dir, compute_backend=compute_backend)
 
         if continue_autoresearch:
             success = False
@@ -396,7 +421,10 @@ class ResearchRunner:
                     scorer_timeout=scorer_timeout,
                     manifest_trimmer_timeout=manifest_trimmer_timeout,
                     autoresearch_history_dir=autoresearch_history_dir,
-                    prepare_workspace=self._copy_workspace_resources,
+                    prepare_workspace=lambda bootstrap_work_dir: self._copy_workspace_resources(
+                        bootstrap_work_dir,
+                        compute_backend=compute_backend,
+                    ),
                 )
                 success = baseline_result.get("success", False)
             except Exception as e:
@@ -411,9 +439,6 @@ class ResearchRunner:
                 "success": success,
                 "bootstrap_autoresearch_baseline": baseline_result,
             }
-
-        # Copy helper scripts to workspace
-        self._copy_workspace_resources(work_dir)
 
         # Choose execution mode: multi-agent pipeline or legacy monolithic
         if multi_agent:
@@ -593,7 +618,12 @@ class ResearchRunner:
         # Prepare session instructions using the new template
         domain = idea.get("idea", {}).get("domain", "general")
         session_instructions = generate_instructions(
-            prompt=prompt, work_dir=str(work_dir), use_scribe=use_scribe, domain=domain
+            prompt=prompt,
+            work_dir=str(work_dir),
+            use_scribe=use_scribe,
+            domain=domain,
+            idea_spec=idea.get("idea", {}),
+            provider=provider,
         )
 
         # Save session instructions
@@ -745,6 +775,7 @@ https://github.com/ChicagoHAI/neurico
         provider: str = "claude",
         timeout: int = 1800,
         full_permissions: bool = True,
+        compute_backend: str = "local",
     ) -> Dict[str, Any]:
         """
         Run comment mode: make targeted improvements based on user comments.
@@ -775,6 +806,8 @@ https://github.com/ChicagoHAI/neurico
 
         if not idea:
             raise ValueError(f"Idea not found: {idea_id}")
+        compute_backend = normalize_compute_backend(compute_backend)
+        attach_runtime_compute_backend(idea, compute_backend)
 
         idea_spec = idea.get("idea", idea)
         title = idea_spec.get("title", idea_id)
@@ -788,6 +821,7 @@ https://github.com/ChicagoHAI/neurico
             )
 
         print(f"   Title: {title}")
+        print(f"   Compute backend: {compute_backend}")
         print()
 
         # Resolve workspace
@@ -808,6 +842,7 @@ https://github.com/ChicagoHAI/neurico
 
         print(f"   Work dir: {work_dir}")
         print()
+        self._copy_workspace_resources(work_dir, compute_backend=compute_backend)
 
         # Get GitHub URL if available
         github_url = None
@@ -893,7 +928,7 @@ https://github.com/ChicagoHAI/neurico
             print(f"\n⚠️  Paper generation failed (research still succeeded)")
         return paper_result
 
-    def _copy_workspace_resources(self, work_dir: Path):
+    def _copy_workspace_resources(self, work_dir: Path, compute_backend: str = "local"):
         """
         Copy helper scripts and resources to workspace.
 
@@ -902,45 +937,37 @@ https://github.com/ChicagoHAI/neurico
         """
         import shutil
 
-        # Copy Claude Code skills to .claude/skills/
-        # Scripts (like find_papers.py, pdf_chunker.py) live inside skills
-        # and get copied automatically as part of the skill directory
         skills_src = self.project_root / "templates" / "skills"
-        skills_dst = work_dir / ".claude" / "skills"
+        provider_skill_roots = [".claude", ".gemini", ".codex"]
+        compute_skill_names = {"modal-training", "modal-vllm", "dsi-slurm"}
+        backend_skill_names = {
+            "local": set(),
+            "modal": {"modal-training", "modal-vllm"},
+            "dsi-slurm": {"dsi-slurm"},
+        }
+        selected_compute_skills = backend_skill_names[compute_backend]
 
         if skills_src.exists():
-            skills_dst.mkdir(parents=True, exist_ok=True)
-            for skill_dir in skills_src.iterdir():
-                if skill_dir.is_dir():
+            for provider_root in provider_skill_roots:
+                skills_dst = work_dir / provider_root / "skills"
+                skills_dst.mkdir(parents=True, exist_ok=True)
+                copied = 0
+                for skill_dir in skills_src.iterdir():
+                    if not skill_dir.is_dir():
+                        continue
+                    is_compute_skill = skill_dir.name in compute_skill_names
+                    if is_compute_skill and skill_dir.name not in selected_compute_skills:
+                        stale_skill_dir = skills_dst / skill_dir.name
+                        if stale_skill_dir.exists():
+                            shutil.rmtree(stale_skill_dir)
+                        continue
+
                     dst_skill_dir = skills_dst / skill_dir.name
                     if dst_skill_dir.exists():
                         shutil.rmtree(dst_skill_dir)
                     shutil.copytree(skill_dir, dst_skill_dir)
-            print(f"   Copied Claude Code skills to .claude/skills/")
-
-        # Copy skills to .gemini/skills/ for Gemini support
-        gemini_skills_dst = work_dir / ".gemini" / "skills"
-        if skills_src.exists():
-            gemini_skills_dst.mkdir(parents=True, exist_ok=True)
-            for skill_dir in skills_src.iterdir():
-                if skill_dir.is_dir():
-                    dst_skill_dir = gemini_skills_dst / skill_dir.name
-                    if dst_skill_dir.exists():
-                        shutil.rmtree(dst_skill_dir)
-                    shutil.copytree(skill_dir, dst_skill_dir)
-            print(f"   Copied skills to .gemini/skills/")
-
-        # Copy skills to .codex/skills/ for Codex support
-        codex_skills_dst = work_dir / ".codex" / "skills"
-        if skills_src.exists():
-            codex_skills_dst.mkdir(parents=True, exist_ok=True)
-            for skill_dir in skills_src.iterdir():
-                if skill_dir.is_dir():
-                    dst_skill_dir = codex_skills_dst / skill_dir.name
-                    if dst_skill_dir.exists():
-                        shutil.rmtree(dst_skill_dir)
-                    shutil.copytree(skill_dir, dst_skill_dir)
-            print(f"   Copied skills to .codex/skills/")
+                    copied += 1
+                print(f"   Copied {copied} skills to {provider_root}/skills/")
 
         # Add/merge .gitignore for research workspace
         self._setup_workspace_gitignore(work_dir)
@@ -1083,6 +1110,12 @@ def main():
         default="claude",
         choices=["claude", "gemini", "codex"],
         help="AI provider to use (default: claude)",
+    )
+    parser.add_argument(
+        "--compute-backend",
+        default="local",
+        choices=["local", "dsi-slurm", "modal"],
+        help="Compute backend for experiment/comment execution (default: local)",
     )
     parser.add_argument(
         "--no-hash",
@@ -1259,6 +1292,7 @@ def main():
                 provider=args.provider,
                 timeout=args.timeout,
                 full_permissions=args.full_permissions,
+                compute_backend=args.compute_backend,
             )
 
             print()
@@ -1308,6 +1342,7 @@ def main():
             continue_autoresearch=args.continue_autoresearch,
             bootstrap_autoresearch_baseline=args.bootstrap_autoresearch_baseline,
             proposer_timeout=args.proposer_timeout,
+            compute_backend=args.compute_backend,
         )
 
         print()

--- a/src/templates/prompt_generator.py
+++ b/src/templates/prompt_generator.py
@@ -16,6 +16,7 @@ import sys
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from core.config_loader import ConfigLoader, normalize_domain
+from core.compute_backend import get_runtime_compute_backend
 
 
 class PromptGenerator:
@@ -546,8 +547,136 @@ Location: {run_dir}
 
         return self.render_template(template, variables)
 
+    @staticmethod
+    def _skill_root_for_provider(provider: str) -> str:
+        return f".{provider}/skills"
+
+    def _generate_compute_backend_section(
+        self, idea_spec: Dict[str, Any], mode: str, provider: str = "claude"
+    ) -> str:
+        """
+        Generate operational compute-backend constraints for execution agents.
+
+        Missing --compute-backend means local and intentionally emits nothing.
+        """
+        backend = get_runtime_compute_backend(idea_spec)
+        if backend == "local":
+            return ""
+        if backend == "modal" and mode == "comment":
+            return ""
+
+        skill_root = self._skill_root_for_provider(provider)
+        dsi_skill_path = f"{skill_root}/dsi-slurm/SKILL.md"
+        summary_target = "REPORT.md"
+        if mode == "comment":
+            summary_target = "REPORT.md or the comment-handler summary"
+
+        backend_sections = {
+            "dsi-slurm": f"""
+════════════════════════════════════════════════════════════════════════════════
+COMPUTE BACKEND: dsi-slurm
+════════════════════════════════════════════════════════════════════════════════
+
+Use the `{skill_root}/dsi-slurm/` skill for any cluster training, evaluation,
+or batch execution. Before writing or submitting Slurm jobs, read
+`{dsi_skill_path}` and follow its guidance.
+
+The local workspace is for orchestration and reporting only. Do not run
+training, evaluation, model selection, benchmarking, scored-output generation,
+smoke tests, or result-changing validation locally.
+
+Local commands may inspect files, edit code, prepare scripts, package inputs,
+and verify already-copied results only.
+
+DSI Slurm is the only allowed compute surface for experiment workload.
+
+When using this backend:
+
+1. Use the operating guidance and resource conventions from the `dsi-slurm`
+   skill. Do not hand-write an unrelated cluster workflow.
+2. NeuriCo runtime creates the remote workspace and records it in
+   `.neurico/dsi_slurm_remote_workspace.json`. Use only that remote workspace.
+   Do not create, choose, or reuse another remote root.
+3. Run the skill's setup/discovery checks before the first cluster submission.
+   Surface missing account, partition, module, storage, or GPU details in the
+   final report instead of guessing.
+4. Start with a cheap smoke job when possible, then scale to the full run.
+5. You are responsible for copying required experiment outputs from the remote
+   workspace back to the same relative paths in the local workspace before
+   reporting success. This includes configs, checkpoints, metrics, reports,
+   figures, predictions, evaluation outputs, and files required by scoring.
+6. Copy each terminal job's `dsi-slurm-artifacts/<JOB_ID>/` bundle back to the
+   local workspace. NeuriCo runtime archives local `dsi-slurm-artifacts/` into
+   logs after the stage.
+7. Do not remove the remote workspace. NeuriCo runtime removes it after the
+   stage finishes.
+8. At the end of the run, the local workspace must contain enough information
+   to reproduce or resume the experiment without relying on hidden cluster
+   state.
+
+Do not use Modal, local GPU fallback, or any other off-machine backend unless
+the user reruns NeuriCo with a different `--compute-backend`.
+
+If `{dsi_skill_path}` is missing, or required DSI Slurm details such as
+account, partition, GPU type, or submission access are unavailable, do not
+submit jobs and do not switch to another backend. Record the missing
+requirement clearly in {summary_target}, mark the experiment as blocked by
+configuration, and keep any local preparatory work reproducible.
+
+""",
+            "modal": """
+════════════════════════════════════════════════════════════════════════════════
+
+COMPUTE BACKENDS BEYOND THE LOCAL CONTAINER
+────────────────────────────────────────────────────────────────────────────────
+
+If your experiment needs model training, fine-tuning, or LLM serving that
+exceeds the local Docker container's GPU (or there is no local GPU), check
+.claude/skills/ for a compute backend that fits.
+
+DISCOVERY (do not hard-code a specific backend):
+
+1. List skills: `ls .claude/skills/`
+2. For each skill, read its SKILL.md frontmatter. Skills tagged
+   `compute-backend` describe ways to run workloads off-machine.
+3. Pick the backend whose description matches your need:
+   - Tag `training` → fine-tuning, LoRA SFT, full SFT, data prep, GPU eval
+   - Tag `serving` → deploying a model as an HTTPS endpoint for queries
+4. Read the chosen skill's SKILL.md end-to-end before writing any code that
+   uses it. The skill describes a setup doctor, a scaffolder, and a
+   leave-no-trace lifecycle that you MUST follow — your scaffolded script will
+   call lifecycle.register() / pull_all() / teardown() automatically.
+
+REQUIREMENTS WHEN A COMPUTE BACKEND IS USED:
+
+✓ Use the skill's scaffolder to generate the off-machine app — do NOT
+  hand-write volume / environment / app names. The lifecycle sweep finds
+  resources by name and only the scaffolder names them correctly.
+✓ Run the skill's setup doctor (e.g. `check_modal_setup.py`) BEFORE the
+  first off-machine call. Surface its `fix:` output if anything fails.
+✓ Pull all training logs, trained models, run configs, and metadata into
+  the workspace BEFORE teardown — the skill enforces this, do not override.
+✓ At the end of the run the workspace must contain enough to reproduce the
+  experiment without any cloud-side state.
+
+✗ Do not assume Modal specifically. The skills directory may grow other
+  backends; the discovery + reproducibility contract above applies to all.
+
+If no compute-backend skill is present and the experiment cannot run on the
+local container, document the gap in REPORT.md and reduce model scale until
+it fits.
+
+════════════════════════════════════════════════════════════════════════════════
+
+""",
+        }
+
+        return backend_sections.get(backend, "")
+
     def generate_session_instructions(self, prompt: str, work_dir: str,
-                                       use_scribe: bool = False, domain: str = 'general') -> str:
+                                       use_scribe: bool = False, domain: str = 'general',
+                                       idea_spec: Optional[Dict[str, Any]] = None,
+                                       provider: str = "claude") -> str:
         """
         Generate session instructions from template.
 
@@ -597,10 +726,15 @@ and the general workflow, ALWAYS follow the user's instructions.
             code_workflow = "✓ Write Python scripts in src/ directory for experiments and analysis"
             code_reminder = "- Write Python scripts (.py) in src/ for experiments (NOT Jupyter notebooks)"
 
+        compute_backend_section = self._generate_compute_backend_section(
+            idea_spec or {}, mode="experiment", provider=provider
+        )
+
         # Prepare variables
         variables = {
             'session_start': session_start,
             'priority_section': priority_section,
+            'compute_backend_section': compute_backend_section,
             'code_workflow': code_workflow,
             'code_reminder': code_reminder,
             'prompt': prompt,
@@ -755,7 +889,9 @@ RESEARCH DOMAIN:
 
         return full_prompt
 
-    def generate_comment_prompt(self, idea: Dict[str, Any], work_dir: Path) -> str:
+    def generate_comment_prompt(
+        self, idea: Dict[str, Any], work_dir: Path, provider: str = "claude"
+    ) -> str:
         """
         Generate comment handler prompt from template.
 
@@ -789,7 +925,10 @@ RESEARCH DOMAIN:
             'domain': domain,
             'comments': comments,
             'work_dir': str(work_dir),
-            'priority_section': priority_section
+            'priority_section': priority_section,
+            'compute_backend_section': self._generate_compute_backend_section(
+                idea_spec, mode="comment", provider=provider
+            )
         }
 
         # Render template with variables

--- a/templates/agents/autoresearch_proposer.txt
+++ b/templates/agents/autoresearch_proposer.txt
@@ -33,25 +33,7 @@ The existing NeuriCo comment handler will inspect and edit source files later.
 Your proposal should tell comment mode what targeted experiment-stage change to
 try next.
 
-═══════════════════════════════════════════════════════════════════════════════
-                              COMPUTE BUDGET
-═══════════════════════════════════════════════════════════════════════════════
-
-If your proposal would require GPU model training, fine-tuning, or LLM serving
-that exceeds the local container, the workspace may have a compute-backend
-skill available. Do not propose a backend by name. Instead, scope your proposal
-so that:
-
-1. If a compute backend is available, you state the proposal's compute needs
-   (model size, GPU memory, expected wall time) and note that an off-machine
-   backend may be required — the experiment_runner agent will discover and
-   pick the appropriate skill.
-2. If no compute backend is available, propose only changes that fit on the
-   local container (smaller models, fewer steps, eval-only paths).
-
-Treat compute-backend availability as a constraint to scope around, not as a
-licence to propose unbounded training jobs.
-
+{{ compute_backend_section }}
 ═══════════════════════════════════════════════════════════════════════════════
                               PUBLIC CONTEXT
 ═══════════════════════════════════════════════════════════════════════════════

--- a/templates/agents/comment_handler.txt
+++ b/templates/agents/comment_handler.txt
@@ -7,6 +7,7 @@ You are working on an existing research project. The user has provided feedback 
 
 {{ comments }}
 
+{{ compute_backend_section }}
 ═══════════════════════════════════════════════════════════════════════════════════════════════
                               WORKSPACE
 ═══════════════════════════════════════════════════════════════════════════════════════════════

--- a/templates/agents/session_instructions.txt
+++ b/templates/agents/session_instructions.txt
@@ -1,5 +1,6 @@
 {{ session_start }}
 {{ priority_section }}
+{{ compute_backend_section }}
 CRITICAL: Environment Setup
 ────────────────────────────────────────────────────────────────────────────────
 You MUST use an isolated environment for this project. DO NOT use the
@@ -106,49 +107,6 @@ At the START of your session, check for GPU availability:
    - GPU model and memory
    - Batch sizes used
    - Training time comparisons
-
-════════════════════════════════════════════════════════════════════════════════
-
-COMPUTE BACKENDS BEYOND THE LOCAL CONTAINER
-────────────────────────────────────────────────────────────────────────────────
-
-If your experiment needs model training, fine-tuning, or LLM serving that
-exceeds the local Docker container's GPU (or there is no local GPU), check
-.claude/skills/ for a compute backend that fits.
-
-DISCOVERY (do not hard-code a specific backend):
-
-1. List skills: `ls .claude/skills/`
-2. For each skill, read its SKILL.md frontmatter. Skills tagged
-   `compute-backend` describe ways to run workloads off-machine.
-3. Pick the backend whose description matches your need:
-   - Tag `training` → fine-tuning, LoRA SFT, full SFT, data prep, GPU eval
-   - Tag `serving` → deploying a model as an HTTPS endpoint for queries
-4. Read the chosen skill's SKILL.md end-to-end before writing any code that
-   uses it. The skill describes a setup doctor, a scaffolder, and a
-   leave-no-trace lifecycle that you MUST follow — your scaffolded script will
-   call lifecycle.register() / pull_all() / teardown() automatically.
-
-REQUIREMENTS WHEN A COMPUTE BACKEND IS USED:
-
-✓ Use the skill's scaffolder to generate the off-machine app — do NOT
-  hand-write volume / environment / app names. The lifecycle sweep finds
-  resources by name and only the scaffolder names them correctly.
-✓ Run the skill's setup doctor (e.g. `check_modal_setup.py`) BEFORE the
-  first off-machine call. Surface its `fix:` output if anything fails.
-✓ Pull all training logs, trained models, run configs, and metadata into
-  the workspace BEFORE teardown — the skill enforces this, do not override.
-✓ At the end of the run the workspace must contain enough to reproduce the
-  experiment without any cloud-side state.
-
-✗ Do not assume Modal specifically. The skills directory may grow other
-  backends; the discovery + reproducibility contract above applies to all.
-
-If no compute-backend skill is present and the experiment cannot run on the
-local container, document the gap in REPORT.md and reduce model scale until
-it fits.
-
-════════════════════════════════════════════════════════════════════════════════
 
 CRITICAL: Resources Have Been Pre-Gathered
 ────────────────────────────────────────────────────────────────────────────────

--- a/templates/research_agent_instructions.py
+++ b/templates/research_agent_instructions.py
@@ -35,7 +35,8 @@ def extract_user_instructions(prompt: str) -> str:
 
 
 def generate_instructions(prompt: str, work_dir: str, use_scribe: bool = False,
-                          domain: str = 'general') -> str:
+                          domain: str = 'general', idea_spec=None,
+                          provider: str = "claude") -> str:
     """
     Generate comprehensive session instructions for the research agent.
 
@@ -54,7 +55,14 @@ def generate_instructions(prompt: str, work_dir: str, use_scribe: bool = False,
     from templates.prompt_generator import PromptGenerator
     generator = PromptGenerator()
     try:
-        return generator.generate_session_instructions(prompt, work_dir, use_scribe, domain=domain)
+        return generator.generate_session_instructions(
+            prompt,
+            work_dir,
+            use_scribe,
+            domain=domain,
+            idea_spec=idea_spec,
+            provider=provider,
+        )
     except TypeError:
         # Backwards compatibility: old Docker images don't support 'domain' parameter
         print(

--- a/templates/skills/dsi-slurm/SKILL.md
+++ b/templates/skills/dsi-slurm/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: dsi-slurm
+description: Use the University of Chicago Data Science Institute Slurm cluster, called dsi-cluster here, for NeuriCo training, evaluation, sweeps, and batch jobs. Use only when NeuriCo is run with --compute-backend dsi-slurm. Run jobs in the runtime-provided remote workspace, monitor Slurm safely, and copy required outputs back to the local NeuriCo workspace.
+tags:
+  - compute-backend
+  - training
+  - dsi-slurm
+  - slurm
+  - gpu
+---
+
+# dsi-slurm
+
+Use `dsi-cluster` only when NeuriCo is run with:
+
+```bash
+--compute-backend dsi-slurm
+```
+
+The official cluster reference is https://cluster-policy.ds.uchicago.edu/.
+
+## When to Use
+
+Use this skill for experiment, evaluation, sweep, or batch execution only when
+NeuriCo was started with `--compute-backend dsi-slurm`.
+
+Do not use this skill for local runs, Modal runs, paper writing, or lightweight
+analysis that can safely finish inside the local NeuriCo workspace.
+
+## Prerequisites
+
+Before submitting cluster work, verify:
+
+- `.neurico/dsi_slurm_remote_workspace.json` exists in the local workspace;
+- `login.ds` works as a configured SSH alias without asking the agent for a
+  username;
+- `rsync` can copy files through `login.ds`;
+- Slurm commands such as `sbatch`, `squeue`, `sacct`, and `scancel` are
+  available on `login.ds`;
+- the job script requests an account, partition, time, memory, CPU count, and
+  any GPU or storage profile required by the job that the user is allowed to
+  use.
+
+If any prerequisite is missing, report the blocker instead of guessing.
+
+## Contract
+
+The local NeuriCo workspace is the source of truth for scoring, reporting, and
+paper/comment writing. `dsi-cluster` is compute, not artifact storage.
+
+NeuriCo runtime owns:
+
+- creating the remote workspace;
+- recording its location in `.neurico/dsi_slurm_remote_workspace.json`;
+- archiving local `dsi-slurm-artifacts/` after the stage;
+- removing the remote workspace after the stage.
+
+You own:
+
+- reading `.neurico/dsi_slurm_remote_workspace.json`;
+- syncing code/data needed for the job into that remote workspace;
+- submitting and monitoring Slurm jobs safely;
+- copying required outputs back to the same relative paths in the local
+  workspace;
+- copying each completed job bundle back to local
+  `dsi-slurm-artifacts/<JOB_ID>/`.
+
+Do not create, choose, reuse, or remove a different remote root.
+
+## Core Rules
+
+- The local workspace is for orchestration and reporting only. Do not run
+  experiment workload locally.
+- Training, evaluation, selection, benchmarking, scored-output generation, and
+  any result-changing command must run through Slurm in the runtime-provided
+  remote workspace.
+- Local commands may inspect files, prepare scripts, edit code, and verify
+  copied-back results only.
+- If really needed, run a very small Slurm smoke job before the full job. It
+  must use `sbatch`, `srun`, or `salloc` and write logs under
+  `dsi-slurm-artifacts/<JOB_ID>/`.
+- Use `login.ds` for SSH. Do not SSH directly to compute nodes.
+- Use Slurm (`sbatch`, `srun`, or `salloc`) for compute-node work.
+- Do not run training, heavy preprocessing, code agents, or IDE backends on
+  login nodes.
+- Do not use Modal, local GPU fallback, or another backend unless
+  the user reruns NeuriCo with a different `--compute-backend`.
+- Do not leave the only copy of important outputs in node-local scratch or the
+  remote workspace.
+- Do not report success until all files required by `scoring/interface.md` are
+  local and local scoring/reporting can use them.
+
+## Workspace Layout
+
+Remote execution should mirror local execution. Keep the same relative paths
+for code, configs, metrics, predictions, checkpoints, and final artifacts.
+
+Each Slurm job must have this bundle, both remotely while the job runs and
+locally before you finish:
+
+```text
+dsi-slurm-artifacts/
+  <JOB_ID>/
+    slurm_<JOB_ID>.out
+    slurm_<JOB_ID>.err
+    job.json
+```
+
+For job arrays, use the array job ID:
+
+```text
+dsi-slurm-artifacts/
+  <ARRAY_JOB_ID>/
+    slurm_<ARRAY_JOB_ID>_<TASK_ID>.out
+    slurm_<ARRAY_JOB_ID>_<TASK_ID>.err
+    job.json
+```
+
+`job.json` schema:
+
+```json
+{
+  "job_id": "Slurm job or array ID returned by sbatch --parsable",
+  "status": "completed, failed, cancelled, timeout, preempted, or unknown",
+  "slurm_state": "raw Slurm accounting state such as COMPLETED",
+  "exit_code": "raw Slurm exit code such as 0:0",
+  "script": "sbatch script path relative to the workspace root",
+  "description": "short purpose of this job",
+  "submitted_at_utc": "UTC timestamp recorded after submission",
+  "recorded_at_utc": "UTC timestamp recorded after final state lookup"
+}
+```
+
+`job.json` is audit and postmortem metadata. It helps humans and runtime
+cleanup understand what ran; scoring and paper writing should use the normal
+local files required by `scoring/interface.md`.
+
+One experiment may submit multiple jobs. Use one directory per job or array ID.
+
+## Cluster Facts
+
+- Login host: `login.ds`.
+- `general` is the default partition for unattended batch work and can preempt.
+- `interactive` is for active debugging or Jupyter-style work.
+- `protected` is for short jobs that must avoid preemption.
+- Request GPUs with options such as `--gres=gpu:1`.
+- Request node-local scratch with `--gres=local:<SIZE>`; it appears as
+  `/local/scratch/<CNetID>_<JOBID>/` and is deleted when the job releases it.
+- Probe actual storage paths. Do not assume `/project`, `/scratch`, or a lab
+  partition exists.
+
+## Workflow
+
+1. Read `.neurico/dsi_slurm_remote_workspace.json`.
+   Use its `remote_root` and `rsync_remote_root` values. If the file is
+   missing, do not invent a path; report that runtime did not create the
+   remote workspace.
+
+2. Read `scoring/interface.md`.
+   Identify which local files scoring and reporting must see.
+
+3. Sync the workspace to the remote root.
+   Copy only what the job needs. Exclude environments, caches, logs, and large
+   unrelated outputs unless they are required inputs.
+
+   Example:
+
+   ```bash
+   rsync -av \
+     --exclude ".venv/" \
+     --exclude ".conda/" \
+     --exclude "__pycache__/" \
+     --exclude ".cache/" \
+     --exclude "logs/" \
+     ./ <rsync_remote_root>
+   ```
+
+4. Submit one intended job.
+   Use `sbatch --parsable --hold`, capture `JOB_ID`, create
+   `dsi-slurm-artifacts/<JOB_ID>/`, then release the same job. Do not submit a
+   second job just to wait on it.
+
+5. Monitor safely.
+   Use one SSH session with `sleep >= 60`, `sbatch --wait` for short bounded
+   jobs, or sparse local checks no more than once per 60 seconds.
+
+6. Record terminal state.
+   Write `dsi-slurm-artifacts/<JOB_ID>/job.json` after the final Slurm state is
+   known.
+
+7. Copy results back.
+   Copy all required experiment outputs from the remote workspace to the same
+   relative paths in the local workspace. Also copy
+   `dsi-slurm-artifacts/<JOB_ID>/` back locally.
+
+8. Verify locally.
+   Check that required local files exist and local scoring/reporting can run.
+   Do not remove the remote workspace; runtime does that after the stage.
+
+Repeat steps 4-7 for each additional job.
+
+## Safe Submit, Wait, Record
+
+Use this pattern instead of inventing a polling loop:
+
+```bash
+ssh -o BatchMode=yes -o ConnectTimeout=20 login.ds 'bash -lc "
+set -euo pipefail
+
+REMOTE_ROOT=\"<remote_root from .neurico/dsi_slurm_remote_workspace.json>\"
+SCRIPT=\"scripts/train.sbatch\"
+DESCRIPTION=\"<short purpose of this job>\"
+
+cd \"\$REMOTE_ROOT\"
+mkdir -p dsi-slurm-artifacts artifacts results
+
+JOB_ID=\$(sbatch --parsable --hold \"\$SCRIPT\" | tail -n 1)
+JOB_ID=\"\${JOB_ID%%;*}\"
+SUBMITTED_AT_UTC=\"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+JOB_DIR=\"dsi-slurm-artifacts/\$JOB_ID\"
+mkdir -p \"\$JOB_DIR\"
+
+JOB_RELEASED=0
+cleanup_held_job() {
+  if [ \"\$JOB_RELEASED\" != \"1\" ]; then
+    scancel \"\$JOB_ID\" 2>/dev/null || true
+  fi
+}
+trap cleanup_held_job EXIT
+
+echo \"Submitted job \$JOB_ID\"
+scontrol release \"\$JOB_ID\"
+JOB_RELEASED=1
+trap - EXIT
+
+while true; do
+  STATES=\$(squeue -h -j \"\$JOB_ID\" -o \"%T\" 2>/dev/null \
+    | sort -u | paste -sd, - || true)
+  if [ -z \"\$STATES\" ]; then
+    break
+  fi
+  echo \"\$(date -u +%Y-%m-%dT%H:%M:%SZ) job \$JOB_ID states=\$STATES\"
+  sleep 60
+done
+
+sleep 10
+sacct -j \"\$JOB_ID\" --format=State,ExitCode -P -n \
+  > \"\$JOB_DIR/.sacct.tmp\" 2>/dev/null || true
+SLURM_STATE=\$(head -n 1 \"\$JOB_DIR/.sacct.tmp\" | cut -d\"|\" -f1)
+EXIT_CODE=\$(head -n 1 \"\$JOB_DIR/.sacct.tmp\" | cut -d\"|\" -f2)
+rm -f \"\$JOB_DIR/.sacct.tmp\"
+
+if [ -z \"\$SLURM_STATE\" ]; then SLURM_STATE=\"UNKNOWN\"; fi
+if [ -z \"\$EXIT_CODE\" ]; then EXIT_CODE=\"unknown\"; fi
+case \"\$SLURM_STATE\" in
+  COMPLETED) STATUS=\"completed\" ;;
+  CANCELLED*) STATUS=\"cancelled\" ;;
+  TIMEOUT*) STATUS=\"timeout\" ;;
+  PREEMPTED*) STATUS=\"preempted\" ;;
+  FAILED|NODE_FAIL|OUT_OF_MEMORY) STATUS=\"failed\" ;;
+  *) STATUS=\"unknown\" ;;
+esac
+
+cat > \"\$JOB_DIR/job.json\" <<EOF
+{
+  \"job_id\": \"\$JOB_ID\",
+  \"status\": \"\$STATUS\",
+  \"slurm_state\": \"\$SLURM_STATE\",
+  \"exit_code\": \"\$EXIT_CODE\",
+  \"script\": \"\$SCRIPT\",
+  \"description\": \"\$DESCRIPTION\",
+  \"submitted_at_utc\": \"\$SUBMITTED_AT_UTC\",
+  \"recorded_at_utc\": \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+}
+EOF
+
+tail -n 120 \"\$JOB_DIR\"/*.out 2>/dev/null || true
+tail -n 120 \"\$JOB_DIR\"/*.err 2>/dev/null || true
+test -f \"\$JOB_DIR/job.json\"
+"'
+```
+
+Your sbatch script should write Slurm logs directly into the job bundle:
+
+```bash
+#SBATCH --output=dsi-slurm-artifacts/%j/slurm_%j.out
+#SBATCH --error=dsi-slurm-artifacts/%j/slurm_%j.err
+```
+
+For arrays:
+
+```bash
+#SBATCH --array=0-99%10
+#SBATCH --output=dsi-slurm-artifacts/%A/slurm_%A_%a.out
+#SBATCH --error=dsi-slurm-artifacts/%A/slurm_%A_%a.err
+```
+
+For preemptable `general` jobs, add checkpoint/requeue support when the code can
+resume safely:
+
+```bash
+#SBATCH --signal=B:USR1@300
+#SBATCH --requeue
+```
+
+## Copy-Back
+
+Read `.neurico/dsi_slurm_remote_workspace.json` locally. Use `remote_root` only
+inside commands running on `login.ds`; use `rsync_remote_root` for local
+`rsync`. Example:
+
+```bash
+mkdir -p dsi-slurm-artifacts/<JOB_ID>
+rsync -av <rsync_remote_root>dsi-slurm-artifacts/<JOB_ID>/ \
+  dsi-slurm-artifacts/<JOB_ID>/
+
+rsync -av <rsync_remote_root>metrics.json metrics.json
+rsync -av <rsync_remote_root>artifacts/ artifacts/
+rsync -av <rsync_remote_root>results/ results/
+```
+
+If mirroring the remote workspace is simpler, exclude disposable paths:
+
+```bash
+rsync -av \
+  --exclude ".venv/" \
+  --exclude ".conda/" \
+  --exclude "__pycache__/" \
+  --exclude ".cache/" \
+  --exclude "logs/" \
+  <rsync_remote_root> ./
+```
+
+Do not use `--delete` unless the destination is disposable and exactly mirrors
+the remote artifact set.
+
+## Monitor, Cancel, Recover
+
+Useful commands on `login.ds`:
+
+```bash
+squeue -u "$USER"
+squeue -j <JOB_ID>
+sacct -j <JOB_ID> --format=JobID,JobName,Partition,QOS,State,ExitCode,Elapsed -P
+scancel <JOB_ID>
+```
+
+Do not implement local polling loops that repeatedly run
+`ssh login.ds "squeue ..."` or `ssh login.ds "tail ..."`. Rapidly opening SSH
+connections to the login node can trigger temporary connection resets or access
+throttling and is impolite to shared cluster infrastructure. If SSH fails
+before authentication with `kex_exchange_identification: read: Connection reset
+by peer`, stop monitoring, record the last known job ID/state/walltime, and
+retry at most once after a several-minute backoff.
+
+After cancellation or failure, inspect `sacct`, `.err`, and `.out`; copy back
+available artifacts; and report what was recovered.
+
+## Final Checklist
+
+- Each submitted job has local `dsi-slurm-artifacts/<JOB_ID>/job.json`.
+- Slurm stdout/stderr are local.
+- All files required by `scoring/interface.md` are local.
+- Metrics, predictions, checkpoints, and final artifacts needed for reporting
+  are local.
+- No job is left running unless the user requested asynchronous work.
+- The report/comment states what ran, what succeeded/failed/cancelled, and what
+  artifacts were recovered.


### PR DESCRIPTION
## Summary

This PR builds on [PR #124](https://github.com/ChicagoHAI/NeuriCo/pull/124). It keeps PR #124’s Modal skills and compute-backend guidance, while adding runtime backend selection and a new DSI Slurm compute path.

The new backend is implemented as a dsi-slurm skill and presented to agents as dsi-cluster. It provides guidance for running NeuriCo experiment workloads on the University of Chicago Data Science Institute Slurm cluster.

Compute backend selection is controlled at runtime through a CLI flag:

```bash
--compute-backend local
--compute-backend dsi-slurm
--compute-backend modal
```

When local is selected, NeuriCo does not inject Slurm or Modal-specific guidance and does not create any remote workspace.

The intended model for using `dsi-slurm` for computation is:

```text
runtime selects compute backend
→ NeuriCo attaches backend to the in-memory run state
→ relevant agents receive backend guidance only when needed
→ local workspace remains the source of truth for scoring, reporting, comments, and paper writing
```

## CLI behavior

New runtime flag:

```bash
--compute-backend {local,dsi-slurm,modal}
```

Examples:

```bash
./neurico run <id>
./neurico run <id> --compute-backend local
./neurico run <id> --compute-backend dsi-slurm
./neurico run <id> --compute-backend modal
```

Comment mode and standalone agent runner support the same backend selection.

If the flag is omitted, NeuriCo uses `local`.

## Backend behavior

### `local`

Default behavior.

No Slurm prompt is injected. No Modal prompt is injected. No remote workspace is created. Existing local execution remains unchanged.

### `dsi-slurm`

NeuriCo conditionally injects DSI Slurm guidance into experiment/comment/AutoResearch prompts.

Agents are instructed to use the provider-specific skill path:

```text
.<provider>/skills/dsi-slurm/SKILL.md
```

Examples:

```text
.codex/skills/dsi-slurm/SKILL.md
.claude/skills/dsi-slurm/SKILL.md
.gemini/skills/dsi-slurm/SKILL.md
```

The agent must use the runtime-provided remote workspace, submit work through Slurm, and copy required outputs back to the local workspace before reporting success.

All cluster access is through the configured SSH alias:

```bash
login.ds
```

NeuriCo does not require the agent to construct a username-qualified hostname such as `<user>@...`.

### `modal`

Modal/backend guidance is emitted only when `--compute-backend modal` is selected.

## Prerequisites for `dsi-slurm`

Using `--compute-backend dsi-slurm` assumes the human user has already prepared the access that NeuriCo agents cannot create themselves.

Required human prerequisites:

- the user has an active account on `dsi-cluster`
- the machine running NeuriCo has a configured SSH alias `login.ds`
- `ssh login.ds` works non-interactively enough for agent-run commands
- `rsync` over `login.ds` works from the machine running NeuriCo
- the user has permission to submit Slurm jobs on the cluster

Everything else is job-specific setup. The agent may inspect available partitions, storage, modules, Conda/Mamba, Python packages, and GPUs, and may create project-local environments or scripts when appropriate. If a job requires access or permissions the user has not prepared, the agent would report that missing prerequisite instead of guessing or falling back to another backend.

## dsi-cluster runtime workspace lifecycle

When `--compute-backend dsi-slurm` is selected, NeuriCo runtime creates a remote workspace through `login.ds` before the experiment/comment stage starts.

The runtime writes:

```text
.neurico/dsi_slurm_remote_workspace.json
```

with a contract like:

```json
{
  "backend": "dsi-slurm",
  "ssh_host": "login.ds",
  "workspace_name": "<local workspace name>",
  "remote_root": "$HOME/neurico_workspaces/<local workspace name>",
  "rsync_remote_root": "login.ds:~/neurico_workspaces/<local workspace name>/"
}
```

The runtime owns:

```text
create remote workspace
→ expose remote workspace metadata
→ remove remote workspace after the stage
```

The agent owns:

```text
sync needed files
→ submit Slurm jobs
→ monitor safely
→ copy required outputs back to local workspace
→ copy job evidence back to local dsi-slurm-artifacts/
```

The remote workspace is intentionally not reused if it already exists, to avoid stale artifacts contaminating a run.

## dsi-slurm skill

This PR adds/refines:

```text
templates/skills/dsi-slurm/SKILL.md
```

The skill treats `dsi-cluster` as compute, not artifact storage.

Core contract:

```text
local NeuriCo workspace = source of truth
dsi-cluster = compute backend
```

The skill covers:

- using the configured `login.ds` SSH alias
- avoiding heavy work on login nodes
- using Slurm for compute-node work
- using the runtime-provided remote workspace
- safe monitoring without rapid repeated SSH polling
- copying outputs back to the local workspace
- recording per-job Slurm evidence
- handling cancellation, failure, and recovery
- avoiding fallback to another backend unless the user reruns with a different backend

Each Slurm job records local evidence under:

```text
dsi-slurm-artifacts/
  <JOB_ID>/
    slurm_<JOB_ID>.out
    slurm_<JOB_ID>.err
    job.json
```

`job.json` uses this compact schema:

```json
{
  "job_id": "Slurm job or array ID returned by sbatch --parsable",
  "status": "completed, failed, cancelled, timeout, preempted, or unknown",
  "slurm_state": "raw Slurm accounting state such as COMPLETED",
  "exit_code": "raw Slurm exit code such as 0:0",
  "script": "sbatch script path relative to the workspace root",
  "description": "short purpose of this job",
  "submitted_at_utc": "UTC timestamp recorded after submission",
  "recorded_at_utc": "UTC timestamp recorded after final state lookup"
}
```

## Prompt injection behavior

Backend guidance is conditional.

### Experiment runner

Receives backend guidance only when a non-local backend is selected.

For `dsi-slurm`, the experiment agent is told to read the provider-specific skill path and use the runtime-provided remote workspace.

### Comment handler

Receives `dsi-slurm` guidance when `--compute-backend dsi-slurm` is selected.

The runtime also creates and removes the remote workspace around comment-mode execution.

### AutoResearch proposer

Receives backend guidance when `--compute-backend dsi-slurm` is selected, so proposals can preserve the correct cluster execution contract for the comment agent.

## What changed

### Added files

- `src/core/compute_backend.py`
  - defines valid runtime backends
  - normalizes missing backend to `local`
  - attaches backend to in-memory run state
  - exposes backend lookup helpers

- `src/core/dsi_slurm_remote.py`
  - creates dsi-cluster remote workspaces through `login.ds`
  - writes `.neurico/dsi_slurm_remote_workspace.json`
  - removes the remote workspace after the stage
  - no-ops unless backend is exactly `dsi-slurm`

### Modified files

- `src/core/runner.py`
  - adds `--compute-backend`
  - prints selected backend
  - attaches runtime backend before run/comment execution

- `src/core/agent_runner.py`
  - adds `--compute-backend`
  - passes backend into standalone agent execution
  - creates/removes dsi-cluster remote workspace for `dsi-slurm`
  - passes remote workspace environment variables to the agent

- `src/core/pipeline_orchestrator.py`
  - creates/removes dsi-cluster remote workspace around experiment execution
  - passes remote workspace environment variables to agent subprocesses
  - archives DSI Slurm artifacts only for `dsi-slurm`

- `src/agents/comment_handler.py`
  - wraps comment handler execution with dsi-cluster remote workspace lifecycle when needed
  - passes remote workspace metadata via environment variables

- `src/agents/autoresearch_proposer.py`
  - injects proposer guidance for `dsi-slurm`

- `src/templates/prompt_generator.py`
  - emits backend prompt sections only when needed
  - omits backend guidance for local runs
  - injects DSI Slurm guidance for `dsi-slurm`
  - keeps Modal/backend guidance conditional

- `templates/skills/dsi-slurm/SKILL.md`
  - defines the DSI Slurm workflow and runtime/agent responsibility split

## Design notes

- Backend selection is runtime state.
- Missing backend means `local`.
- Local runs do not see Slurm or Modal instructions.
- The DSI Slurm skill is provider-aware through paths like `.codex/skills/dsi-slurm/SKILL.md`.
- The skill avoids hard-coding one provider’s skill root.
- Cluster access uses the configured `login.ds` SSH alias.
- `dsi-cluster` is compute only, not artifact storage.
- Local workspace files remain authoritative for scoring, reports, comments, and paper writing.
- Runtime creates/removes the remote workspace.
- Agent handles job execution and copy-back because it knows which outputs the experiment generated.
- Remote workspace reuse is rejected to avoid stale cross-run contamination.
- Slurm monitoring guidance avoids rapid repeated SSH polling.

## Test

- [x] Local backend smoke run completed without DSI remote workspace metadata
- [x] Local Codex continue-AutoResearch round completed successfully
- [x] DSI Slurm smoke testing completed
- [x] DSI Slurm artifacts were copied back and archived during DSI runs
- [x] Continue AutoResearch worked after DSI-backed runs
- [x] Bootstrap and continue-research flows were exercised with the DSI backend