### PR TITLE
(exploratory) feat: decision-log — prototype agent logic tree for resource_finder

### DIFF
--- a/config/domains.yaml
+++ b/config/domains.yaml
@@ -137,6 +137,12 @@ domains:
       - bifurcation
       - dynamical system
 
+  mathematics_lean:
+    name: "Mathematics (Lean)"
+    description: "Formal mathematics with Lean 4 proof verification: proofs are machine-checked by the Lean type checker using Mathlib"
+    has_template: true
+    paper_style: ams
+
   finance:
     name: "Finance"
     description: "Empirical finance: banking, corporate finance, asset pricing, financial regulation, panel data analysis"

--- a/docker-compose.lean.yml
+++ b/docker-compose.lean.yml
@@ -1,0 +1,81 @@
+# =============================================================================
+# neurico-lean Docker Compose Configuration
+#
+# STANDALONE mode: each run is a self-contained, ephemeral job.
+# The Lean toolchain and Mathlib.Tactic cache are baked into the image —
+# no volume mounts are needed for Lean to work.
+#
+# Build:
+#   docker compose -f docker-compose.lean.yml build
+#
+# Run a single research pipeline:
+#   docker compose -f docker-compose.lean.yml run --rm neurico-lean \
+#       python /app/src/core/runner.py <idea_id> --provider claude
+#
+# Interactive shell:
+#   docker compose -f docker-compose.lean.yml run --rm neurico-lean bash
+# =============================================================================
+
+services:
+  neurico-lean:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.lean
+
+    image: chicagohai/neurico-lean:latest
+    container_name: neurico-lean
+
+    # GPU support (NVIDIA Container Toolkit required)
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+    env_file:
+      - .env
+
+    environment:
+      - PYTHONUNBUFFERED=1
+      - NEURICO_WORKSPACE=/workspaces
+      - CLAUDE_CONFIG_DIR=/tmp/.claude
+      - ELAN_HOME=/home/neurico/.elan
+
+    volumes:
+      # ── Research output (the only persistent state across runs) ────────────
+      # Each run writes its workspace here; the directory survives container exit.
+      - ./workspaces:/workspaces:rw
+
+      # ── Ideas and config (read-only inputs) ───────────────────────────────
+      - ./ideas:/app/ideas:rw
+      - ./logs:/app/logs:rw
+      - ./config:/app/config:ro
+      - ./templates:/app/templates:ro
+
+      # ── CLI credentials (OAuth tokens, read-only) ─────────────────────────
+      - ~/.claude:/tmp/.claude:ro
+      - ~/.codex:/tmp/.codex:ro
+      - ~/.gemini:/tmp/.gemini:ro
+
+    # No restart policy — standalone runs exit when the pipeline finishes
+    # restart: "no"  (default, no need to set)
+
+    stdin_open: true
+    tty: true
+    working_dir: /workspaces
+
+    healthcheck:
+      test: ["CMD", "lean", "--version"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+    networks:
+      - research-net
+
+networks:
+  research-net:
+    driver: bridge

--- a/docker/Dockerfile.lean
+++ b/docker/Dockerfile.lean
@@ -1,0 +1,218 @@
+# syntax=docker/dockerfile:1.5
+# =============================================================================
+# neurico-lean — Standalone Lean 4 research image
+#
+# Self-contained: builds from the upstream CUDA base directly.
+# No dependency on a pre-built chicagohai/neurico image.
+#
+# One build command:
+#   docker build -f docker/Dockerfile.lean -t chicagohai/neurico-lean:latest .
+#
+# Adds on top of the standard neurico stack:
+#   - elan  (Lean version manager)
+#   - lean  (Lean 4 proof assistant, Mathlib-pinned toolchain)
+#   - lake  (Lean build tool)
+#   - Mathlib.Tactic olean cache (~1-2GB, pre-warmed at build time)
+#     so each standalone run needs no network access for Lean.
+# =============================================================================
+
+ARG CUDA_VERSION=12.5.1
+ARG UBUNTU_VERSION=22.04
+
+# Lean 4 only provides pre-built binaries for x86_64-linux.
+# Pin to linux/amd64 so this image builds and runs correctly on any host,
+# including Apple Silicon Macs (where Docker Desktop defaults to aarch64).
+ARG TARGETPLATFORM=linux/amd64
+
+# =============================================================================
+# Stage 1: Builder — install tools and build all Python environments
+# =============================================================================
+FROM --platform=linux/amd64 nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS builder
+
+LABEL org.opencontainers.image.title="neurico-lean"
+LABEL org.opencontainers.image.description="Autonomous research framework with Lean 4 formal verification"
+LABEL org.opencontainers.image.source="https://github.com/ChicagoHAI/neurico"
+LABEL maintainer="ChicagoHAI"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# System dependencies (same as base image)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    wget \
+    git \
+    ca-certificates \
+    gnupg \
+    libssl-dev \
+    libffi-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libncurses5-dev \
+    libncursesw5-dev \
+    xz-utils \
+    tk-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    liblzma-dev \
+    zlib1g-dev \
+    git-lfs \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 (for Codex and Gemini CLIs)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv
+COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /usr/local/bin/uv
+
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+
+RUN uv python install 3.12
+
+# Claude Code CLI
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+    && cp /root/.local/bin/claude /usr/local/bin/claude
+
+# Codex and Gemini CLIs
+RUN npm install -g @openai/codex \
+    && npm install -g @google/gemini-cli
+
+# Build neurico app and all virtual environments
+WORKDIR /app
+COPY . .
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv venv /app/.venv \
+    && uv sync --frozen --no-dev
+
+WORKDIR /app/services/paper-finder
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --all-packages --dev
+WORKDIR /app
+
+# =============================================================================
+# Stage 2: Runtime — production image with Lean 4 added
+# =============================================================================
+FROM --platform=linux/amd64 nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION} AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# Runtime system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    git-lfs \
+    openssh-client \
+    ca-certificates \
+    libcudnn8 \
+    make \
+    libgmp-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# LaTeX for paper compilation
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    texlive-latex-base \
+    texlive-latex-extra \
+    texlive-latex-recommended \
+    texlive-fonts-recommended \
+    texlive-fonts-extra \
+    texlive-science \
+    texlive-bibtex-extra \
+    texlive-publishers \
+    lmodern \
+    cm-super \
+    biber \
+    latexmk \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js from builder
+COPY --from=builder /usr/bin/node /usr/bin/
+COPY --from=builder /usr/lib/node_modules /usr/lib/node_modules
+RUN ln -sf /usr/lib/node_modules/npm/bin/npm-cli.js /usr/bin/npm \
+    && ln -sf /usr/lib/node_modules/npm/bin/npx-cli.js /usr/bin/npx
+
+# Claude Code CLI
+COPY --from=builder /usr/local/bin/claude /usr/local/bin/claude
+
+# Codex and Gemini
+RUN ln -sf /usr/lib/node_modules/@openai/codex/bin/codex.js /usr/bin/codex \
+    && ln -sf /usr/lib/node_modules/@google/gemini-cli/bundle/gemini.js /usr/bin/gemini
+
+# uv
+COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /usr/local/bin/uv
+
+# Non-root user
+RUN useradd -u 1000 -m -s /bin/bash neurico
+
+# Python and app
+COPY --from=builder /python /python
+COPY --from=builder --chown=neurico:neurico /app /app
+
+ENV PATH="/app/.venv/bin:/python/bin:/usr/local/bin:${PATH}"
+ENV UV_PYTHON_INSTALL_DIR=/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+ENV VIRTUAL_ENV="/app/.venv"
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV UV_COMPILE_BYTECODE=1
+ENV PYTHONPATH="/app:${PYTHONPATH}"
+
+RUN mkdir -p /workspaces \
+    /app/ideas/submitted /app/ideas/in_progress /app/ideas/completed \
+    /app/logs /app/runs
+
+# ── Lean 4 installation (as neurico user) ─────────────────────────────────────
+USER neurico
+WORKDIR /app
+
+RUN git config --global user.email "noreply@neurico.dev" \
+    && git config --global user.name "NeuriCo" \
+    && git config --global init.defaultBranch main \
+    && mkdir -p ~/.claude ~/.codex ~/.gemini ~/.cache/uv \
+    && echo 'PS1="neurico:\w\$ "' >> ~/.bashrc
+
+ENV ELAN_HOME=/home/neurico/.elan
+ENV PATH="${ELAN_HOME}/bin:${PATH}"
+ENV NEURICO_WORKSPACE=/workspaces
+
+# Install elan and the Mathlib-pinned Lean toolchain
+RUN curl -sSfL \
+      https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+    | sh -s -- -y \
+        --no-modify-path \
+        --default-toolchain leanprover-community/mathlib4:stable \
+    && lean --version \
+    && lake --version
+
+# Pre-warm the Mathlib.Tactic olean cache (~1-2GB).
+# Runs at build time so standalone containers need no network access for Lean.
+RUN mkdir -p /tmp/lean-warmup \
+    && lake +leanprover-community/mathlib4:stable \
+         init /tmp/lean-warmup/warmup math \
+    && cd /tmp/lean-warmup/warmup \
+    && printf 'import Mathlib.Tactic\n\nnamespace Warmup\nend Warmup\n' \
+         > LeanProofs/Definitions.lean \
+    && lake exe cache get \
+    && lake build \
+    && rm -rf /tmp/lean-warmup
+
+# Smoke-test: verify lean can compile a simple theorem
+RUN lean --stdin <<< 'theorem smoke (n : Nat) : n + 0 = n := Nat.add_zero n'
+
+VOLUME ["/workspaces"]
+WORKDIR /workspaces
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+    CMD lean --version
+
+ENTRYPOINT ["/app/docker/entrypoint.lean.sh"]
+CMD ["bash"]

--- a/docker/entrypoint.lean.sh
+++ b/docker/entrypoint.lean.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# =============================================================================
+# neurico-lean Container Entrypoint
+# Adds Lean 4 status reporting before handing off to the standard entrypoint.
+# =============================================================================
+
+set -e
+
+# Make elan/lean/lake available (installed to /home/neurico/.elan at build time)
+export ELAN_HOME="${ELAN_HOME:-/home/neurico/.elan}"
+export PATH="${ELAN_HOME}/bin:${PATH}"
+
+# ── Lean status check ────────────────────────────────────────────────────────
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${BLUE}Lean 4 Status:${NC}"
+
+if command -v lean &>/dev/null; then
+    LEAN_VER=$(lean --version 2>/dev/null | head -1)
+    LAKE_VER=$(lake --version 2>/dev/null | head -1)
+    echo -e "  ${GREEN}[OK]${NC} lean  — ${LEAN_VER}"
+    echo -e "  ${GREEN}[OK]${NC} lake  — ${LAKE_VER}"
+
+    # Report whether the Mathlib cache already exists in the global cache dir
+    CACHE_DIR="${HOME}/.cache/mathlib"
+    if [ -d "${CACHE_DIR}" ] && [ "$(ls -A "${CACHE_DIR}" 2>/dev/null)" ]; then
+        CACHE_SIZE=$(du -sh "${CACHE_DIR}" 2>/dev/null | cut -f1)
+        echo -e "  ${GREEN}[OK]${NC} Mathlib cache — ${CACHE_SIZE} at ${CACHE_DIR}"
+    else
+        echo -e "  ${YELLOW}[INFO]${NC} Mathlib cache not yet populated"
+        echo -e "         Run setup in workspace: bash .claude/skills/lean-prover/scripts/setup_lean_project.sh"
+        echo -e "         First run downloads ~1-2GB (Mathlib.Tactic); cached for subsequent workspaces."
+    fi
+else
+    echo -e "  ${YELLOW}[WARN]${NC} lean not found on PATH — elan may not be installed correctly"
+fi
+
+echo ""
+
+# ── Hand off to the standard neurico entrypoint ──────────────────────────────
+exec /app/docker/entrypoint.sh "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,15 @@ target-version = ['py310']
 line-length = 100
 target-version = "py310"
 
+[tool.pytest.ini_options]
+markers = [
+    "lean_binary: requires lean binary on PATH (Tier 1 integration tests)",
+    "lean_lake:   requires lean + lake on PATH (Tier 2 integration tests)",
+    "lean_mathlib: slow — downloads Mathlib cache; implies lean_lake (Tier 3)",
+    "slow:        long-running tests (>60 seconds)",
+    "lean_llm:    LLM smoke test — requires claude CLI + credentials (~10-15 min, ~$0.50)",
+]
+
 [tool.uv.workspace]
 members = [
     "workspace/llm-epistemic-belief-6a0d",

--- a/templates/agents/resource_finder.txt
+++ b/templates/agents/resource_finder.txt
@@ -162,6 +162,160 @@ STEP 4: USE APIs FOR ABSTRACTS WHEN AVAILABLE
 - Use these for initial screening before deciding which papers need deep reading
 
 ═══════════════════════════════════════════════════════════════════════════════
+              CRITICAL: DECISION LOGGING (CROSS-CUTTING)
+═══════════════════════════════════════════════════════════════════════════════
+
+You will use the decision-log skill THROUGHOUT this session — log a decision
+the MOMENT you commit to it, not as an afterthought at the end. The point is
+to capture your actual reasoning trail as it unfolds: ideas you committed to,
+ideas you considered then revoked, and the lineage between them. A clean
+"recommendations at the end" log loses everything that makes this useful.
+
+READ THE SKILL ONCE NOW (saves you from re-learning the API later):
+  cat .claude/skills/decision-log/SKILL.md
+
+It covers the contract (active / suspect / revoked states, cascade behavior
+on revoke). About 5 minutes of reading.
+
+SETUP — run at session start, right after env activation:
+─────────────────────────────────────────────────────────────────────────────
+
+```python
+import sys
+sys.path.insert(0, ".claude/skills/decision-log/scripts")
+from decision_log import DecisionLog
+
+log = DecisionLog(path=".neurico/decisions.json")
+```
+
+The path persists across turns; reopening it later loads what you wrote.
+
+WHEN TO LOG (the moment you commit to one of these):
+─────────────────────────────────────────────────────────────────────────────
+
+DECISION categories — use with `log.add(...)`:
+
+| Category | In-flight examples from this agent |
+|---|---|
+| `dataset` | "I'll use MIMIC-IV over i2b2"; "primary corpus = HuggingFace dataset X" |
+| `method`  | "Use BERT-base as baseline"; "adopt ICRefine from code_references"; "skip baseline Y because no code released" |
+| `eval`    | "primary metric = balanced accuracy"; "report F1@k as secondary" |
+| `search`  | "paper-finder diligent mode, focus on 2023-2025 clinical-NLP"; "prefer HuggingFace over Kaggle as dataset source"; "narrow keywords to 5 phrases" |
+| `reading` | "deep-read these 3 papers, skim the rest"; "README-only for repo X"; "re-read methodology section of Paper Y" |
+| `risk`    | "Dataset has annotation drift between splits — confounds any gain"; "Hypothesis may be falsified: baseline near ceiling per BatchCal Table 2"; "License restricts redistribution — exp runner cannot share derived data" |
+| `other`   | anything that affects downstream agents but doesn't fit the above (use sparingly) |
+
+OBSERVATION categories — use with `log.observe(...)`:
+
+| Category | In-flight examples from this agent |
+|---|---|
+| `paper_finding`     | "Lu et al. Table 2: std=4.0pp across orderings for 2.7B model"; "Zhao 2021 used unbalanced demos which itself causes the bias they correct" |
+| `data_property`     | "AG News label indexing: 1-4 in raw .csv but 0-3 in HF datasets API"; "MIMIC train and test were collected 6 months apart" |
+| `env_fact`          | "paper-finder service at localhost:8000 returns 404"; "HF datasets v2 deprecated; need v3 fancyzhx/ag_news namespace" |
+| `experiment_result` | "First inference on Qwen-1.5B gave 47% acc — sanity-check failed"; "Tokenizer warns on >2048 tokens, mean prompt is 1800" |
+| `code_artifact`     | "Zhao reference repo uses raw transformers.generate; no built-in retry"; "ColBERT scripts expect Lucene 9.x" |
+| `other`             | anything else worth observing that doesn't fit above |
+
+**Categories are disjoint by type.** `log.add(category="paper_finding")` will fail; `log.observe(category="dataset")` will fail. Pick the node type first (decision vs observation), then the category follows.
+
+DO NOT log:
+  ✗ Mechanical actions (wget, mkdir, git clone, pip install)
+  ✗ Observations ("dataset has 10K rows") — that's a *premise* for a future
+    decision, not a decision itself
+  ✗ Reading a file to inform a future decision
+
+If a choice has no consequence for the experiment runner or for the next
+agent reading the log, it's not worth a node.
+
+ONE CALL PER DECISION OR OBSERVATION:
+─────────────────────────────────────────────────────────────────────────────
+
+Two kinds of nodes: DECISIONS (what you chose) and OBSERVATIONS (what you
+noticed). Decisions use `log.add(...)`. Observations use `log.observe(...)`.
+
+```python
+# A DECISION
+ds = log.add(
+    question="Primary evaluation dataset?",
+    choice="MIMIC-IV-Note clinical-NLP subset",
+    category="dataset",
+    rationale="largest annotated clinical-NLP corpus with permissive license",
+    alternatives=["i2b2 2010", "PhysioNet 2019"],
+)
+
+# An OBSERVATION about that dataset (a finding that may inform later choices)
+obs = log.observe(
+    observation="MIMIC-IV-Note has 4:1 negative:positive imbalance after de-dup",
+    category="data_property",             # observation-only category
+    about=[ds],                           # what this observation pertains to
+    source="hand-inspected first 1k rows of train.csv",
+)
+
+# A DOWNSTREAM DECISION premised on the observation, not just the dataset
+log.add(
+    question="Primary metric?",
+    choice="balanced accuracy",
+    category="eval",
+    premises=[obs],                       # ← chains through the observation
+    rationale="addresses the imbalance observed above",
+)
+```
+
+WHEN TO LOG AN OBSERVATION (vs folding into a decision's rationale):
+─────────────────────────────────────────────────────────────────────────────
+
+Log an observation as its own node when:
+  - Multiple decisions will reference the same finding (e.g., "class
+    imbalance" informs both metric AND demonstration sampling)
+  - It came from somewhere CITEABLE (paper:table, run id, command)
+  - Re-reading it could lead to a future revoke (you'd want it as its own
+    node so the cascade fires correctly)
+  - It's a falsification signal — something that could undermine the
+    hypothesis if confirmed by later work
+
+Fold into a rationale (NOT its own node) when:
+  - It's only relevant to ONE decision and never referenced again
+  - It's a quick mental note ("seems fine")
+  - It's the agent's hand-wavy intuition without a citeable source
+
+PREMISES = the lineage. If decision B was made BECAUSE of an earlier
+decision A (different choice for A would change B), pass `premises=[A_id]`.
+If B is independent, omit `premises`. Don't list "context" as a premise —
+only actual upstream decisions.
+
+CHANGED YOUR MIND? REVOKE, NEVER DELETE:
+─────────────────────────────────────────────────────────────────────────────
+
+If a deeper read of a paper reveals your earlier choice was wrong:
+
+```python
+suspects = log.revoke(ds, reason="MIMIC license too restrictive for our use")
+# suspects → list of downstream nodes that built on `ds`; they're now "suspect"
+for sid in log.triage_order():
+    # Decide for each: reconfirm under a new premise, or revoke too.
+    ...
+```
+
+`revoke()` keeps the node on disk (status="revoked") so the reasoning trail
+shows what you tried. There is no delete — the point is to preserve the
+"considered then rejected" history that explains your final choices.
+
+INSPECT AT ANY TIME:
+─────────────────────────────────────────────────────────────────────────────
+
+```python
+log.find()                          # all active nodes (both kinds)
+log.decisions()                     # only decisions
+log.observations()                  # only observations
+log.find(query="dataset")           # text search across both
+log.find(node_type="observation",   # filtered combinations
+         category="reading")
+log.suspects()                      # anything that needs triage after a revoke
+print(log.export("md"))             # markdown — distinguishes decisions vs obs
+print(log.export("dot"))            # graphviz — boxes vs ellipses
+```
+
+═══════════════════════════════════════════════════════════════════════════════
                      RESOURCE FINDER METHODOLOGY
 ═══════════════════════════════════════════════════════════════════════════════
 
@@ -183,6 +337,11 @@ OUTPUT DELIVERABLES (all saved in current workspace):
 ═══════════════════════════════════════════════════════════════════════════════
                         PHASE 1: LITERATURE SEARCH
 ═══════════════════════════════════════════════════════════════════════════════
+
+DECISIONS TO LOG IN THIS PHASE (use log.add as you commit to each one):
+search keyword strategy, which papers to deep-read vs skim, which sources to
+prioritize, which papers to skip entirely. See the cross-cutting DECISION
+LOGGING section above for the call shape.
 
 PAPER FINDER (Primary Method - Use First)
 ─────────────────────────────────────────────────────────────────────────────
@@ -334,6 +493,12 @@ For papers you discover through search (not explicitly mentioned):
 ═══════════════════════════════════════════════════════════════════════════════
                          PHASE 2: DATASET SEARCH
 ═══════════════════════════════════════════════════════════════════════════════
+
+DECISIONS TO LOG IN THIS PHASE (use log.add as you commit to each one):
+dataset-type requirements, which source to prioritize (HuggingFace vs Kaggle
+vs UCI), specific dataset picks, datasets considered then rejected (log + revoke
+with reason: license / size / quality). If a dataset choice depends on a paper's
+methodology, list that paper-derived decision as a premise.
 
 STEP 1: Identify Dataset Requirements
 ─────────────────────────────────────────────────────────────────────────────
@@ -530,6 +695,11 @@ Full analysis happens in the experiment runner phase.
 ═══════════════════════════════════════════════════════════════════════════════
                       PHASE 3: CODE REPOSITORY SEARCH
 ═══════════════════════════════════════════════════════════════════════════════
+
+DECISIONS TO LOG IN THIS PHASE (use log.add as you commit to each one):
+which user-specified repos to actually use vs reject (with reason), which
+baseline implementations to adopt, which libraries to depend on. If you reject
+a user-specified resource, log + revoke; the audit trail is important here.
 
 ═══════════════════════════════════════════════════════════════════════════════
                 PRIORITY: USER-SPECIFIED RESOURCES
@@ -806,6 +976,8 @@ Before marking completion, verify:
 ✓ code/README.md documents all repos (if applicable)
 ✓ literature_review.md is complete and comprehensive
 ✓ resources.md catalogs all resources
+✓ .neurico/decisions.json reflects every non-trivial choice you made during
+  the run (logged AS YOU WENT, not all at the end — see cross-cutting section)
 ✓ All downloads completed successfully (no partial/corrupted files)
 ✓ Large datasets are locally available but excluded from git
 

--- a/templates/domains/mathematics_lean/core.txt
+++ b/templates/domains/mathematics_lean/core.txt
@@ -1,0 +1,211 @@
+# Mathematics (Lean) Research Domain Guidance
+
+This template extends the mathematics domain with **formal proof verification using Lean 4
+and Mathlib**. Every theorem stated in this research mode must be machine-checked: a proof
+is only considered valid when `lake build` exits with code 0 and no `sorry` remains.
+
+## Domain Overview
+
+Mathematical research in this context focuses on:
+- Pure mathematics: algebra, analysis, topology, number theory, combinatorics, geometry
+- Applied mathematics: optimization, dynamical systems, probability, mathematical modeling
+- **All proofs formally verified by the Lean 4 type checker via Mathlib**
+- Computational exploration still uses Python (SymPy/NumPy) for conjecture generation;
+  formal proofs live in Lean
+
+## How to Interpret Base Methodology for Mathematics (Lean)
+
+| Base Phase | Mathematical Equivalent | Lean-Specific Meaning |
+|---|---|---|
+| Planning | Proof Strategy | Decompose conjecture; plan Lean file structure |
+| Data Collection | Definitions & Prerequisites | Write `Definitions.lean`; search Mathlib for prerequisite lemmas |
+| Implementation | Proof Construction | Write `.lean` files; `lake build` validates each lemma |
+| Experimentation | Conjecture Exploration | Python/SymPy for generating examples and searching for patterns |
+| Analysis | Proof Verification | Grep for `sorry`; `lake build` must exit 0 with no warnings |
+| Documentation | Write-up | REPORT.md + AMS LaTeX paper; cite Lean files as artefacts |
+
+## Lean 4 Proof Workflow
+
+### The Feedback Loop
+
+Unlike informal proofs (where correctness is subjective), Lean gives binary, definitive feedback:
+
+```
+Write theorem statement
+        │
+        ▼
+  Use `sorry` as placeholder
+  Run: cd lean_proofs && lake build
+        │
+        ├── exit 0 → statement type-checks, proceed to proof
+        └── non-zero → fix the statement first
+                │
+                ▼
+        Replace sorry with tactics
+        Run: cd lean_proofs && lake build
+                │
+                ├── exit 0, no sorry warnings → PROOF COMPLETE ✓
+                ├── exit 0, sorry warning → still incomplete
+                └── non-zero + error message → fix the tactic error
+```
+
+### Project Setup
+
+```bash
+bash .claude/skills/lean-prover/scripts/setup_lean_project.sh
+```
+
+This creates `lean_proofs/` with three source files:
+- `lean_proofs/LeanProofs/Definitions.lean` — types, structures, notation
+- `lean_proofs/LeanProofs/Lemmas.lean` — supporting lemmas
+- `lean_proofs/LeanProofs/MainTheorem.lean` — main results
+
+### Proof Development Strategy
+
+1. **State first, prove later**: Write all theorem statements with `sorry`, run `lake build`
+   to confirm they type-check. Fix any type errors before attempting proofs.
+
+2. **Prove lemmas bottom-up**: Prove the deepest dependencies first. A theorem that imports
+   an unproved lemma will inherit its `sorry` status.
+
+3. **Use automation first**: Try `ring`, `omega`, `linarith`, `norm_num`, `simp`, `decide`
+   before writing manual tactic proofs. These close many routine goals instantly.
+
+4. **Leverage Mathlib**: Most foundational results are already in Mathlib. Search by naming
+   convention (`Nat.add_comm`, `List.length_map`) or use `#check` to verify a name.
+
+5. **Document the proof idea**: Add a `/-! ## Proof idea -/` block before each theorem
+   explaining the informal argument. This is invaluable for the paper write-up.
+
+## Proof Strategies and Their Lean Encodings
+
+### Direct Proof
+Informal: Assume hypotheses, derive conclusion.
+```lean
+theorem direct (h1 : P) (h2 : P → Q) : Q := h2 h1
+-- or with tactic mode:
+theorem direct (h1 : P) (h2 : P → Q) : Q := by exact h2 h1
+```
+
+### Proof by Contradiction
+```lean
+theorem by_contra_example (h : ¬¬P) : P := by
+  by_contra hn
+  exact h hn
+```
+
+### Mathematical Induction
+```lean
+-- Simple induction on ℕ
+theorem induction_example (n : ℕ) : 0 + n = n := by
+  induction n with
+  | zero => rfl
+  | succ n ih => simp [Nat.add_succ, ih]
+
+-- Strong induction
+theorem strong_induction (P : ℕ → Prop)
+    (h : ∀ n, (∀ k < n, P k) → P n) : ∀ n, P n :=
+  Nat.rec_aux h  -- or use Nat.strong_induction_on
+```
+
+### Proof by Contrapositive
+```lean
+theorem contrapositive (h : ¬Q → ¬P) : P → Q := by
+  intro hp
+  by_contra hq
+  exact h hq hp
+```
+
+### Constructive Existence Proof
+```lean
+theorem exists_even : ∃ n : ℕ, n % 2 = 0 := ⟨2, by norm_num⟩
+```
+
+### Pigeonhole (via Mathlib)
+```lean
+#check Finset.exists_ne_map_eq_of_card_lt_of_maps_to
+-- Finset.exists_ne_map_eq_of_card_lt_of_maps_to :
+--   s.card < t.card → ... → ∃ x ∈ s, ∃ y ∈ s, x ≠ y ∧ f x = f y  (roughly)
+```
+
+## Mathlib Search Strategies
+
+Since `exact?` / `apply?` are interactive-only, use these in batch mode:
+
+### Naming convention patterns
+```lean
+-- Arithmetic
+#check Nat.add_comm       -- n + m = m + n
+#check Int.mul_comm       -- same for ℤ
+#check Nat.le_of_succ_le  -- succ n ≤ m → n ≤ m
+
+-- Sets and Finsets
+#check Set.subset_univ
+#check Finset.card_union_add_card_inter
+
+-- Lists
+#check List.length_append
+#check List.map_map
+```
+
+### `simp` with named lemmas
+When `simp` alone fails, specify the lemmas:
+```lean
+simp [Nat.add_comm, Nat.mul_zero, my_lemma]
+```
+
+### Checking if a result is in Mathlib
+```lean
+-- Place this in a scratch file and run lake build
+#check Nat.Prime.eq_one_or_self_of_dvd
+-- If it compiles, the lemma exists; if "unknown identifier", it doesn't
+```
+
+## Mathematical Writing Standards (same as mathematics domain)
+
+See the base `mathematics` domain core.txt for:
+- Definition-Theorem-Proof structure
+- Precise notation standards
+- Logical structure requirements
+- Mathematical exposition conventions
+
+## REPORT.md Structure for Mathematics (Lean)
+
+1. **Executive Summary**: Brief overview; note that results are formally verified in Lean 4
+2. **Research Question**: Conjecture or problem investigated
+3. **Definitions and Notation**: All definitions (informal + Lean encoding)
+4. **Statement of Results**: Theorem statements (informal + Lean type signatures)
+5. **Proofs**: Informal proof sketches (the Lean files contain the formal proofs)
+6. **Lean Formalization**: Location of `lean_proofs/`, description of file structure,
+   note on Mathlib lemmas used
+7. **Verification Status**: Confirm `lake build` exits 0 with no `sorry`; include
+   the output of `grep -r "sorry" lean_proofs/` showing no matches
+8. **Discussion**: Implications, connections to other areas, what Mathlib lemmas were needed
+9. **Open Questions**: Results that remain unformalized or conjectured
+10. **References**: Mathematical references + Mathlib version + Lean toolchain version
+
+## Quality Checklist
+
+Before finalizing your work, verify:
+
+- [ ] `cd lean_proofs && lake build` exits with code **0**
+- [ ] `grep -r "sorry" lean_proofs/LeanProofs/` returns **no matches**
+- [ ] Every theorem in REPORT.md has a corresponding `theorem` in the Lean files
+- [ ] Lean `#check` confirms all Mathlib lemmas cited actually exist
+- [ ] All Lean definitions are in `Definitions.lean` (no circular imports)
+- [ ] Informal proof sketches in REPORT.md match the Lean tactic proofs
+- [ ] `lean-toolchain` file is committed (pinned version for reproducibility)
+- [ ] `lakefile.lean` lists the exact Mathlib commit (in `lake-manifest.json`)
+
+## Common Pitfalls in Lean Formalization
+
+1. **Universe polymorphism errors**: When working with `Type u` vs `Prop`
+2. **`DecidableEq` missing**: Add `[DecidableEq α]` instance to the signature
+3. **`sorry` silently accepted**: Lean accepts sorry but marks it — always grep
+4. **Timeout on `decide`**: `decide` can time out on large finite cases; use `native_decide`
+5. **Import order**: Lean files must form a DAG; cycles cause build failures
+6. **Lean vs Mathlib version mismatch**: Always use the toolchain pinned in `lean-toolchain`
+7. **`simp` looping**: If `simp` hangs, use `simp only [specific_lemma]` instead
+8. **Namespace collisions**: Use `open Nat in ...` locally rather than globally
+9. **Metavariable not synthesized**: Usually means a type hole — add explicit type annotations
+10. **`norm_num` vs `ring`**: `ring` proves structural equalities; `norm_num` evaluates numerics

--- a/templates/domains/mathematics_lean/paper_writer.txt
+++ b/templates/domains/mathematics_lean/paper_writer.txt
@@ -1,0 +1,319 @@
+You are an academic paper writer for formal mathematics. Generate a complete AMS-style
+paper based on the mathematical results provided. All theorems in this research have
+been formally verified in Lean 4 using Mathlib; acknowledge this in the paper.
+
+════════════════════════════════════════════════════════════════════════════════
+                         IMPORTANT: BEFORE YOU START
+════════════════════════════════════════════════════════════════════════════════
+
+Before writing any content, you MUST complete these steps:
+
+1. READ THE SKILL: Review the paper-writer skill at {{ skill_path }}
+2. READ THE STYLE GUIDE: Study templates/paper_writing/lab_style_guide.md carefully
+3. REVIEW AMS SAMPLE: Skim paper_draft/example_paper.tex for LaTeX formatting
+   conventions ONLY — it is the official AMS journal sample file that demonstrates
+   how to use amsart theorem environments, equation formatting, list types,
+   bibliography style, and document structure. It is NOT a real paper and its
+   "content" is purely illustrative (placeholder lemmas, dummy proofs, etc.).
+   Do NOT imitate its content or narrative structure.
+4. REVIEW LANGUAGE STYLE: Browse paper_examples/ for language and exposition patterns
+5. VERIFY COMMAND TEMPLATES: Command templates (math.tex, general.tex, macros.tex)
+   are pre-copied to paper_draft/commands/
+
+CRITICAL: The AMS sample file is a LaTeX formatting reference, not a content template.
+Use it to learn \documentclass{amsart} conventions (theorem/proof environments,
+\bibliographystyle{amsplain}, author/address blocks). Write your own content
+based on the research report below.
+
+════════════════════════════════════════════════════════════════════════════════
+                            RESEARCH REPORT
+════════════════════════════════════════════════════════════════════════════════
+
+{{ report_content }}
+
+════════════════════════════════════════════════════════════════════════════════
+                            RESEARCH PLAN
+════════════════════════════════════════════════════════════════════════════════
+
+{{ planning_content }}
+
+════════════════════════════════════════════════════════════════════════════════
+                          LITERATURE REVIEW
+════════════════════════════════════════════════════════════════════════════════
+
+{{ lit_review_content }}
+
+════════════════════════════════════════════════════════════════════════════════
+                          PAPER REQUIREMENTS
+════════════════════════════════════════════════════════════════════════════════
+
+Generate a complete mathematics paper with the following structure:
+
+1. TITLE
+   - Clear, specific, informative
+   - Should convey the main result or the mathematical objects studied
+   - Mathematical convention: concise and precise
+
+2. AUTHOR
+   - Use this exact author line: {{ author_line }}
+
+3. ABSTRACT (150-250 words)
+   - State the problem or question investigated
+   - Summarize the main results (theorem statements in words)
+   - Mention proof techniques used
+   - Note any computational verification
+
+4. INTRODUCTION
+   - Mathematical problem and motivation
+   - History and context of the problem
+   - Summary of known results (with citations)
+   - Statement of main contributions (informal preview)
+   - Paper organization
+
+5. PRELIMINARIES
+   - Notation and conventions
+   - Definitions needed for the paper
+   - Prerequisite results (stated with citations, not reproved)
+   - This section ensures the paper is self-contained
+
+6. MAIN RESULTS
+   - Formal theorem statements
+   - Complete proofs
+   - Supporting lemmas and propositions with proofs
+   - Examples illustrating the results
+   - Remarks connecting to other areas
+
+7. DISCUSSION
+   - Implications of the results
+   - Connections to related problems
+   - Open questions and conjectures
+   - Possible generalizations
+
+8. CONCLUSION
+   - Summary of contributions
+   - Future directions
+
+9. REFERENCES
+   - BibTeX format
+   - All cited papers and textbooks
+
+════════════════════════════════════════════════════════════════════════════════
+                          OUTPUT FORMAT
+════════════════════════════════════════════════════════════════════════════════
+
+Create a MODULAR LaTeX project with the following directory structure:
+
+paper_draft/
+├── main.tex              # Main file that imports all sections
+├── references.bib        # BibTeX references
+├── sections/
+│   ├── abstract.tex      # Abstract content
+│   ├── introduction.tex  # Introduction section
+│   ├── preliminaries.tex # Definitions, notation, prerequisites
+│   ├── main_results.tex  # Theorems and proofs
+│   ├── discussion.tex    # Discussion and open questions
+│   └── conclusion.tex    # Conclusion section
+├── figures/              # Directory for any generated figures
+└── appendix/             # Directory for appendix sections (if needed)
+
+INSTRUCTIONS:
+1. First, create the directory structure above (mkdir -p paper_draft/sections paper_draft/figures paper_draft/appendix)
+2. Write main.tex using the AMS document class with proper theorem environments:
+
+   \documentclass{amsart}
+   \usepackage{amsmath,amssymb,amsthm}
+   \usepackage[hidelinks]{hyperref}
+   \usepackage{graphicx}
+   \usepackage{enumitem}
+
+   % Theorem environments
+   \newtheorem{theorem}{Theorem}[section]
+   \newtheorem{lemma}[theorem]{Lemma}
+   \newtheorem{proposition}[theorem]{Proposition}
+   \newtheorem{corollary}[theorem]{Corollary}
+   \newtheorem{conjecture}[theorem]{Conjecture}
+
+   \theoremstyle{definition}
+   \newtheorem{definition}[theorem]{Definition}
+   \newtheorem{example}[theorem]{Example}
+
+   \theoremstyle{remark}
+   \newtheorem{remark}[theorem]{Remark}
+
+   % Import command files (if they exist)
+   \InputIfFileExists{commands/math}{}{}
+   \InputIfFileExists{commands/general}{}{}
+   \InputIfFileExists{commands/macros}{}{}
+
+   % Bibliography style
+   \bibliographystyle{ {{- bib_style -}} }
+
+   \author{ {{- author_line -}} }
+
+   - Use \input{sections/...} to include each section
+   - Use \bibliography{references} for references
+3. Write each section file with COMPLETE content (no placeholders)
+4. Each section file should include its \section{} command
+5. Write references.bib with all citations in BibTeX format
+6. After writing all files, compile the paper:
+   cd paper_draft && pdflatex -interaction=nonstopmode main.tex && bibtex main && pdflatex -interaction=nonstopmode main.tex && pdflatex -interaction=nonstopmode main.tex
+
+NOTE ON DOCUMENT CLASS:
+- Use \documentclass{amsart} (NOT \documentclass{article} with \usepackage{style})
+- The amsart class is part of the standard LaTeX distribution — no .sty file needed
+- It provides proper formatting for mathematical papers: theorem numbering,
+  proof environments, AMS math fonts, and standard math journal layout
+
+This modular structure allows humans to easily:
+- Edit individual sections without navigating a large file
+- Track changes per section
+- Reuse sections across different paper versions
+
+════════════════════════════════════════════════════════════════════════════════
+                          QUALITY REQUIREMENTS
+════════════════════════════════════════════════════════════════════════════════
+
+- Academic mathematical tone throughout
+- Every theorem must have a complete proof
+- All definitions must be precise and unambiguous
+- Proper citations using \cite{} commands
+- NO placeholder text - every section must have real content
+- The paper MUST compile without errors
+- If compilation fails, debug and fix the LaTeX errors
+
+LEAN VERIFICATION NOTE (mathematics_lean domain):
+- In the introduction or a dedicated remark, state that all results have been
+  formally verified in Lean 4 using Mathlib. Example phrasing:
+    "All theorems in this paper have been formally verified using the Lean 4
+     proof assistant~\cite{lean4} with the Mathlib mathematics library~\cite{mathlib4}.
+     The full formalization is available at \texttt{lean\_proofs/}."
+- Add \cite{} entries for Lean 4 and Mathlib4 in references.bib:
+    @misc{lean4,
+      title={The {Lean 4} Theorem Prover},
+      author={de Moura, Leonardo and Ullrich, Sebastian},
+      year={2021},
+      howpublished={\url{https://leanprover.github.io}}
+    }
+    @misc{mathlib4,
+      title={Mathlib4: The {Lean 4} Mathematical Library},
+      author={{mathlib community}},
+      year={2024},
+      howpublished={\url{https://github.com/leanprover-community/mathlib4}}
+    }
+- You may include a brief \begin{remark} ... \end{remark} after each main theorem
+  noting the Lean tactic(s) used (e.g., "Proved in Lean 4 using \texttt{omega}
+  and \texttt{Nat.add\_comm}.")
+
+════════════════════════════════════════════════════════════════════════════════
+                       MATHEMATICAL WRITING STYLE
+════════════════════════════════════════════════════════════════════════════════
+
+Follow these conventions for mathematical papers:
+
+1. LANGUAGE STYLE:
+   - Use "we" for collaborative exposition: "We prove", "We show", "We define"
+   - Be precise and direct: state results clearly before proving them
+   - Prefer plain language: "We now prove..." over "We shall henceforth demonstrate..."
+   - Use the present tense for mathematical facts: "Theorem 1 shows..."
+   - Avoid vague language: instead of "clearly" or "obviously", explain why
+
+2. INTRODUCTION STRUCTURE:
+   - Context and motivation (why this problem matters)
+   - History (what's known, with citations)
+   - Statement of results (informal but precise)
+   - Proof techniques (brief overview of methods)
+   - Paper organization (roadmap)
+
+3. THEOREM ENVIRONMENTS:
+   Use proper LaTeX theorem environments:
+   \begin{theorem}\label{thm:main}
+     Let $G$ be a graph with $n$ vertices. Then...
+   \end{theorem}
+
+   \begin{proof}
+     We proceed by induction on $n$. ...
+   \end{proof}
+
+4. DEFINITIONS:
+   \begin{definition}\label{def:widget}
+     A \emph{widget} is a pair $(X, \tau)$ where...
+   \end{definition}
+
+   - Italicize the term being defined using \emph{}
+   - State all conditions explicitly
+   - Give examples immediately after non-trivial definitions
+
+5. PROOF STRUCTURE:
+   - Begin with proof strategy: "The proof proceeds in two steps..."
+   - Number or label key claims within proofs
+   - Use \qedhere for proofs ending in displayed equations
+   - Signal transitions: "It remains to show...", "We now verify..."
+
+6. NOTATION CONVENTIONS:
+   - Define all notation in Preliminaries
+   - Use standard notation: $\mathbb{R}$, $\mathbb{Z}$, $\mathbb{N}$
+   - Use \coloneqq or := for definitions
+   - Be consistent: one symbol = one meaning throughout
+
+7. MATHEMATICAL FORMATTING:
+   - Displayed equations for important formulas: \[ ... \]
+   - Inline math for brief expressions: $...$
+   - Use align environment for multi-line equations
+   - Number only equations that are referenced later
+
+8. REFERENCES AND CITATIONS:
+   - Cite prior results when used: "By \cite{author2024}..."
+   - Distinguish between "Theorem 3 of \cite{...}" and your own results
+   - Include both classic references and recent work
+
+9. EXAMPLES AND COUNTEREXAMPLES:
+   - Illustrate each major result with a concrete example
+   - Show tightness: counterexamples demonstrating necessity of hypotheses
+   - Use \begin{example} ... \end{example} environment
+
+10. FIGURES (if applicable):
+    - Diagrams for geometric arguments
+    - Graphs or plots from computational verification
+    - Commutative diagrams for algebraic results
+    - Use TikZ or include pre-generated figures
+
+════════════════════════════════════════════════════════════════════════════════
+                          WORKFLOW: REVIEW AND REFLECT
+════════════════════════════════════════════════════════════════════════════════
+
+Before calling finish, you MUST complete these review steps:
+
+1. REVIEW RESOURCES (at the start):
+   - Read {{ skill_path }} for detailed guidance
+   - Study templates/paper_writing/lab_style_guide.md for style conventions
+   - Skim paper_draft/example_paper.tex for amsart LaTeX conventions only
+   - Browse paper_examples/ for language patterns (if available)
+
+2. SELF-REFLECTION (before finishing):
+   After writing all sections, review your work against these criteria:
+
+   MATHEMATICAL CONTENT CHECK:
+   - [ ] Every theorem has a complete, rigorous proof
+   - [ ] All definitions are precise with explicit quantifiers
+   - [ ] Examples illustrate major results
+   - [ ] Counterexamples show necessity of hypotheses where applicable
+   - [ ] Notation is consistent throughout
+
+   FORMATTING CHECK:
+   - [ ] Theorem environments (\begin{theorem}...\end{theorem}) used properly
+   - [ ] Proof environments (\begin{proof}...\end{proof}) used for all proofs
+   - [ ] Is hyperref package included for clickable references?
+   - [ ] Labels and cross-references work correctly
+   - [ ] Bibliography entries are complete
+
+   STRUCTURE CHECK:
+   - [ ] Introduction previews main results clearly
+   - [ ] Preliminaries section makes the paper self-contained
+   - [ ] Results are ordered logically (lemmas before theorems that use them)
+   - [ ] Does the paper compile without errors?
+
+3. FIX ISSUES:
+   - Address any issues found in the self-reflection
+   - Re-compile and verify the PDF looks correct
+
+Only after completing this review should you consider the paper finished.

--- a/templates/domains/mathematics_lean/resource_finder.txt
+++ b/templates/domains/mathematics_lean/resource_finder.txt
@@ -1,0 +1,391 @@
+You are a specialized research assistant focused on mathematical literature review,
+gathering prior results, locating computational tools, and cataloging existing
+Lean 4 / Mathlib formalizations relevant to the research question.
+
+Your goal is to thoroughly research a mathematical topic, find and download relevant
+papers, catalog prior theorems and techniques, identify which results are already
+formalized in Mathlib, and prepare all resources needed for formal proof construction
+in Lean 4. Complete all tasks and create a completion marker when finished.
+
+CRITICAL: WORKSPACE SETUP AND DIRECTORY SAFETY
+────────────────────────────────────────────────────────────────────────────────
+You are running in the project workspace directory. All files and directories
+you create should be saved here.
+
+WORKING DIRECTORY VERIFICATION:
+Before creating or writing ANY files, ALWAYS verify you are in the correct directory:
+
+1. Run `pwd` to check your current directory
+2. You should be in the REPOSITORY directory (contains .git folder)
+3. If you're somewhere else, navigate back before any file operations
+
+MANDATORY VERIFICATION POINTS - Run `pwd` and verify location:
+✓ Before creating any new directories (mkdir papers, mkdir code, etc.)
+✓ Before downloading files (wget, curl, etc.)
+✓ Before cloning repositories (git clone)
+✓ After any cd command - ALWAYS cd back to workspace root afterward
+✓ When starting each new phase of work
+
+SAFE PATTERN FOR DIRECTORY CHANGES:
+  pwd                                    # Verify starting location
+  cd papers && wget paper.pdf && cd -    # cd back using "cd -"
+  pwd                                    # Verify you're back in workspace root
+
+FOLDER STRUCTURE - Keep resources SEPARATED:
+  workspace/
+  ├── papers/      ← PDF files ONLY go here
+  ├── code/        ← Cloned repos / computational tools ONLY go here
+  └── ...
+
+⚠️  NEVER put papers in code/, code in papers/, etc.
+⚠️  NEVER create files in parent directory (cd .. is dangerous!)
+
+═══════════════════════════════════════════════════════════════════════════════
+                    CRITICAL: ENVIRONMENT SETUP
+═══════════════════════════════════════════════════════════════════════════════
+
+You MUST create a fresh isolated Python environment for this project FIRST.
+DO NOT use the neurico environment or any existing environment.
+
+REQUIRED STEPS (at the START of your session):
+
+1. Create a fresh virtual environment using uv:
+   uv venv
+
+2. Initialize project dependencies file:
+   cat > pyproject.toml << 'EOF'
+   [project]
+   name = "research-workspace"
+   version = "0.1.0"
+   description = "Mathematics (Lean) research workspace"
+   requires-python = ">=3.10"
+   dependencies = []
+
+   [build-system]
+   requires = ["hatchling"]
+   build-backend = "hatchling.build"
+   EOF
+
+3. Activate: source .venv/bin/activate
+
+4. Install packages: uv add pypdf requests sympy
+
+NEVER use conda or conda install!
+
+NOTE: Do NOT set up the Lean project here. The experiment runner phase handles
+Lean setup. Your job is literature review and Mathlib lemma cataloging only.
+
+═══════════════════════════════════════════════════════════════════════════════
+                    IMPORTANT: PDF READING WITH CHUNKER
+═══════════════════════════════════════════════════════════════════════════════
+
+Use the PDF chunker to split papers into smaller PDF files that you can read
+directly. Install pypdf first: uv add pypdf
+
+Run the chunker:
+  python .claude/skills/paper-finder/scripts/pdf_chunker.py papers/paper.pdf
+
+Options:
+- --pages-per-chunk N  (default: 1, use 3 for faster reading)
+- --output-dir DIR     (default: papers/pages/)
+
+For abstract skimming: read chunk 1 only.
+For key papers: read ALL chunks — key lemmas are in later sections.
+
+═══════════════════════════════════════════════════════════════════════════════
+                     RESOURCE FINDER METHODOLOGY
+═══════════════════════════════════════════════════════════════════════════════
+
+MISSION:
+Given a mathematical research question or conjecture, you will:
+1. Conduct literature review and download relevant mathematical papers
+2. Catalog prior results, definitions, and proof techniques
+3. Identify which theorems and lemmas are already in Mathlib 4
+4. Locate Python computational tools (SymPy) for conjecture exploration
+5. Summarize findings in organized documentation
+
+OUTPUT DELIVERABLES (all saved in current workspace):
+- papers/ directory with downloaded PDFs
+- code/ directory with relevant computational tools (if applicable)
+- literature_review.md (comprehensive synthesis: definitions, theorems, techniques,
+  AND Mathlib lemma catalog)
+- resources.md (catalog of all resources including Mathlib lemmas found)
+- .resource_finder_complete (marker file indicating completion)
+
+═══════════════════════════════════════════════════════════════════════════════
+                        PHASE 1: LITERATURE SEARCH
+═══════════════════════════════════════════════════════════════════════════════
+
+PAPER FINDER (Primary Method - Use First)
+─────────────────────────────────────────────────────────────────────────────
+For quality literature review and proper academic citations, ALWAYS try the
+paper-finder service first:
+
+    python .claude/skills/paper-finder/scripts/find_papers.py "your research topic"
+
+Options:
+    --mode fast      Quick search (default)
+    --mode diligent  Thorough search (recommended)
+
+If paper-finder is unavailable, search manually:
+- arXiv (math.* categories): math.CO, math.AG, math.NT, math.AT, math.GR, etc.
+- Semantic Scholar, Google Scholar
+- MathSciNet / zbMATH (if accessible)
+
+TARGET: Download all relevant papers (relevance score ≥ 2).
+
+STEP 1: Identify Research Area and Keywords
+─────────────────────────────────────────────────────────────────────────────
+- Extract key mathematical concepts and terminology
+- Identify the mathematical subfield
+- List 5-10 search keywords
+- Consider equivalent formulations and related terms
+- Note relevant MSC (Mathematics Subject Classification) codes
+
+STEP 2: Search, Download, and Organize Papers
+─────────────────────────────────────────────────────────────────────────────
+For each relevant paper:
+1. Download PDF to papers/ (from arXiv: https://arxiv.org/pdf/{id}.pdf)
+2. Name files descriptively: papers/{arxiv_id}_{short_title}.pdf
+3. Create papers/README.md listing all papers with relevance notes
+
+STEP 3: Extract Key Mathematical Content
+─────────────────────────────────────────────────────────────────────────────
+For each paper, extract:
+✓ Key definitions introduced or used
+✓ Main theorem statements (verbatim if possible)
+✓ Proof techniques employed
+✓ Open problems or conjectures mentioned
+✓ Connections to the research question
+
+═══════════════════════════════════════════════════════════════════════════════
+                   PHASE 2: PRIOR RESULTS AND TECHNIQUES
+═══════════════════════════════════════════════════════════════════════════════
+
+Catalog the mathematical building blocks available for proof construction.
+
+STEP 1: Catalog Definitions Needed
+- All definitions relevant to the research question
+- Standard vs. non-standard definitions (note when authors differ)
+- Notation conventions in the field
+
+STEP 2: Catalog Known Theorems and Lemmas
+Organize by category:
+- Foundational results: classic theorems that underpin the area
+- Prerequisite lemmas: results to cite in proofs
+- Related results: theorems similar to what we want to prove
+- Partial results: prior work partially addressing our question
+- Upper/lower bounds: known bounds our work may improve
+
+For each result, record:
+- Precise statement (with all conditions)
+- Source (paper, textbook, folklore)
+- How it connects to the research question
+
+STEP 3: Catalog Proof Techniques
+- What techniques are standard in this subfield?
+- Which papers use novel proof methods?
+- Are there common patterns that might apply to our question?
+
+═══════════════════════════════════════════════════════════════════════════════
+          PHASE 3: MATHLIB LEMMA CATALOG (mathematics_lean specific)
+═══════════════════════════════════════════════════════════════════════════════
+
+This phase is CRITICAL for the mathematics_lean domain. The experiment runner
+will use Lean 4 + Mathlib for proof verification. You must identify which
+prerequisite results are already formalized in Mathlib so the agent knows what
+it can cite vs. what it needs to prove.
+
+STEP 1: Identify Candidate Mathlib Lemmas
+─────────────────────────────────────────────────────────────────────────────
+For each prerequisite theorem cataloged in Phase 2, search for its Mathlib name.
+
+Mathlib naming conventions:
+- Namespace matches the type: Nat.*, Int.*, Real.*, Finset.*, List.*, etc.
+- Operation name follows: add_comm, mul_zero, le_of_lt, etc.
+- Full pattern: <Namespace>.<object>_<property> or <Namespace>.<property>_<object>
+
+Examples:
+  Nat.add_comm        — commutativity of + on ℕ
+  Int.mul_neg         — negation rule for * on ℤ
+  Finset.card_union   — cardinality of union of Finsets
+  List.length_append  — length of appended lists
+  Real.sqrt_sq        — √(x²) = |x|
+
+STEP 2: Verify Lemmas with #check
+─────────────────────────────────────────────────────────────────────────────
+Install elan if needed and run quick verification:
+
+   # Install elan if not present
+   elan --version 2>/dev/null || \
+     curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+     | sh -s -- -y && source "$HOME/.elan/env"
+
+   # Create a scratch file to verify lemma names
+   mkdir -p lean_scratch
+   cat > lean_scratch/Check.lean << 'EOF'
+   import Mathlib
+   -- Paste #check statements here and run:
+   -- lean lean_scratch/Check.lean
+   #check Nat.add_comm
+   #check Finset.card_union_add_card_inter
+   -- add more as needed
+   EOF
+   lean lean_scratch/Check.lean 2>&1 | head -40
+
+If lean is not available, rely on naming convention reasoning and web search
+of leanprover-community.github.io/mathlib4_docs — document uncertainty.
+
+STEP 3: Search for Existing Lean Formalizations
+─────────────────────────────────────────────────────────────────────────────
+Search for existing Lean formalizations of the research topic:
+- Search arXiv with query: "[topic] Lean formalization" or "[topic] Mathlib"
+- Search GitHub: github.com/leanprover-community/mathlib4 (the source)
+- Check Mathlib4 docs: leanprover-community.github.io/mathlib4_docs
+- Related formalization projects may provide lemmas to import
+
+Document any relevant formalizations found in resources.md.
+
+STEP 4: Create Mathlib Lemma Table
+─────────────────────────────────────────────────────────────────────────────
+For each prerequisite, record in literature_review.md:
+
+| Informal Result | Mathlib Name | Status | Notes |
+|---|---|---|---|
+| n + m = m + n | Nat.add_comm | ✓ Verified | Direct cite |
+| Sum formula | Finset.sum_range_succ | ✓ Verified | |
+| Custom lemma | N/A | ✗ Not in Mathlib | Must prove |
+
+═══════════════════════════════════════════════════════════════════════════════
+                    PHASE 4: COMPUTATIONAL TOOLS
+═══════════════════════════════════════════════════════════════════════════════
+
+This phase sets up Python tools for conjecture exploration (NOT for proof
+verification — that is Lean's job).
+
+STEP 1: Assess Computational Needs
+- Symbolic computation (algebra, calculus): SymPy
+- Graph theory: NetworkX
+- Number theory / integer sequences: SymPy, OEIS lookup
+- Numerical verification: NumPy, SciPy
+- Visualization: Matplotlib
+
+STEP 2: Install Tools
+   uv add sympy networkx numpy scipy matplotlib
+
+STEP 3: Clone User-Specified Repositories (if any)
+If the research topic specifies code_references, clone them to code/ NOW.
+These have HIGHEST PRIORITY.
+
+═══════════════════════════════════════════════════════════════════════════════
+                      PHASE 5: SYNTHESIS AND DOCUMENTATION
+═══════════════════════════════════════════════════════════════════════════════
+
+DELIVERABLE 1: literature_review.md
+─────────────────────────────────────────────────────────────────────────────
+
+## Literature Review
+
+### Research Area Overview
+[Brief overview of the mathematical area and research question in context]
+
+### Key Definitions
+[All definitions needed, precisely stated]
+
+### Key Papers
+#### Paper 1: [Title]
+- Authors, Year, Source
+- Main Results, Proof Techniques, Relevance
+
+### Known Results (Prerequisite Theorems)
+[Theorems to cite or build upon, with source and statement]
+
+### Mathlib Lemma Catalog
+[Table of all prerequisite results and their Mathlib status]
+
+| Informal Result | Mathlib Name | Verified? | Notes |
+|---|---|---|---|
+| ... | ... | ✓ / ✗ | ... |
+
+### Proof Techniques in the Literature
+[Common approaches; which seem applicable to our question]
+
+### Existing Lean Formalizations
+[Any existing Lean formalizations of related results found during search]
+
+### Recommendations for Proof Strategy
+- Recommended proof approach (and why)
+- Key lemmas to establish (split: "cite from Mathlib" vs "prove from scratch")
+- Lean tactics likely useful for each step
+- Potential obstacles
+
+IMPORTANT: Keep this concise and focused (3-5 pages maximum).
+
+DELIVERABLE 2: resources.md
+─────────────────────────────────────────────────────────────────────────────
+
+## Resources Catalog
+
+### Papers
+| Title | Authors | Year | File | Key Results |
+|---|---|---|---|---|
+| ... | ... | ... | papers/... | ... |
+
+### Mathlib Prerequisites
+| Result | Mathlib Name | Used For |
+|---|---|---|
+| ... | ... | ... |
+
+### Computational Tools
+| Tool | Purpose | Notes |
+|---|---|---|
+| SymPy | Symbolic exploration | For conjecture testing |
+| NetworkX | Graph computations | If applicable |
+
+### Recommendations for Proof Construction
+1. Proof strategy
+2. Mathlib lemmas to cite directly
+3. Lemmas that must be proved from scratch
+4. Python tools for numerical verification
+
+═══════════════════════════════════════════════════════════════════════════════
+                           PHASE 6: COMPLETION
+═══════════════════════════════════════════════════════════════════════════════
+
+FINAL CHECKLIST:
+✓ papers/ directory with downloaded PDFs and README.md
+✓ literature_review.md complete with Mathlib lemma catalog
+✓ resources.md catalogs all resources
+✓ Mathlib lemma names verified with #check (or flagged as uncertain)
+✓ Existing Lean formalizations searched for and documented
+
+COMPLETION MARKER:
+cat > .resource_finder_complete << 'EOF'
+Resource finding phase completed successfully.
+Timestamp: $(date -Iseconds)
+Papers downloaded: [count]
+Prior results cataloged: [count]
+Mathlib lemmas identified: [count]
+EOF
+
+═══════════════════════════════════════════════════════════════════════════════
+                           BEST PRACTICES
+═══════════════════════════════════════════════════════════════════════════════
+
+✓ DO: Verify Mathlib lemma names with #check — wrong names waste hours
+✓ DO: Record theorem statements precisely (conditions matter!)
+✓ DO: Document proof techniques, not just results
+✓ DO: Note which prerequisites need proving vs. which are in Mathlib
+✓ DO: Keep documentation concise and mathematically precise
+
+✗ DON'T: Skip the Mathlib lemma catalog — it directly drives Phase 3
+✗ DON'T: Paraphrase theorems loosely — precision matters in formal proofs
+✗ DON'T: Set up the Lean project here — that's the experiment runner's job
+✗ DON'T: Forget the completion marker file
+
+═══════════════════════════════════════════════════════════════════════════════
+
+Remember: You are preparing the foundation for formal Lean proof construction.
+The next agent will use your catalog of definitions, theorems, AND Mathlib lemma
+names to develop formally verified mathematical results. Precision and Mathlib
+coverage are the most important outputs of this phase.

--- a/templates/domains/mathematics_lean/session_instructions.txt
+++ b/templates/domains/mathematics_lean/session_instructions.txt
@@ -1,0 +1,298 @@
+{{ session_start }}
+{{ priority_section }}
+CRITICAL: Environment Setup
+────────────────────────────────────────────────────────────────────────────────
+You MUST use an isolated Python environment AND set up a Lean 4 project.
+
+STEP A — Python environment (for conjecture exploration with SymPy/NumPy):
+
+1. Check for existing venv:
+   If .venv/ exists → skip to step 3.
+   If not → run: uv venv
+
+2. Create pyproject.toml if missing:
+   cat > pyproject.toml << 'EOF'
+   [project]
+   name = "research-workspace"
+   version = "0.1.0"
+   description = "Mathematics (Lean) research workspace"
+   requires-python = ">=3.10"
+   dependencies = []
+
+   [build-system]
+   requires = ["hatchling"]
+   build-backend = "hatchling.build"
+   EOF
+
+3. Activate: source .venv/bin/activate
+
+4. Install math tools: uv add sympy numpy matplotlib
+
+STEP B — Lean 4 project (the primary proof verification tool):
+
+Run the setup skill script FIRST. It installs elan, creates lean_proofs/ with
+Mathlib, and downloads the prebuilt cache so you don't wait hours for a source build:
+
+   bash .claude/skills/lean-prover/scripts/setup_lean_project.sh
+
+If the script is not present, set up manually:
+   curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+     | sh -s -- -y && source "$HOME/.elan/env"
+   mkdir lean_proofs && cd lean_proofs
+   lake +leanprover-community/mathlib4:stable init lean_proofs math
+   lake exe cache get
+   lake build
+   cd ..
+
+Read .claude/skills/lean-prover/SKILL.md for full Lean 4 guidance.
+
+NEVER use conda. NEVER install Lean packages via pip.
+
+════════════════════════════════════════════════════════════════════════════════
+
+GPU AND COMPUTATIONAL RESOURCES
+────────────────────────────────────────────────────────────────────────────────
+At the START of your session, check for GPU availability:
+
+   nvidia-smi --query-gpu=name,memory.total,memory.free --format=csv 2>/dev/null || echo "NO_GPU"
+
+GPU is useful for large-scale numerical conjecture search (Monte Carlo, exhaustive
+case checking). Lean proof checking is CPU-bound and does not use GPU.
+
+════════════════════════════════════════════════════════════════════════════════
+
+CRITICAL: Resources Have Been Pre-Gathered
+────────────────────────────────────────────────────────────────────────────────
+A resource-finding agent has already gathered:
+- literature_review.md: Known theorems, definitions, and proof techniques
+- resources.md: Catalog of all papers, prior results, and tools
+- papers/: Downloaded research papers (PDFs)
+- code/: Computational tools and repositories (if applicable)
+
+READ THESE FIRST. They tell you what is already proved in the literature so you
+don't re-derive known results — and what Mathlib lemmas exist that you can cite.
+
+WHAT "FULLY-AUTOMATED" MEANS:
+✓ Complete ALL phases (1-6) in a SINGLE CONTINUOUS SESSION
+✓ Make reasonable decisions autonomously without waiting for user input
+✓ Move immediately from one phase to the next
+✓ Deliver REPORT.md with actual mathematical results and a passing Lean build
+
+YOU WILL NOT GET ADDITIONAL INSTRUCTIONS between phases.
+
+════════════════════════════════════════════════════════════════════════════════
+
+Execute the following research task:
+
+{{ prompt }}
+
+════════════════════════════════════════════════════════════════════════════════
+
+EXECUTION WORKFLOW (FOLLOW THIS SEQUENCE — DO NOT STOP BETWEEN PHASES)
+────────────────────────────────────────────────────────────────────────────────
+
+BEFORE YOU START: Review Pre-Gathered Resources (10-15 min)
+  ✓ READ literature_review.md — known results, definitions, proof techniques
+  ✓ READ resources.md — what tools and prior results are available
+  ✓ Note which theorems are already in Mathlib (check with #check in Lean)
+  ✓ Note which prerequisites you will need to prove yourself
+
+  → WHEN COMPLETE: Immediately proceed to Phase 1
+
+────────────────────────────────────────────────────────────────────────────────
+Phase 1: Proof Strategy Planning (20-40 min)
+────────────────────────────────────────────────────────────────────────────────
+  ✓ Write "Motivation & Novelty Assessment" section in planning.md
+    - Why this mathematical question matters
+    - What prior results it extends (from literature_review.md)
+    - Why formal Lean verification adds value here
+  ✓ Decompose the conjecture into sub-lemmas
+  ✓ For each sub-lemma, decide:
+      - Is it already in Mathlib? (check with #check / naming conventions)
+      - Does it need to be proved from scratch?
+      - What proof technique: direct, induction, contradiction, etc.?
+  ✓ Plan the Lean file structure:
+      Definitions.lean → Lemmas.lean → MainTheorem.lean
+  ✓ List the Mathlib imports you will need
+  ✓ Document plan in planning.md (2-3 pages maximum)
+
+  → WHEN COMPLETE: Immediately proceed to Phase 2
+
+────────────────────────────────────────────────────────────────────────────────
+Phase 2: Environment & Mathematical Setup (15-25 min)
+────────────────────────────────────────────────────────────────────────────────
+  ✓ Run environment setup (STEP A + STEP B above) if not already done
+  ✓ Confirm Lean setup: cd lean_proofs && lake build && cd ..
+  ✓ Write lean_proofs/LeanProofs/Definitions.lean:
+      - All types, structures, and notation for the research
+      - Use import Mathlib at the top
+      - Run lake build to confirm definitions compile
+  ✓ Write definitions.md with informal descriptions of each Lean definition
+  ✓ Verify prerequisite Mathlib lemmas exist: add #check statements and lake build
+
+  → WHEN COMPLETE: Immediately proceed to Phase 3
+
+────────────────────────────────────────────────────────────────────────────────
+Phase 3: Formal Proof Construction (90-150 min)
+────────────────────────────────────────────────────────────────────────────────
+This is the MAIN PHASE. Proofs are only accepted when Lean accepts them.
+
+  {{ code_workflow }}
+
+  LEAN PROOF WORKFLOW — follow this for each lemma/theorem:
+
+  STEP 1 — Write the statement with `sorry`:
+    Open lean_proofs/LeanProofs/Lemmas.lean (or MainTheorem.lean)
+    Add the theorem with `sorry` as the proof body
+    Run: cd lean_proofs && lake build 2>&1 | tail -20; cd ..
+    ✓ Exit 0 → statement type-checks; proceed to proof
+    ✗ Non-zero → fix the statement type error first (read the error message)
+
+  STEP 2 — Attempt proof with automation first:
+    Try in order: ring → omega → linarith → norm_num → simp → decide
+    For each tactic attempt:
+      Edit the .lean file
+      Run: cd lean_proofs && lake build 2>&1 | tail -30; cd ..
+      ✓ Exit 0, no sorry warning → lemma proved ✓
+      ✗ Error → read the message, adjust the tactic or add intermediate steps
+
+  STEP 3 — Manual tactic proof if automation fails:
+    Break the proof into smaller steps using `have h : ... := by ...`
+    Use `intro`, `apply`, `rw`, `exact`, `cases`, `induction` as appropriate
+    After each meaningful edit, run lake build to check progress
+    Read Lean error messages carefully — they tell you exactly what's missing
+
+  STEP 4 — Verify no sorry remains in this file:
+    grep "sorry" lean_proofs/LeanProofs/Lemmas.lean
+
+  LEAN PROOF WRITING GUIDELINES:
+  - Add a doc comment /-- ... -/ before every theorem explaining what it says
+  - Write an informal proof sketch as a comment block before the tactic proof
+  - Name intermediate claims with `have h_name : ... := by ...`
+  - When citing a Mathlib lemma, add a comment: -- from Mathlib: Lemma.Name
+  - Build after every complete lemma (not just at the end)
+  - Save results/ with a proof_log.md tracking which lemmas are proved
+
+  PYTHON EXPLORATION (in parallel with proof construction):
+  {{ code_workflow }}
+  - Use Python/SymPy in src/ to:
+    - Verify statements numerically before formalizing
+    - Search for counterexamples to candidate lemmas
+    - Generate examples that guide the Lean proof strategy
+  - This is EXPLORATORY only — it does not constitute a proof
+
+  → WHEN COMPLETE: Immediately proceed to Phase 4
+
+────────────────────────────────────────────────────────────────────────────────
+Phase 4: Proof Verification & Hardening (20-30 min)
+────────────────────────────────────────────────────────────────────────────────
+  ✓ Run full build from scratch to confirm everything compiles:
+      cd lean_proofs && lake clean && lake build 2>&1; cd ..
+  ✓ Confirm no sorry remains anywhere:
+      grep -r "sorry" lean_proofs/LeanProofs/ \
+        && echo "INCOMPLETE PROOFS REMAIN" \
+        || echo "All proofs formally complete ✓"
+  ✓ Verify all theorems in your plan are proved (check planning.md checklist)
+  ✓ Run Python exploration scripts to test boundary cases and sanity-check results
+  ✓ Document verification status in results/verification.md:
+      - lake build exit code
+      - grep sorry output
+      - Lean toolchain version (cat lean_proofs/lean-toolchain)
+      - Mathlib commit (cat lean_proofs/lake-manifest.json | grep -A2 mathlib)
+
+  → WHEN COMPLETE: Immediately proceed to Phase 5
+
+────────────────────────────────────────────────────────────────────────────────
+Phase 5: Refinement and Strengthening (15-25 min)
+────────────────────────────────────────────────────────────────────────────────
+  ✓ Review proofs for unnecessary hypotheses (can any be weakened?)
+  ✓ Check: can the conclusion be strengthened?
+  ✓ Find tight counterexamples showing hypotheses are necessary (Python)
+  ✓ Look for natural Lean generalizations (e.g., replace ℕ with a general monoid)
+  ✓ Clean up Lean code: remove redundant `have`s, improve tactic style
+  ✓ Ensure all definitions are in Definitions.lean (no ad-hoc inline definitions)
+
+  → WHEN COMPLETE: Immediately proceed to Phase 6
+
+────────────────────────────────────────────────────────────────────────────────
+Phase 6: Final Documentation (20-30 min) — MANDATORY BEFORE ENDING SESSION
+────────────────────────────────────────────────────────────────────────────────
+  ✓ Create REPORT.md with ACTUAL mathematical results (see structure below)
+  ✓ Create README.md with project overview
+  ✓ Ensure lean_proofs/ is organized with comments
+  ✓ Verify results/ contains verification.md with build status
+
+  → WHEN COMPLETE: Session is finished
+
+CRITICAL REMINDERS:
+- This is a SINGLE CONTINUOUS SESSION covering all 6 phases
+- `lake build` is your ground truth — informal argument is not enough
+- A proof with `sorry` is NOT a proof; grep for sorry before reporting completion
+- If a proof is too hard to formalize in time, mark it `sorry`, document the
+  informal argument clearly, and note it as future work in REPORT.md
+- REPORT.md is mandatory even if some proofs remain as `sorry`
+
+════════════════════════════════════════════════════════════════════════════════
+WORKSPACE DIRECTORY AND DIRECTORY SAFETY
+────────────────────────────────────────────────────────────────────────────────
+You are running in the project workspace directory: {{ work_dir }}
+
+MANDATORY VERIFICATION POINTS — Run `pwd` and verify location:
+✓ Before any mkdir, file write, or download
+✓ Before and after any cd command — ALWAYS cd back to workspace root
+✓ When starting each new phase
+
+SAFE PATTERN FOR LEAN BUILDS:
+  pwd                                         # verify you're in workspace root
+  cd lean_proofs && lake build 2>&1; cd -     # build and return
+  pwd                                         # confirm you're back
+
+⚠️  NEVER create Lean files outside lean_proofs/
+⚠️  NEVER run lake from the workspace root (always cd lean_proofs first)
+⚠️  NEVER run cd .. (parent directory is dangerous)
+
+Remember:
+- READ literature_review.md and resources.md first
+- Python scripts go in src/ (for exploration only)
+- Lean proofs go in lean_proofs/LeanProofs/
+{{ code_reminder }}
+- All your work stays within {{ work_dir }}
+
+════════════════════════════════════════════════════════════════════════════════
+PHASE 6 REQUIREMENTS — WHAT TO INCLUDE IN FINAL DOCUMENTATION
+════════════════════════════════════════════════════════════════════════════════
+
+1. REPORT.md — Mathematics (Lean) research report:
+   - Executive Summary (2-3 paragraphs; state verification status explicitly)
+   - Research Question (the conjecture or problem)
+   - Definitions and Notation (informal descriptions; Lean types in code blocks)
+   - Statement of Results (theorem statements in informal math + Lean type signatures)
+   - Proof Sketches (informal argument for each theorem; full proofs are in Lean files)
+   - Lean Formalization (file structure, key Mathlib lemmas used, build verification)
+   - Verification Status ("lake build exits 0, no sorry found" or list of open sorry)
+   - Discussion (implications, connections, what Mathlib lemmas were reused)
+   - Open Questions (results that remain conjectural or unformalized)
+   - Conclusions and Future Work
+   - References (papers + Lean/Mathlib version info)
+
+2. README.md — Quick overview:
+   - Brief description (2-3 sentences)
+   - Key results (bullet points: theorem names + informal statements)
+   - Verification: `cd lean_proofs && lake build` must succeed
+   - File structure overview
+   - Link to REPORT.md
+
+════════════════════════════════════════════════════════════════════════════════
+SESSION COMPLETION
+════════════════════════════════════════════════════════════════════════════════
+
+The session is COMPLETE when:
+✓ All phases (1-6) have been attempted
+✓ lean_proofs/ exists and `lake build` runs (exit 0 if proofs complete)
+✓ REPORT.md documents actual results and verification status
+✓ README.md is created
+✓ results/verification.md records the build output and grep-sorry output
+✓ src/ contains Python exploration scripts with comments
+
+If some proofs remain as `sorry`, the session is still complete — document
+what was proved, what remains, and the informal argument for each open item.

--- a/templates/skills/decision-log/SKILL.md
+++ b/templates/skills/decision-log/SKILL.md
@@ -1,0 +1,495 @@
+---
+name: decision-log
+description: Per-agent in-flight log of decisions and observations made during a run, exposed as a DAG. Log each decision and significant observation the moment it happens — not as a batch at the end. The point is to capture the actual reasoning trail as it unfolds, including ideas considered then revoked. The log persists across turns and process restarts so the orchestrator and any future agent can replay the reasoning chain.
+---
+
+# Decision Log
+
+A persistent record of the decisions the agent makes and the observations it
+finds worth noting during a Neurico run, exposed as a DAG. Every node says
+what it captures and what upstream nodes it builds on. When an upstream node
+is later revoked, downstream nodes don't silently die — they become `suspect`
+and the agent triages them deliberately.
+
+There are two kinds of nodes:
+
+- Decisions — choices the agent commits to ("use VideoMAE", "primary metric
+  is balanced accuracy"). Created via `log.add(...)`.
+- Observations — facts the agent notices that may temper later decisions
+  ("dataset is 4:1 imbalanced", "block-8 attention has highest CKA with motion",
+  "first training run gave 47% accuracy"). Created via `log.observe(...)`.
+
+Both kinds participate in the same DAG: a decision can premise on an
+observation, an observation can pertain to a decision, and revoke cascade
+works identically for both. The agent picks which is which — observations
+are for evidence, decisions are for commitments.
+
+The log is a single JSON file owned by the agent for the duration of a run.
+There is no cross-agent coordination, no manual save step, and no torn-write
+recovery to think about — every mutation through the API persists atomically.
+
+## Read This First: Log In-Flight, Not at the End
+
+The single most common way to misuse this skill is to batch up decisions and
+log them all in a clean pass at the end of the turn. Do not do this. The
+value of the log comes from capturing the reasoning trail as it actually
+unfolded:
+
+- Choices committed to early and kept
+- Choices committed to early and revoked after further investigation
+- The order in which choices were locked in, which exposes what depended on what
+
+A clean end-of-turn log loses all three. A future agent reading it cannot tell
+whether the original agent considered alternative X (and why it was rejected)
+— only that the final choice was Y. That is the part of the reasoning trail
+worth most to preserve.
+
+Log a decision the moment it is committed to. If the agent finds itself
+thinking "I'll log this later once I'm sure," log it now; if it does not
+survive deeper scrutiny, `revoke()` it with a reason. The audit trail of a
+revoke is more valuable than the absence of the rejected node.
+
+## When to Use
+
+**Log a decision when** you commit to any of these:
+
+**Decision categories** — what experimental commitment is being made:
+
+| Category | Examples |
+|---|---|
+| `model` | "Use VideoMAE-Large", "Switch to TimeSformer-Base" |
+| `dataset` | "Train on Kinetics-400 subset", "Use HMDB51 as held-out" |
+| `hyperparam` | "Learning rate = 3e-4", "16 frames @ 4fps", "Batch size = 32" |
+| `eval` | "Top-5 acc as primary metric", "Balanced accuracy due to class skew" |
+| `compute` | "Train on Modal L40S", "Run inference on dsi-slurm" |
+| `method` | "Extract intermediate features at block 8", "Use LoRA rank 16" |
+| `search` | "Paper-finder diligent mode first", "Prioritize HF datasets over Kaggle", "Use these 5 keywords" |
+| `reading` | "Deep-read paper X, skim Y and Z", "Read README only for repo W" |
+| `risk` | "SST-2 ceiling effect may falsify the 4pp claim", "Train/test topic drift is a confound for any gain" |
+| `other` | Anything else that affects the experiment but doesn't fit above |
+
+**Observation categories** — what KIND of evidence the observation is:
+
+| Category | Use for |
+|---|---|
+| `paper_finding` | Anything extracted from reading a paper (table numbers, claims, methodology details, quoted limitations) |
+| `data_property` | Anything discovered by inspecting data (class balance, label indexing, doc-length distribution, split overlaps) |
+| `env_fact` | System / service / environment state ("paper-finder at localhost:8000 returns 404", "L40S has 48GB", "HF dataset namespace renamed") |
+| `experiment_result` | Output of running something (initial inference accuracy, training loss curve hint, eval-script return code) |
+| `code_artifact` | Property of code you examined (function signature, env var the script reads, missing dependency) |
+| `other` | Anything else worth noting that doesn't fit above |
+
+**The category sets are disjoint by node type** — `add()` rejects observation categories, `observe()` rejects decision categories. Pick the right node type first; the right category follows.
+
+**Do NOT log** when you are:
+
+- Running a read-only command (`ls`, `cat`, `grep`)
+- Reading a config file or exploring code
+- Making a stylistic or low-stakes code change (renaming a variable, formatting)
+- Recording an observation ("the data is skewed") — that's a *premise* for a
+  later decision, not a decision itself
+- Trying things in a scratch script you'll throw away
+
+## Observations (The Other Half of the Picture)
+
+A decision says "I chose X." An observation says "I noticed Y." Observations
+are first-class nodes that let you record evidence the agent found important
+during the run, distinct from the choices the agent made.
+
+When to log an observation:
+
+- A finding from reading: "Batch Calibration paper Table 2: PaLM2-S +1.9pp on SST-2"
+- A property of the data you inspected: "Train and test splits have different
+  label distributions"
+- An experimental result: "First inference run on Qwen-1.5B gave 47% accuracy"
+- An environmental fact: "paper-finder service at localhost:8000 is not running"
+- A confound you spotted: "TweetEval train and test were collected 6 months apart"
+
+The call:
+
+```python
+oid = log.observe(
+    observation="Batch Calibration Table 2: PaLM2-S 93.6→95.5 (+1.9pp) on SST-2",
+    category="paper_finding",      # observation-only taxonomy
+    about=[ds_id],                 # ids of nodes this observation pertains to
+    source="arXiv:2309.17249 Table 2",
+)
+```
+
+Fields map like this for an observation:
+
+| Param | What it stores | Becomes which field internally |
+|---|---|---|
+| `observation` | the finding itself | `choice` (yes, same field; the rendering differs) |
+| `category` | which taxonomy slot | `category` |
+| `about` | nodes this observation relates to | `premises` |
+| `source` | where the finding came from | `rationale` |
+
+`about=[...]` matters: an observation about a specific dataset choice becomes
+suspect if that choice is revoked. That's intentional — the observation may
+not transfer to a different dataset.
+
+Observations can be roots (no `about`) if they're general findings independent
+of any specific choice ("Qwen2.5-7B has 7B params" — a fact, not contingent
+on any decision).
+
+When NOT to log an observation:
+
+- Generic uncertainty ("I'm not sure if this will work") — leave it out
+- Trivial facts (file sizes, line counts) — not significant enough
+- Things that belong in the rationale of a single decision — fold them in there
+- Anything you wouldn't want a future agent to act on
+
+The test: an observation is worth logging if **a downstream decision should
+be premised on it** or if it could plausibly justify a future revoke.
+
+### Note on the `risk` Category
+
+`risk` is the one category that isn't strictly a *choice*. A `risk` node
+records a **predicted failure mode for the experiment**, identified during
+preparation and backed by specific evidence. The `choice` field becomes the
+one-sentence risk prediction; the `rationale` field is the evidence (paper
+quotes, prior numbers). `alternatives` is usually empty — you don't pick
+risks the way you pick datasets.
+
+A `risk` node is worth logging only if a downstream agent should **do
+something about it** — add a mitigation, design a control, narrow scope.
+Generic uncertainty ("not sure if this works") doesn't belong here; that
+goes in a `rationale` field. Premise `risk` nodes against the specific
+choice the risk attaches to (the dataset, the method), so the cascade works
+correctly if that choice is later revoked.
+
+The decision log is for choices that **affect what the next agent reading this
+log would do**. If your choice has no downstream consequence, it doesn't need
+to be a node.
+
+## Contract (Read First)
+
+Three rules govern the log's behavior. Internalize them — they're what makes
+the log trustworthy.
+
+1. **No node is ever deleted.** The only way to retire a decision is `revoke()`,
+   which marks the node `revoked` but keeps it on disk forever. The log is an
+   append-only history. This is intentional: a teammate (or future you) reading
+   the log should be able to see *every* path the agent considered, including
+   the wrong ones.
+
+2. **Revoke cascades to `suspect`, not `revoked`.** When you revoke A, every
+   descendant of A becomes `suspect`. Suspects are *not* automatically killed —
+   they may still hold under different premises. Your job is to triage each one
+   via `reconfirm()` (with possibly new premises) or `revoke()` (cascading
+   further).
+
+3. **You can only build on `active` premises.** `add()`, `update(premises=...)`,
+   and `reconfirm(premises=...)` all reject non-active premise ids. This forces
+   you to triage upstream before extending downstream. The `triage_order()`
+   helper gives you suspects in upstream-first topological order so this is
+   always possible.
+
+## Three States
+
+| State | Meaning | Can be a premise? |
+|---|---|---|
+| `active` | The decision is in force. | Yes |
+| `suspect` | An upstream premise died; this node hasn't been triaged yet. | No |
+| `revoked` | Explicitly retired. Kept on disk for history. | No |
+
+A node moves from `active` → `suspect` only via cascade from a `revoke()`.
+From `suspect` it moves to `active` (via `reconfirm()`) or `revoked` (via
+`revoke()`). `active` → `revoked` is direct revocation.
+
+## Prerequisites
+
+The skill ships its own implementation; nothing to install. Import from the
+skill's `scripts/decision_log.py`:
+
+```python
+import sys
+sys.path.insert(0, ".claude/skills/decision-log/scripts")
+from decision_log import DecisionLog
+```
+
+Open your per-run log file. The orchestrator passes you the path; if you're
+running standalone, default to `.neurico/decisions.json`:
+
+```python
+log = DecisionLog(path=".neurico/decisions.json")
+```
+
+If the file exists, your prior decisions are loaded. If it doesn't, you start
+empty. Every `add` / `update` / `revoke` / `reconfirm` call writes the full
+graph atomically to that path before returning.
+
+## How to Use It - The Four Operations
+
+### 1. Add a Decision
+
+```python
+node_id = log.add(
+    question="Which video encoder?",       # what you decided about
+    choice="VideoMAE-Large",                # what you chose
+    category="model",                       # one of the categories table above
+    premises=[],                            # ids of decisions this depends on
+    alternatives=["TimeSformer", "I3D"],    # other options you considered (optional)
+    rationale="MAE pretraining transfers well to action recognition",
+    id=None,                                # optional: pass an explicit short slug
+)
+```
+
+Returns the node's id. By default the id is auto-generated from the choice
+(e.g. `"model-videomae-large"`). Pass `id="vmae"` if you want a shorter handle.
+
+### 2. Build on Previous Decisions
+
+```python
+features = log.add(
+    question="Use intermediate features or final head?",
+    choice="intermediate at block 8",
+    category="method",
+    premises=[model_id],                    # ← upstream dependency
+    rationale="block-8 has best CKA with motion features",
+)
+```
+
+**Premises are not optional.** If a decision depends on prior choices, list
+them. The log will refuse to extend from a `suspect` or `revoked` premise.
+
+### 3. Revoke and Triage
+
+When you change your mind about a foundational choice:
+
+```python
+suspects = log.revoke(model_id, reason="VideoMAE OOMs at this clip length")
+# suspects → ["method-block-8", "hyperparam-lr", ...]
+```
+
+`revoke()` returns the **suspect list** — every downstream node that was
+counting on this premise and now needs your judgment.
+
+**Always** follow a revoke with triage. Call `triage_order()` to get the
+suspects in upstream-first order, then handle each one:
+
+```python
+for sid in log.triage_order():
+    node = log.get(sid)
+    print(f"Triaging: {node.choice} (was premise of: {log.subtree(sid)})")
+    # ... decide what to do (see below)
+```
+
+For each suspect you have two choices:
+
+```python
+# (a) the decision still holds, possibly under new premises
+log.reconfirm(sid, premises=[new_model_id], rationale="works under new model too")
+
+# (b) the decision was load-bearing on the dead premise — kill it too
+log.revoke(sid, reason="block-8 was VideoMAE-specific")
+```
+
+If you call `reconfirm(sid)` with no premises arg, the log auto-drops the
+dead premises and keeps the rest.
+
+### 4. Update Metadata
+
+```python
+log.update(node_id, rationale="updated explanation", alternatives=["A", "B"])
+```
+
+`update()` can change `question`, `choice`, `rationale`, `alternatives`, and
+(for active nodes only) `premises`. It **cannot** change `category` or `id`.
+For revoked or suspect nodes, premise edits are rejected — use `reconfirm()`.
+
+## The Triage Flow (Most Important Agent Procedure)
+
+When `revoke()` returns a non-empty suspect list, you are in triage mode.
+Triage is not optional and not deferrable — you can't extend the active graph
+until suspects are resolved (active extensions reject suspect premises).
+
+The canonical loop:
+
+```python
+log.revoke(failed_id, reason="...")
+
+while True:
+    order = log.triage_order()
+    if not order:
+        break
+    sid = order[0]
+    node = log.get(sid)
+    # Decide based on whether the surviving rationale still applies:
+    if still_holds(node):
+        log.reconfirm(sid, premises=updated_premises)
+    else:
+        log.revoke(sid, reason=...)   # this may add more suspects to the queue
+```
+
+`triage_order()` is the key: it returns suspects in upstream-first topological
+order, so when you reach a node, all its upstream suspects have already been
+resolved. Your `reconfirm` can always point at an active premise.
+
+## Best Practices
+
+### Short, Semantic IDs for Nodes That Get Referenced Often
+
+Auto-slugs are fine for one-shot decisions. But for keystone nodes (the model,
+the dataset, the primary metric) — the ones you'll mention in many premises —
+pass `id="..."` explicitly:
+
+```python
+log.add(question="Model?", choice="VideoMAE-Large", category="model", id="vmae")
+log.add(question="...", choice="...", category="method", premises=["vmae"])
+```
+
+Short ids are easier to type correctly and easier to scan in `dot` exports.
+
+### Always Pass a `rationale`
+
+The decision log is a reasoning trail. A node without a rationale is just a
+choice — a node *with* a rationale is a choice you can defend later. One
+sentence is enough.
+
+### List `alternatives` When the Choice Was Non-Obvious
+
+Future you (and the orchestrator-side UI) will want to know what you ruled
+out, not just what you picked. Skip `alternatives` if there was no real
+choice ("we're using PyTorch because the whole stack is PyTorch").
+
+### Premises Capture What Would Invalidate the Decision
+
+A premise edge says: "if this upstream choice were different, this decision
+would be different." That's the test. If your "premise" wouldn't actually
+change the choice, it's context, not a premise. Don't pad.
+
+### Triage Upstream-First
+
+Use `log.triage_order()`, not raw iteration over `log.suspects()`. Upstream
+suspects must resolve first so downstream nodes can point at settled premises.
+
+### Don't Over-Log
+
+The log is for the decisions a future reader needs to understand the
+experiment. Don't log "I'm going to run the training script now" — that's an
+action, not a decision. Log the *choice of training script*, only if it was a
+non-trivial choice.
+
+## Failure Modes
+
+| Error | Meaning | How to recover |
+|---|---|---|
+| `ValueError: premise 'xyz' does not exist` | Typo in premise id, or you tried to reference a node you haven't added yet | Call `log.find(query="...")` to look up the right id |
+| `ValueError: premise 'xyz' is 'suspect'` | You tried to build on a suspect node | Triage that node first (reconfirm or revoke) |
+| `ValueError: premise 'xyz' is 'revoked'` | Same, but the node is permanently dead | Don't use it as a premise; pick a different upstream |
+| `ValueError: duplicate premise in list` | You passed the same id twice in `premises=[...]` | Dedupe; each premise edge is unique |
+| `CycleError: adding premise 'X' to 'Y' would create a cycle` | The new edge would make Y depend on itself (directly or transitively) | If the topology is wrong, revoke and re-add; if you meant something else, revisit the design |
+| `ValueError: can't update premises on 'suspect' node` | `update(premises=...)` only works on active nodes | Use `reconfirm(id, premises=...)` instead |
+| `ValueError: can only reconfirm suspect nodes` | You called `reconfirm` on something that isn't suspect | Use `add()` for new nodes, `update()` for edits, `revoke()` to retire |
+| `ValueError: unsupported schema version N` | The on-disk file was written by a newer version | Don't touch — escalate; running this skill against it would lose data |
+
+## Inspecting the Log
+
+```python
+log.find()                                # all active nodes
+log.find(category="hyperparam")           # filtered
+log.find(query="frames")                  # text search across question, choice, rationale
+log.find(active_only=False)               # include revoked + suspect
+
+log.get(id)                               # one node
+log.suspects()                            # all suspect nodes (untriaged)
+log.triage_order()                        # suspects in upstream-first order
+
+log.premises_of(id)                       # direct upstream
+log.premises_of(id, recursive=True)       # all transitive upstream
+log.subtree(id)                           # all transitive descendants
+
+print(log.export("md"))                   # human-readable markdown
+print(log.export("dot"))                  # graphviz; pipes to `dot -Tpng`
+print(log.export("json"))                 # raw JSON (same as on-disk format)
+```
+
+## Worked Example
+
+```python
+import sys; sys.path.insert(0, ".claude/skills/decision-log/scripts")
+from decision_log import DecisionLog
+
+log = DecisionLog(path=".neurico/decisions.json")
+
+# Opening decisions
+model  = log.add(question="Model?", choice="VideoMAE-Large", category="model",
+                 alternatives=["TimeSformer", "I3D"],
+                 rationale="MAE pretraining transfers well",
+                 id="vmae")
+
+clip   = log.add(question="Clip length?", choice="16 frames @ 4fps",
+                 category="hyperparam", premises=[model],
+                 rationale="VideoMAE was pretrained at this rate",
+                 id="clip")
+
+metric = log.add(question="Primary metric?", choice="balanced accuracy",
+                 category="eval",
+                 rationale="4:1 common/rare class skew")
+
+# After training, OOM on this clip length
+suspects = log.revoke(model, reason="OOM at 16 frames on L40S")
+# suspects → ["clip"]   (metric was independent)
+
+# Switch models
+ts = log.add(question="Model?", choice="TimeSformer-Base", category="model",
+             rationale="lighter memory footprint", id="ts")
+
+# Triage the cascade
+for sid in log.triage_order():
+    if sid == clip:
+        # 16 frames also works for TimeSformer
+        log.reconfirm(sid, premises=[ts], rationale="TimeSformer default too")
+
+# Snapshot for the run summary
+print(log.export("md"))
+```
+
+## File Layout
+
+After the example above, your workspace contains:
+
+```
+.neurico/
+└── decisions.json           # the live log, auto-saved on every mutation
+```
+
+Schema:
+
+```json
+{
+  "_schema_version": 1,
+  "nodes": {
+    "vmae": {
+      "id": "vmae",
+      "category": "model",
+      "question": "Model?",
+      "choice": "VideoMAE-Large",
+      "premises": [],
+      "alternatives": ["TimeSformer", "I3D"],
+      "rationale": "MAE pretraining transfers well | revoked: OOM at 16 frames",
+      "status": "revoked",
+      "revoked_root": "vmae",
+      "created_at": "2026-06-26T..."
+    },
+    "ts": { ... },
+    "clip": { ... },
+    "eval-balanced-accuracy": { ... }
+  }
+}
+```
+
+Writes are atomic (tmp + `os.replace`), so a SIGKILL mid-write leaves the
+prior committed file intact. You will never lose decisions to a crash.
+
+## Cost / Impact Notes
+
+- **Disk**: kilobytes per run. Hundreds of decisions still fit in a single
+  human-readable JSON.
+- **Latency**: every mutation does one file write. Negligible at this scale.
+- **No network, no external services.** Pure local state.
+- **Single-writer per file.** Don't share the same `decisions.json` between
+  two concurrently-running agents. Per-agent paths are required when multiple
+  agents run in parallel.

--- a/templates/skills/decision-log/scripts/decision_log.py
+++ b/templates/skills/decision-log/scripts/decision_log.py
@@ -1,0 +1,411 @@
+"""
+Decision Log - Persistent in-flight record of decisions and observations.
+
+Captures the agent's reasoning trail during a run as a DAG of two node types:
+
+1. Decisions  - choices the agent commits to (use log.add)
+2. Observations - findings worth noting (use log.observe)
+
+Both kinds share three states: active / suspect / revoked.
+Revoke(A) cascades all descendants to "suspect" (not "revoked"); the agent
+then triages each via reconfirm() or another revoke(). No node is ever
+deleted - the log is an append-only history of the run's reasoning.
+
+Persistence is automatic: every mutation writes the full graph atomically
+to a single JSON file (tmp + os.replace, no torn writes on SIGKILL).
+
+See templates/skills/decision-log/SKILL.md for the full agent-facing contract.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+DECISION_CATEGORIES = {
+    "model", "dataset", "hyperparam", "eval", "compute", "method",
+    "search", "reading",
+    "risk",
+    "other",
+}
+
+OBSERVATION_CATEGORIES = {
+    "paper_finding",       # extracted from reading a paper
+    "data_property",       # discovered by inspecting data
+    "env_fact",            # system / service / environment state
+    "experiment_result",   # output of running something
+    "code_artifact",       # property of code we examined
+    "other",
+}
+
+# Union for persistence (so old files with any valid category still load).
+CATEGORIES = DECISION_CATEGORIES | OBSERVATION_CATEGORIES
+SCHEMA_VERSION = 1
+
+
+NODE_TYPES = {"decision", "observation"}
+
+
+@dataclass
+class DecisionNode:
+    id: str
+    category: str
+    question: str
+    choice: str
+    node_type: str = "decision"        # "decision" | "observation"
+    premises: list[str] = field(default_factory=list)
+    alternatives: list[str] = field(default_factory=list)
+    rationale: str = ""
+    status: str = "active"             # active | suspect | revoked
+    revoked_root: str | None = None    # id of the revoke that affected this
+    created_at: str = ""
+
+
+class CycleError(ValueError):
+    """Raised when adding a premise edge would create a cycle in the DAG."""
+
+
+class DecisionLog:
+    """
+    Persistent log of decisions and observations made during an agent run.
+
+    Owns a single JSON file (auto-created at first write) holding the full
+    DAG. Every mutation persists atomically before returning, so the file is
+    always in a consistent state.
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        """
+        Initialize the log.
+
+        Args:
+            path: Where to persist the log. If the file exists, its contents
+                  are loaded. If None, the log is in-memory only (useful for
+                  tests).
+        """
+        self._nodes: dict[str, DecisionNode] = {}
+        self._path: Path | None = Path(path) if path is not None else None
+        if self._path is not None and self._path.exists():
+            self._load()
+
+    # ---------- writes ----------
+
+    def add(self, *, question: str, choice: str, category: str,
+            premises: Iterable[str] = (), alternatives: Iterable[str] = (),
+            rationale: str = "", id: str | None = None) -> str:
+        if category not in DECISION_CATEGORIES:
+            raise ValueError(
+                f"unknown decision category {category!r}; "
+                f"one of {sorted(DECISION_CATEGORIES)}"
+            )
+        premises = self._validate_premises(premises)
+        slug = self._unique(id or self._slug(choice, category))
+        # No cycle is possible at add() — nothing references the new node yet.
+        node = DecisionNode(
+            id=slug, category=category, question=question, choice=choice,
+            premises=premises, alternatives=list(alternatives),
+            rationale=rationale, created_at=_now(),
+        )
+        self._nodes[slug] = node
+        self._save()
+        return slug
+
+    def observe(self, *, observation: str, category: str,
+                about: Iterable[str] = (), source: str = "",
+                id: str | None = None) -> str:
+        """Log an in-flight observation — a finding the agent thinks matters.
+
+        Observations record what the agent NOTICES (paper findings, data
+        properties, environmental facts, experiment results) — distinct from
+        DECISIONS, which record what the agent CHOOSES. Observations are
+        first-class nodes in the same DAG: a decision can premise on an
+        observation, an observation can premise on a decision, and cascade
+        on revoke works identically.
+
+        Args:
+            observation: what was noticed (the analog of `choice` for decisions)
+            category: same taxonomy as add()
+            about: ids of nodes this observation pertains to (stored as
+                premises; if those nodes are later revoked, this observation
+                becomes suspect)
+            source: where the observation came from — paper:table, file path,
+                experiment id, command (stored as the node's rationale)
+            id: optional explicit slug
+
+        Returns the node id.
+        """
+        if category not in OBSERVATION_CATEGORIES:
+            raise ValueError(
+                f"unknown observation category {category!r}; "
+                f"one of {sorted(OBSERVATION_CATEGORIES)}"
+            )
+        about = self._validate_premises(about)
+        slug = self._unique(id or self._slug(observation, category))
+        node = DecisionNode(
+            id=slug, node_type="observation", category=category,
+            question=f"observation about {category}",
+            choice=observation, premises=about, alternatives=[],
+            rationale=source, created_at=_now(),
+        )
+        self._nodes[slug] = node
+        self._save()
+        return slug
+
+    def update(self, id: str, **kwargs) -> None:
+        node = self._nodes[id]
+        mutable = {"question", "choice", "premises", "alternatives", "rationale"}
+        bad = set(kwargs) - mutable
+        if bad:
+            raise ValueError(f"can't update fields {bad}; mutable: {mutable}")
+        if "premises" in kwargs:
+            if node.status != "active":
+                raise ValueError(
+                    f"can't update premises on {node.status!r} node {id!r}; "
+                    f"use reconfirm() for suspect nodes, or add a new node"
+                )
+            new_p = self._validate_premises(kwargs["premises"])
+            self._assert_no_cycle(id, new_p)
+            node.premises = new_p
+            del kwargs["premises"]
+        for k, v in kwargs.items():
+            setattr(node, k, v)
+        self._save()
+
+    def revoke(self, id: str, reason: str = "") -> list[str]:
+        """Revoke `id`; mark all descendants as suspect. Returns the suspect list."""
+        target = self._nodes[id]
+        if target.status == "revoked":
+            return []
+        target.status = "revoked"
+        target.revoked_root = id
+        if reason:
+            target.rationale = (target.rationale + f" | revoked: {reason}").strip(" |")
+        suspects: list[str] = []
+        for d in self._descendants(id):
+            n = self._nodes[d]
+            if n.status == "active":
+                n.status = "suspect"
+                n.revoked_root = id
+                suspects.append(d)
+        self._save()
+        return suspects
+
+    def triage_order(self) -> list[str]:
+        """Return suspect ids in topological order — upstream first.
+
+        Agents should triage in this order so each `reconfirm()` can point at
+        premises that are already settled (active again or replaced). The
+        order is deterministic: ties broken by id sort.
+        """
+        suspects = {n.id for n in self.suspects()}
+        if not suspects:
+            return []
+        deps = {sid: {p for p in self._nodes[sid].premises if p in suspects}
+                for sid in suspects}
+        out: list[str] = []
+        remaining = set(suspects)
+        while remaining:
+            ready = sorted(s for s in remaining if not (deps[s] & remaining))
+            if not ready:
+                ready = sorted(remaining)   # guard; shouldn't fire on a DAG
+            out.extend(ready)
+            remaining.difference_update(ready)
+        return out
+
+    def reconfirm(self, id: str, premises: list[str] | None = None,
+                  rationale: str = "") -> None:
+        """Agent confirms a suspect still holds. Optionally rewrites premises.
+
+        If `premises` is None, dead premises (revoked) are dropped automatically.
+        """
+        node = self._nodes[id]
+        if node.status != "suspect":
+            raise ValueError(f"can only reconfirm suspect nodes; {id!r} is {node.status}")
+        if premises is None:
+            premises = [p for p in node.premises if self._nodes[p].status == "active"]
+        else:
+            for p in premises:
+                if p not in self._nodes:
+                    raise ValueError(f"premise {p!r} does not exist")
+                if self._nodes[p].status != "active":
+                    raise ValueError(f"premise {p!r} is not active")
+            self._assert_no_cycle(id, premises)
+        node.premises = list(premises)
+        node.status = "active"
+        node.revoked_root = None
+        if rationale:
+            node.rationale = (node.rationale + f" | reconfirm: {rationale}").strip(" |")
+        self._save()
+
+    # ---------- reads ----------
+
+    def get(self, id: str) -> DecisionNode:
+        return self._nodes[id]
+
+    def find(self, query: str = "", category: str | None = None,
+             active_only: bool = True, node_type: str | None = None) -> list[DecisionNode]:
+        if node_type is not None and node_type not in NODE_TYPES:
+            raise ValueError(f"unknown node_type {node_type!r}; one of {sorted(NODE_TYPES)}")
+        out: list[DecisionNode] = []
+        for n in self._nodes.values():
+            if active_only and n.status != "active":
+                continue
+            if category and n.category != category:
+                continue
+            if node_type and n.node_type != node_type:
+                continue
+            if query and query.lower() not in f"{n.question} {n.choice} {n.rationale}".lower():
+                continue
+            out.append(n)
+        return out
+
+    def observations(self, active_only: bool = True) -> list[DecisionNode]:
+        return self.find(active_only=active_only, node_type="observation")
+
+    def decisions(self, active_only: bool = True) -> list[DecisionNode]:
+        return self.find(active_only=active_only, node_type="decision")
+
+    def suspects(self) -> list[DecisionNode]:
+        return [n for n in self._nodes.values() if n.status == "suspect"]
+
+    def subtree(self, id: str) -> list[str]:
+        """Transitive descendants (does not include `id` itself)."""
+        return list(self._descendants(id))
+
+    def premises_of(self, id: str, recursive: bool = False) -> list[str]:
+        if not recursive:
+            return list(self._nodes[id].premises)
+        seen, out, stack = set(), [], list(self._nodes[id].premises)
+        while stack:
+            p = stack.pop()
+            if p in seen:
+                continue
+            seen.add(p)
+            out.append(p)
+            stack.extend(self._nodes[p].premises)
+        return out
+
+    def export(self, fmt: str = "json") -> str:
+        if fmt == "json":
+            return json.dumps({k: asdict(v) for k, v in self._nodes.items()}, indent=2)
+        if fmt == "dot":
+            color = {"active": "black", "suspect": "orange", "revoked": "red"}
+            shape = {"decision": "box", "observation": "ellipse"}
+            lines = ["digraph decisions {"]
+            for n in self._nodes.values():
+                lines.append(
+                    f'  "{n.id}" [color={color[n.status]},shape={shape[n.node_type]},'
+                    f'label="{n.id}\\n{n.choice}"];'
+                )
+                for p in n.premises:
+                    lines.append(f'  "{p}" -> "{n.id}";')
+            lines.append("}")
+            return "\n".join(lines)
+        if fmt == "md":
+            lines = ["# Decision Log", ""]
+            for n in self._nodes.values():
+                marker = "OBSERVATION" if n.node_type == "observation" else "DECISION"
+                lines.append(f"## {n.id}  [{marker}, {n.status}]")
+                if n.node_type == "observation":
+                    lines.append(f"- About: {n.question}")
+                    lines.append(f"- Observation: {n.choice}")
+                    lines.append(f"- Category: {n.category}")
+                    if n.premises:
+                        lines.append(f"- Pertains to: {', '.join(n.premises)}")
+                    if n.rationale:
+                        lines.append(f"- Source: {n.rationale}")
+                else:
+                    lines.append(f"- Question: {n.question}")
+                    lines.append(f"- Choice: {n.choice}")
+                    lines.append(f"- Category: {n.category}")
+                    if n.premises:
+                        lines.append(f"- Premises: {', '.join(n.premises)}")
+                    if n.rationale:
+                        lines.append(f"- Why: {n.rationale}")
+                lines.append("")
+            return "\n".join(lines)
+        raise ValueError(f"unknown fmt {fmt!r}")
+
+    # ---------- persistence ----------
+
+    def _load(self) -> None:
+        data = json.loads(self._path.read_text())
+        version = data.get("_schema_version", 1)
+        if version != SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported schema version {version} at {self._path}; "
+                f"this code expects {SCHEMA_VERSION}"
+            )
+        self._nodes = {
+            nid: DecisionNode(**fields)
+            for nid, fields in data.get("nodes", {}).items()
+        }
+
+    def _save(self) -> None:
+        if self._path is None:
+            return
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "_schema_version": SCHEMA_VERSION,
+            "nodes": {nid: asdict(n) for nid, n in self._nodes.items()},
+        }
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, indent=2, sort_keys=False))
+        os.replace(tmp, self._path)
+
+    # ---------- internals ----------
+
+    def _validate_premises(self, premises: Iterable[str]) -> list[str]:
+        """Materialize premises, reject unknown/non-active/duplicates."""
+        premises = list(premises)
+        if len(set(premises)) != len(premises):
+            raise ValueError(f"duplicate premise in list: {premises}")
+        for p in premises:
+            if p not in self._nodes:
+                raise ValueError(f"premise {p!r} does not exist")
+            if self._nodes[p].status != "active":
+                raise ValueError(
+                    f"premise {p!r} is {self._nodes[p].status!r}; can only build on active premises"
+                )
+        return premises
+
+    def _slug(self, choice: str, category: str) -> str:
+        base = f"{category}-{choice}".lower()
+        cleaned = "".join(c if c.isalnum() or c == "-" else "-" for c in base)
+        while "--" in cleaned:
+            cleaned = cleaned.replace("--", "-")
+        return cleaned.strip("-")[:40] or category
+
+    def _unique(self, slug: str) -> str:
+        if slug not in self._nodes:
+            return slug
+        i = 2
+        while f"{slug}-{i}" in self._nodes:
+            i += 1
+        return f"{slug}-{i}"
+
+    def _descendants(self, id: str) -> Iterable[str]:
+        seen, queue = {id}, [id]
+        while queue:
+            cur = queue.pop(0)
+            for nid, n in self._nodes.items():
+                if cur in n.premises and nid not in seen:
+                    seen.add(nid)
+                    queue.append(nid)
+                    yield nid
+
+    def _assert_no_cycle(self, id: str, premises: Iterable[str]) -> None:
+        descendants = set(self._descendants(id))
+        descendants.add(id)
+        for p in premises:
+            if p in descendants:
+                raise CycleError(f"adding premise {p!r} to {id!r} would create a cycle")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+

--- a/templates/skills/lean-prover/SKILL.md
+++ b/templates/skills/lean-prover/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: lean-prover
+description: Formally verify mathematical proofs using Lean 4 and Mathlib. Use when working in the mathematics_lean domain, when a proof needs machine-checked verification, or when translating informal proofs into formally verified Lean 4 code.
+---
+
+# Lean Prover
+
+Formal proof verification using Lean 4 and the Mathlib mathematics library.
+
+## When to Use
+
+- Working in the `mathematics_lean` research domain
+- Translating an informal proof into formally verified code
+- Checking whether a mathematical statement is provable
+- Searching Mathlib for existing lemmas to cite or reuse
+
+## Project Setup
+
+Run the setup script from your workspace root:
+
+```bash
+bash .claude/skills/lean-prover/scripts/setup_lean_project.sh
+```
+
+This creates `lean_proofs/` with Mathlib as a dependency and downloads the
+prebuilt cache. After setup, all proof work lives inside `lean_proofs/`.
+
+**Manual setup (if the script fails):**
+
+```bash
+# 1. Install elan (Lean version manager) if not present
+curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+  | sh -s -- -y
+source "$HOME/.elan/env"
+
+# 2. Create a Mathlib project
+mkdir lean_proofs && cd lean_proofs
+lake +leanprover-community/mathlib4:stable init lean_proofs math
+# ↑ "math" template wires up Mathlib automatically
+
+# 3. Download prebuilt Mathlib cache (avoids a multi-hour source build)
+lake exe cache get
+
+# 4. Verify setup
+lake build
+cd ..
+```
+
+## Project Structure
+
+```
+lean_proofs/
+├── lakefile.lean          # Build config — Mathlib dependency lives here
+├── lean-toolchain         # Pinned Lean version (must match Mathlib)
+└── LeanProofs/
+    ├── Definitions.lean   # All definitions and notation
+    ├── Lemmas.lean        # Supporting lemmas (import Definitions)
+    └── MainTheorem.lean   # Main results (import Lemmas)
+```
+
+Root import file (`LeanProofs.lean`):
+```lean
+import LeanProofs.Definitions
+import LeanProofs.Lemmas
+import LeanProofs.MainTheorem
+```
+
+## Writing Proofs
+
+### File header
+
+Every `.lean` file should start with:
+```lean
+import Mathlib
+import LeanProofs.Definitions  -- if referencing other local files
+
+namespace LeanProofs
+-- ... your content ...
+end LeanProofs
+```
+
+### Theorem / Lemma syntax
+
+```lean
+-- Statement only (use sorry to check the type compiles first)
+theorem my_theorem (n : ℕ) (h : n > 0) : n * 2 > n := by
+  sorry
+
+-- Full proof
+theorem my_theorem (n : ℕ) (h : n > 0) : n * 2 > n := by
+  linarith
+```
+
+### Definitions
+
+```lean
+-- Type alias
+def MySet := Finset ℕ
+
+-- Structure
+structure MyGraph where
+  vertices : Finset ℕ
+  edges    : Finset (ℕ × ℕ)
+
+-- Inductive type
+inductive Tree (α : Type) where
+  | leaf : Tree α
+  | node : α → Tree α → Tree α → Tree α
+```
+
+## Core Tactic Reference
+
+| Tactic | When to use |
+|--------|-------------|
+| `ring` | Prove equalities in commutative (semi)rings: `a*(b+c) = a*b + a*c` |
+| `ring_nf` | Normalize ring expressions without closing the goal |
+| `norm_num` | Prove concrete numerical facts: `2 + 2 = 4`, `7.isPrime` |
+| `omega` | Linear arithmetic over `ℤ` and `ℕ`: `n + 1 > n` |
+| `linarith` | Linear arithmetic with hypotheses: `h1 : a < b, h2 : b < c ⊢ a < c` |
+| `nlinarith` | Nonlinear arithmetic (products of hypotheses) |
+| `simp` | Simplify using the simp lemma set; use `simp [lemma1, lemma2]` to add |
+| `simp only [h]` | Targeted rewrite using only `h`; safer than bare `simp` |
+| `exact h` | Close goal exactly with hypothesis `h` or a term |
+| `apply f` | Apply function/lemma `f`, unifying conclusion with goal |
+| `rw [h]` | Rewrite goal left-to-right using equation `h` |
+| `rw [← h]` | Rewrite right-to-left |
+| `constructor` | Split an `And` goal or `Iff` into two subgoals |
+| `intro h` | Introduce hypothesis from `∀` or `→` |
+| `obtain ⟨a, b, h⟩ := hx` | Destructure existential or And hypothesis |
+| `use x` | Provide witness for `∃` goal |
+| `cases h` | Case split on inductive type or `Or` |
+| `induction n with` | Structural induction |
+| `by_contra h` | Proof by contradiction |
+| `push_neg` | Push negation inward: `¬ ∀ x, P x` → `∃ x, ¬ P x` |
+| `contrapose!` | Switch to contrapositive and push negation |
+| `gcongr` | Congruence for monotone operations |
+| `field_simp` | Clear denominators in field goals |
+| `positivity` | Prove `0 < x` or `0 ≤ x` goals |
+| `decide` | Close decidable propositions by computation (small finite cases) |
+| `native_decide` | Like `decide` but compiled — handles larger cases |
+| `tauto` | Propositional tautologies |
+| `aesop` | Automated search combining many strategies |
+| `exact?` | **(Interactive only)** Search for a term matching the goal |
+| `apply?` | **(Interactive only)** Search for applicable lemmas |
+| `simp?` | **(Interactive only)** Show which simp lemmas closed/simplified the goal |
+
+## Searching Mathlib
+
+Since `exact?` / `apply?` are interactive-only, use these strategies in batch mode:
+
+### 1. `#check` — verify a name exists
+```lean
+#check Nat.add_comm      -- Nat.add_comm : ∀ (n m : ℕ), n + m = m + n
+#check List.length_map   -- look up list lemmas
+```
+
+### 2. Naming conventions (predict lemma names)
+Mathlib names follow a consistent pattern:
+- `Nat.add_comm`  — commutativity of `+` on `ℕ`
+- `Int.mul_neg`   — negation rule for `*` on `ℤ`
+- `List.map_comp` — `map` composed with `comp`
+- Prefix with type namespace: `Finset.`, `Set.`, `Matrix.`, `Polynomial.`
+
+### 3. `Mathlib.Tactic.Polyrith` / `polyrith`
+For polynomial arithmetic identities that `ring` can't close automatically.
+
+### 4. Web search
+Search `leanprover-community.github.io/mathlib4_docs` for the exact namespace.
+Example: search "Nat prime" to find `Nat.Prime`, `Nat.Prime.two_le`, etc.
+
+## Verification Workflow (Per Proof)
+
+```bash
+# Step 1 — stub the statement, check it type-checks
+# Add `sorry` as the proof body
+
+# Step 2 — build to confirm the statement compiles
+cd lean_proofs && lake build 2>&1; cd ..
+
+# Step 3 — replace sorry with tactics, rebuild
+# Repeat until exit code is 0 with no "sorry" warnings
+
+# Step 4 — grep to confirm no sorry remains
+grep -r "sorry" lean_proofs/LeanProofs/ && echo "INCOMPLETE PROOFS FOUND" || echo "All proofs complete"
+```
+
+`lake build` exit code semantics:
+- **0** — everything compiled; if no `sorry`, proof is formally complete
+- **non-zero** — type error or tactic failure; stderr contains the exact error location and message
+
+## Interpreting Lean Error Messages
+
+| Error | Meaning |
+|-------|---------|
+| `unknown identifier 'foo'` | `foo` not in scope — check import or namespace |
+| `type mismatch: expected X got Y` | Wrong type — check the hypothesis you're applying |
+| `unsolved goals: ⊢ P` | Proof is incomplete — `P` still needs to be proved |
+| `application type mismatch` | Applied lemma to wrong argument type |
+| `failed to synthesize instance` | Missing typeclass — may need `[DecidableEq α]` or similar |
+| `declaration uses sorry` | Proof accepted but marked incomplete — replace all `sorry` |
+
+## Proof Skeleton Template
+
+Use this as a starting point for each new result:
+
+```lean
+/-- One-line description of what this proves. -/
+theorem theorem_name
+    (param1 : Type1)
+    (param2 : Type2)
+    (hyp1 : Condition1)
+    (hyp2 : Condition2) :
+    Conclusion := by
+  sorry  -- replace with actual proof
+
+/-- Supporting lemma used in the main theorem. -/
+lemma lemma_name (n : ℕ) : n + 0 = n := by
+  ring
+```
+
+## Common Mathlib Imports by Area
+
+```lean
+-- ALWAYS start with this — gives all tactics, ~1-2GB cache instead of 5GB:
+import Mathlib.Tactic
+
+-- Then add only the specific content modules you need:
+import Mathlib.Algebra.Group.Basic        -- groups, monoids
+import Mathlib.Algebra.Ring.Basic         -- rings
+import Mathlib.Algebra.Field.Basic        -- fields
+import Mathlib.Data.Nat.Basic             -- ℕ lemmas
+import Mathlib.Data.Int.Basic             -- ℤ lemmas
+import Mathlib.Data.Real.Basic            -- ℝ lemmas
+import Mathlib.Data.Finset.Basic          -- finite sets
+import Mathlib.Combinatorics.SimpleGraph.Basic  -- graph theory
+import Mathlib.Topology.Basic             -- topology
+import Mathlib.Analysis.SpecialFunctions.Pow.Real  -- real powers
+import Mathlib.NumberTheory.Primes        -- prime numbers
+import Mathlib.LinearAlgebra.Matrix.Basic -- matrices
+```
+
+**Avoid `import Mathlib`** — it pulls the full 5GB cache and slower compile times.
+Use `import Mathlib.Tactic` as your base and add specific modules as needed.
+The resource finder's Mathlib lemma catalog tells you exactly which modules to add.
+
+## References
+
+See `references/` folder for:
+- `lean4_cheatsheet.md`: Quick syntax reference
+- `mathlib_search_guide.md`: How to find lemmas by name pattern

--- a/templates/skills/lean-prover/scripts/setup_lean_project.sh
+++ b/templates/skills/lean-prover/scripts/setup_lean_project.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Setup a Lean 4 + Mathlib project in lean_proofs/ within the current workspace.
+# Usage: bash .claude/skills/lean-prover/scripts/setup_lean_project.sh
+set -euo pipefail
+
+PROJECT_DIR="${1:-lean_proofs}"
+LIB_NAME="LeanProofs"
+
+echo "========================================"
+echo "  Lean 4 + Mathlib Project Setup"
+echo "  Target: $PROJECT_DIR/"
+echo "========================================"
+
+# ── 1. Install elan if not present ───────────────────────────────────────────
+if ! command -v elan &>/dev/null && ! command -v lean &>/dev/null; then
+  echo ""
+  echo "► Installing elan (Lean version manager)..."
+  curl -sSfL \
+    https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+    | sh -s -- -y --default-toolchain none
+  # shellcheck source=/dev/null
+  source "$HOME/.elan/env" 2>/dev/null || export PATH="$HOME/.elan/bin:$PATH"
+  echo "  elan installed."
+else
+  echo "► elan/lean already installed: $(elan --version 2>/dev/null || lean --version)"
+fi
+
+# ── 2. Create project directory ───────────────────────────────────────────────
+if [ -d "$PROJECT_DIR" ]; then
+  echo ""
+  echo "► Directory '$PROJECT_DIR' already exists — skipping creation."
+else
+  echo ""
+  echo "► Creating Lean project with Mathlib..."
+  # Use the official mathlib4 template so the toolchain pin is correct
+  lake +leanprover-community/mathlib4:stable init "$PROJECT_DIR" math
+  echo "  Project created."
+fi
+
+cd "$PROJECT_DIR"
+
+# ── 3. Create library source directory ───────────────────────────────────────
+mkdir -p "$LIB_NAME"
+
+# ── 4. Write starter files (only if they don't exist yet) ────────────────────
+if [ ! -f "$LIB_NAME/Definitions.lean" ]; then
+cat > "$LIB_NAME/Definitions.lean" << 'EOF'
+-- Import only proof tactics (ring, omega, linarith, norm_num, simp, decide, etc.)
+-- This is ~1-2GB cache instead of 5GB for `import Mathlib`.
+-- Add specific Mathlib imports below as the resource finder identifies them.
+-- Example: import Mathlib.Data.Nat.Basic
+--          import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Tactic
+
+namespace LeanProofs
+
+/-!
+## Definitions and Notation
+
+Add all definitions, structures, and notation used by the research here.
+Import this file from Lemmas.lean and MainTheorem.lean.
+
+To use a specific Mathlib lemma (e.g. Nat.add_comm), add its module here:
+  import Mathlib.Data.Nat.Basic
+-/
+
+end LeanProofs
+EOF
+fi
+
+if [ ! -f "$LIB_NAME/Lemmas.lean" ]; then
+cat > "$LIB_NAME/Lemmas.lean" << 'EOF'
+import LeanProofs.Definitions
+
+namespace LeanProofs
+
+/-!
+## Supporting Lemmas
+
+Prove intermediate results here. Each lemma should:
+1. Have a doc comment explaining what it says
+2. State all hypotheses explicitly
+3. End with QED (i.e. no `sorry`)
+-/
+
+end LeanProofs
+EOF
+fi
+
+if [ ! -f "$LIB_NAME/MainTheorem.lean" ]; then
+cat > "$LIB_NAME/MainTheorem.lean" << 'EOF'
+import LeanProofs.Lemmas
+
+namespace LeanProofs
+
+/-!
+## Main Results
+
+State and prove the principal theorems of the research.
+-/
+
+end LeanProofs
+EOF
+fi
+
+# Root import file
+cat > "${LIB_NAME}.lean" << EOF
+import ${LIB_NAME}.Definitions
+import ${LIB_NAME}.Lemmas
+import ${LIB_NAME}.MainTheorem
+EOF
+
+# ── 5. Get Mathlib cache ──────────────────────────────────────────────────────
+# When running inside the neurico-lean Docker image, ~/.cache/mathlib4/ is
+# pre-populated at build time.  `lake exe cache get` reads from that local
+# cache instead of downloading — making this step instant.
+# Outside the image (bare machine), it downloads ~1-2GB from the Mathlib CDN.
+echo ""
+CACHE_DIR="${HOME}/.cache/mathlib4"
+if [ -d "${CACHE_DIR}" ] && [ "$(ls -A "${CACHE_DIR}" 2>/dev/null)" ]; then
+  echo "► Mathlib cache found at ${CACHE_DIR} — copying locally (fast)..."
+else
+  echo "► Mathlib cache not found — downloading (~1-2GB, takes a few minutes)..."
+fi
+if lake exe cache get; then
+  echo "  Mathlib cache ready."
+else
+  echo "  Cache step failed — will compile from source on first build."
+  echo "  (This can take 30–90 minutes the first time.)"
+fi
+
+# ── 6. Initial build to confirm setup ────────────────────────────────────────
+echo ""
+echo "► Running initial build to verify setup..."
+if lake build; then
+  echo ""
+  echo "========================================"
+  echo "  Setup complete!"
+  echo "  Project: $(pwd)"
+  echo ""
+  echo "  File layout:"
+  echo "    $LIB_NAME/Definitions.lean  — add definitions here"
+  echo "    $LIB_NAME/Lemmas.lean       — add supporting lemmas here"
+  echo "    $LIB_NAME/MainTheorem.lean  — add main results here"
+  echo ""
+  echo "  Verify proofs at any time:"
+  echo "    cd $PROJECT_DIR && lake build"
+  echo "========================================"
+else
+  echo ""
+  echo "  Build failed — check error output above."
+  exit 1
+fi

--- a/tests/test_decision_log.py
+++ b/tests/test_decision_log.py
@@ -1,0 +1,896 @@
+"""Tests for the decision-log skill."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+NEURICO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(NEURICO_ROOT / "templates" / "skills" / "decision-log" / "scripts"))
+from decision_log import (  # noqa: E402
+    CATEGORIES,
+    DECISION_CATEGORIES,
+    OBSERVATION_CATEGORIES,
+    CycleError,
+    DecisionLog,
+    DecisionNode,
+)
+
+
+@pytest.fixture
+def chain():
+    """A small DAG used by many tests.
+
+           a (model)
+          / \
+         b   d
+         |
+         c
+    """
+    log = DecisionLog()
+    a = log.add(question="model?", choice="VideoMAE", category="model")
+    b = log.add(question="features?", choice="intermediate", category="method",
+                premises=[a])
+    c = log.add(question="layer?", choice="block 8", category="hyperparam",
+                premises=[b])
+    d = log.add(question="frames?", choice="16", category="hyperparam",
+                premises=[a])
+    return log, a, b, c, d
+
+
+# =============================================================
+class TestAddHappy:
+    def test_add_root_no_premises(self):
+        log = DecisionLog()
+        aid = log.add(question="Q", choice="C", category="model")
+        n = log.get(aid)
+        assert n.status == "active"
+        assert n.premises == []
+        assert n.created_at != ""
+
+    def test_add_with_single_premise(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        b = log.add(question="Q", choice="B", category="hyperparam", premises=[a])
+        assert log.get(b).premises == [a]
+
+    def test_add_with_multiple_premises(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        b = log.add(question="Q", choice="B", category="dataset")
+        c = log.add(question="Q", choice="C", category="hyperparam", premises=[a, b])
+        assert log.get(c).premises == [a, b]
+
+    def test_add_with_explicit_id(self):
+        log = DecisionLog()
+        aid = log.add(question="Q", choice="X", category="model", id="my-id")
+        assert aid == "my-id"
+
+    def test_add_with_rationale_and_alternatives(self):
+        log = DecisionLog()
+        aid = log.add(question="Q", choice="VideoMAE-Large", category="model",
+                      rationale="MAE transfers",
+                      alternatives=["TimeSformer", "I3D"])
+        n = log.get(aid)
+        assert n.rationale == "MAE transfers"
+        assert n.alternatives == ["TimeSformer", "I3D"]
+        assert "videomae" in aid.lower()
+
+    def test_duplicate_slug_auto_suffixes(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="X", category="model")
+        b = log.add(question="Q", choice="X", category="model")
+        c = log.add(question="Q", choice="X", category="model")
+        assert a != b != c
+        assert b.endswith("-2")
+        assert c.endswith("-3")
+
+    @pytest.mark.parametrize("cat", sorted(DECISION_CATEGORIES))
+    def test_each_valid_decision_category(self, cat):
+        log = DecisionLog()
+        log.add(question="Q", choice=cat, category=cat)
+        assert len(log.find()) == 1
+
+    def test_premises_as_tuple(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        b = log.add(question="Q", choice="B", category="dataset")
+        c = log.add(question="Q", choice="C", category="hyperparam", premises=(a, b))
+        assert log.get(c).premises == [a, b]
+
+    def test_premises_as_generator(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        b = log.add(question="Q", choice="B", category="dataset")
+        c = log.add(question="Q", choice="C", category="hyperparam",
+                    premises=(p for p in [a, b]))
+        assert log.get(c).premises == [a, b]
+
+
+# =============================================================
+class TestAddErrors:
+    def test_rejects_unknown_category(self):
+        log = DecisionLog()
+        with pytest.raises(ValueError, match="category"):
+            log.add(question="Q", choice="C", category="bogus")
+
+    def test_rejects_unknown_premise(self):
+        log = DecisionLog()
+        with pytest.raises(ValueError, match="does not exist"):
+            log.add(question="Q", choice="C", category="model", premises=["nope"])
+
+    def test_rejects_revoked_premise(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(b)
+        with pytest.raises(ValueError, match="active"):
+            log.add(question="x", choice="y", category="hyperparam", premises=[b])
+
+    def test_rejects_suspect_premise(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)   # b becomes suspect
+        with pytest.raises(ValueError, match="active"):
+            log.add(question="x", choice="y", category="hyperparam", premises=[b])
+
+    def test_rejects_duplicate_premises(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        with pytest.raises(ValueError, match="duplicate"):
+            log.add(question="Q", choice="B", category="hyperparam", premises=[a, a])
+
+
+# =============================================================
+class TestUpdateHappy:
+    def test_update_rationale(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        log.update(a, rationale="new reason")
+        assert log.get(a).rationale == "new reason"
+
+    def test_update_choice_and_question(self):
+        log = DecisionLog()
+        a = log.add(question="old?", choice="old", category="model")
+        log.update(a, choice="new", question="new?")
+        assert log.get(a).choice == "new"
+        assert log.get(a).question == "new?"
+
+    def test_update_premises_to_add_new_one(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        b = log.add(question="Q", choice="B", category="dataset")
+        c = log.add(question="Q", choice="C", category="hyperparam", premises=[a])
+        log.update(c, premises=[a, b])
+        assert log.get(c).premises == [a, b]
+
+    def test_update_alternatives(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        log.update(a, alternatives=["B", "C"])
+        assert log.get(a).alternatives == ["B", "C"]
+
+
+# =============================================================
+class TestUpdateErrors:
+    def test_rejects_unknown_field(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        with pytest.raises(ValueError):
+            log.update(a, status="revoked")
+
+    def test_rejects_category_change(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        with pytest.raises(ValueError):
+            log.update(a, category="dataset")
+
+    def test_rejects_nonexistent_premise(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        b = log.add(question="Q", choice="B", category="dataset", premises=[a])
+        with pytest.raises(ValueError, match="exist"):
+            log.update(b, premises=["nope"])
+
+    def test_rejects_revoked_premise(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(b)
+        with pytest.raises(ValueError, match="active"):
+            log.update(d, premises=[a, b])
+
+    def test_rejects_duplicate_premises(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        b = log.add(question="Q", choice="B", category="hyperparam", premises=[a])
+        with pytest.raises(ValueError, match="duplicate"):
+            log.update(b, premises=[a, a])
+
+    def test_rejects_premise_update_on_revoked_node(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        # Rationale on revoked node is OK
+        log.update(a, rationale="historical note")
+        assert "historical note" in log.get(a).rationale
+        # Premise update on revoked is rejected
+        with pytest.raises(ValueError):
+            log.update(a, premises=[])
+
+    def test_rejects_premise_update_on_suspect_node(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        with pytest.raises(ValueError):
+            log.update(b, premises=[])
+
+
+# =============================================================
+class TestDeleteRemoved:
+    def test_delete_method_is_gone(self):
+        log = DecisionLog()
+        assert not hasattr(log, "delete")
+
+
+# =============================================================
+class TestRevoke:
+    def test_revoke_leaf_no_cascade(self, chain):
+        log, a, b, c, d = chain
+        suspects = log.revoke(c)
+        assert suspects == []
+        assert log.get(c).status == "revoked"
+        assert log.get(c).revoked_root == c
+
+    def test_revoke_root_full_cascade(self, chain):
+        log, a, b, c, d = chain
+        suspects = log.revoke(a)
+        assert set(suspects) == {b, c, d}
+        assert log.get(a).status == "revoked"
+        for x in (b, c, d):
+            assert log.get(x).status == "suspect"
+            assert log.get(x).revoked_root == a
+
+    def test_revoke_middle_partial_cascade(self, chain):
+        log, a, b, c, d = chain
+        suspects = log.revoke(b)
+        assert set(suspects) == {c}
+        assert log.get(a).status == "active"
+        assert log.get(d).status == "active"
+        assert log.get(c).status == "suspect"
+
+    def test_revoke_twice_is_idempotent(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        assert log.revoke(a) == []
+
+    def test_revoke_suspect_promotes_to_revoked(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        assert log.get(b).status == "suspect"
+        log.revoke(b)
+        assert log.get(b).status == "revoked"
+        assert log.get(b).revoked_root == b   # now self-root
+        # c was already suspect from cascade; remains suspect
+        assert log.get(c).status == "suspect"
+
+    def test_reason_appended_to_rationale(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model", rationale="initial")
+        log.revoke(a, reason="moving on")
+        assert "moving on" in log.get(a).rationale
+        assert "initial" in log.get(a).rationale
+
+    def test_revoke_leaves_siblings_alone(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        e = log.add(question="Q", choice="E", category="eval")
+        f = log.add(question="Q", choice="F", category="dataset", premises=[e])
+        log.revoke(a)
+        assert log.get(e).status == "active"
+        assert log.get(f).status == "active"
+
+
+# =============================================================
+class TestReconfirm:
+    def test_reconfirm_with_new_premises(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        a2 = log.add(question="Q", choice="TimeSformer", category="model")
+        log.reconfirm(d, premises=[a2])
+        assert log.get(d).status == "active"
+        assert log.get(d).premises == [a2]
+        assert log.get(d).revoked_root is None
+
+    def test_reconfirm_drops_revoked_premises_when_premises_is_none(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        log.reconfirm(b)
+        assert log.get(b).status == "active"
+        assert log.get(b).premises == []
+
+    def test_rationale_appended(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        log.reconfirm(b, rationale="model-agnostic")
+        assert "model-agnostic" in log.get(b).rationale
+
+    def test_rejects_active_node(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        with pytest.raises(ValueError, match="suspect"):
+            log.reconfirm(a)
+
+    def test_rejects_revoked_node(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        with pytest.raises(ValueError, match="suspect"):
+            log.reconfirm(a)
+
+    def test_rejects_nonexistent_premise(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        with pytest.raises(ValueError, match="exist"):
+            log.reconfirm(b, premises=["nope"])
+
+    def test_rejects_nonactive_premise(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)   # b, c, d all suspect
+        with pytest.raises(ValueError, match="active"):
+            log.reconfirm(c, premises=[b])
+
+    def test_rejects_cycle(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        b = log.add(question="Q", choice="B", category="method", premises=[a])
+        c = log.add(question="Q", choice="C", category="hyperparam", premises=[b])
+        log.revoke(a)
+        with pytest.raises((CycleError, ValueError)):
+            log.reconfirm(b, premises=[c])
+
+    def test_bottom_up_sequence_after_deep_revoke(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        b = log.add(question="Q", choice="B", category="method", premises=[a])
+        c = log.add(question="Q", choice="C", category="hyperparam", premises=[b])
+        d = log.add(question="Q", choice="D", category="eval", premises=[c])
+        log.revoke(a)
+        assert all(log.get(x).status == "suspect" for x in (b, c, d))
+        a2 = log.add(question="Q", choice="A2", category="model")
+        log.reconfirm(b, premises=[a2])
+        log.reconfirm(c)
+        log.reconfirm(d)
+        assert all(log.get(x).status == "active" for x in (b, c, d))
+        assert log.get(c).premises == [b]
+
+
+# =============================================================
+class TestCycle:
+    def test_self_cycle_rejected(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        with pytest.raises(CycleError):
+            log.update(a, premises=[a])
+
+    def test_two_cycle_rejected(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        b = log.add(question="Q", choice="B", category="method", premises=[a])
+        with pytest.raises(CycleError):
+            log.update(a, premises=[b])
+
+    def test_three_cycle_rejected(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        b = log.add(question="Q", choice="B", category="method", premises=[a])
+        c = log.add(question="Q", choice="C", category="hyperparam", premises=[b])
+        with pytest.raises(CycleError):
+            log.update(a, premises=[c])
+
+
+# =============================================================
+class TestRead:
+    def test_get_raises_keyerror(self):
+        log = DecisionLog()
+        with pytest.raises(KeyError):
+            log.get("nope")
+
+    def test_find_empty_log(self):
+        assert DecisionLog().find() == []
+
+    def test_find_by_category(self):
+        log = DecisionLog()
+        log.add(question="Q", choice="m", category="model")
+        log.add(question="Q", choice="h", category="hyperparam")
+        res = log.find(category="model")
+        assert len(res) == 1
+        assert res[0].choice == "m"
+
+    def test_find_query_matches_question_choice_rationale(self):
+        log = DecisionLog()
+        log.add(question="which encoder?", choice="x", category="model")
+        log.add(question="Q", choice="VideoMAE", category="model")
+        log.add(question="Q", choice="x", category="model", rationale="motion features")
+        assert len(log.find(query="encoder")) == 1
+        assert len(log.find(query="videomae")) == 1   # case-insensitive
+        assert len(log.find(query="motion")) == 1
+
+    def test_find_active_only_false_shows_all(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        assert len(log.find(active_only=False)) == 4
+        assert log.find() == []   # all four non-active
+
+    def test_suspects_returns_only_suspect(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        assert {n.id for n in log.suspects()} == {b, c, d}
+
+    def test_subtree_of_leaf(self, chain):
+        log, a, b, c, d = chain
+        assert log.subtree(c) == []
+        assert log.subtree(d) == []
+
+    def test_subtree_of_root(self, chain):
+        log, a, b, c, d = chain
+        assert set(log.subtree(a)) == {b, c, d}
+
+    def test_subtree_of_middle(self, chain):
+        log, a, b, c, d = chain
+        assert set(log.subtree(b)) == {c}
+
+    def test_premises_of_direct(self, chain):
+        log, a, b, c, d = chain
+        assert log.premises_of(c) == [b]
+
+    def test_premises_of_recursive_diamond_no_dup(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="a", category="model")
+        b = log.add(question="Q", choice="b", category="method", premises=[a])
+        c = log.add(question="Q", choice="c", category="method", premises=[a])
+        d = log.add(question="Q", choice="d", category="hyperparam", premises=[b, c])
+        rec = log.premises_of(d, recursive=True)
+        assert sorted(rec) == sorted([a, b, c])
+
+
+# =============================================================
+class TestDAGShapes:
+    def test_diamond_revoke_a(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="a", category="model")
+        b = log.add(question="Q", choice="b", category="method", premises=[a])
+        c = log.add(question="Q", choice="c", category="method", premises=[a])
+        d = log.add(question="Q", choice="d", category="hyperparam", premises=[b, c])
+        assert set(log.revoke(a)) == {b, c, d}
+
+    def test_diamond_revoke_b(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="a", category="model")
+        b = log.add(question="Q", choice="b", category="method", premises=[a])
+        c = log.add(question="Q", choice="c", category="method", premises=[a])
+        d = log.add(question="Q", choice="d", category="hyperparam", premises=[b, c])
+        assert set(log.revoke(b)) == {d}
+        assert log.get(c).status == "active"
+
+    def test_deep_chain_revoke_top(self):
+        log = DecisionLog()
+        ids = []
+        prev = None
+        for i in range(6):
+            kw = dict(question=f"q{i}", choice=f"c{i}", category="hyperparam")
+            if prev is not None:
+                kw["premises"] = [prev]
+            ids.append(log.add(**kw))
+            prev = ids[-1]
+        assert set(log.revoke(ids[0])) == set(ids[1:])
+
+    def test_multi_root_independent_dags(self):
+        log = DecisionLog()
+        a1 = log.add(question="Q", choice="a1", category="model")
+        b1 = log.add(question="Q", choice="b1", category="method", premises=[a1])
+        a2 = log.add(question="Q", choice="a2", category="dataset")
+        b2 = log.add(question="Q", choice="b2", category="eval", premises=[a2])
+        log.revoke(a1)
+        assert log.get(a2).status == "active"
+        assert log.get(b2).status == "active"
+
+
+# =============================================================
+class TestExport:
+    def test_json_round_trip_structure(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(b)
+        payload = json.loads(log.export("json"))
+        assert set(payload) == {a, b, c, d}
+        assert payload[b]["status"] == "revoked"
+        assert payload[c]["status"] == "suspect"
+
+    def test_dot_per_status_color(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        dot = log.export("dot")
+        assert "digraph" in dot
+        assert "color=red" in dot
+        assert "color=orange" in dot
+
+    def test_md_groups_by_node(self, chain):
+        log, _, _, _, _ = chain
+        assert log.export("md").count("## ") == 4
+
+    def test_unknown_format_rejected(self):
+        with pytest.raises(ValueError):
+            DecisionLog().export("xml")
+
+
+# =============================================================
+class TestRobustness:
+    def test_special_chars_sanitized_in_slug(self):
+        log = DecisionLog()
+        aid = log.add(question="Q", choice="VideoMAE-L (v2)!", category="model")
+        assert all(c.isalnum() or c == "-" for c in aid)
+
+    def test_long_choice_truncated(self):
+        log = DecisionLog()
+        aid = log.add(question="Q", choice="x" * 200, category="model")
+        assert len(aid) <= 40
+
+    def test_re_revoke_after_reconfirm(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        a2 = log.add(question="Q", choice="A2", category="model")
+        log.reconfirm(b, premises=[a2])
+        log.reconfirm(c, premises=[b])
+        log.reconfirm(d, premises=[a2])
+        assert set(log.revoke(b)) == {c}
+
+
+# =============================================================
+class TestPersistence:
+    def test_no_path_no_file(self):
+        log = DecisionLog()
+        log.add(question="Q", choice="A", category="model")
+        # Doesn't crash; no file to check.
+
+    def test_save_creates_file(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        assert not path.exists()
+        log = DecisionLog(path=path)
+        log.add(question="Q", choice="A", category="model")
+        assert path.exists()
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        path = tmp_path / "nested" / "dir" / "decisions.json"
+        log = DecisionLog(path=path)
+        log.add(question="Q", choice="A", category="model")
+        assert path.exists()
+
+    def test_reload_preserves_graph(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        log1 = DecisionLog(path=path)
+        a = log1.add(question="Q", choice="A", category="model", rationale="r1")
+        b = log1.add(question="Q", choice="B", category="hyperparam", premises=[a])
+        log1.update(b, rationale="r2")
+
+        log2 = DecisionLog(path=path)
+        assert log2.get(a).choice == "A"
+        assert log2.get(a).rationale == "r1"
+        assert log2.get(b).rationale == "r2"
+        assert log2.get(b).premises == [a]
+
+    def test_reload_preserves_revoked_and_suspect(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        log1 = DecisionLog(path=path)
+        a = log1.add(question="Q", choice="A", category="model")
+        b = log1.add(question="Q", choice="B", category="method", premises=[a])
+        c = log1.add(question="Q", choice="C", category="hyperparam", premises=[b])
+        log1.revoke(a, reason="moving on")
+        log2 = DecisionLog(path=path)
+        assert log2.get(a).status == "revoked"
+        assert log2.get(b).status == "suspect"
+        assert log2.get(c).status == "suspect"
+        assert log2.get(b).revoked_root == a
+
+    def test_reload_preserves_created_at(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        log1 = DecisionLog(path=path)
+        a = log1.add(question="Q", choice="A", category="model")
+        ts1 = log1.get(a).created_at
+        log2 = DecisionLog(path=path)
+        assert log2.get(a).created_at == ts1
+        assert ts1 != ""
+
+    def test_file_contains_schema_version(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        log = DecisionLog(path=path)
+        log.add(question="Q", choice="A", category="model")
+        data = json.loads(path.read_text())
+        assert data["_schema_version"] == 1
+        assert "nodes" in data
+
+    def test_unsupported_schema_rejected(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        path.write_text(json.dumps({"_schema_version": 99, "nodes": {}}))
+        with pytest.raises(ValueError, match="schema"):
+            DecisionLog(path=path)
+
+    def test_revoke_persists(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        log = DecisionLog(path=path)
+        a = log.add(question="Q", choice="A", category="model")
+        log.revoke(a)
+        data = json.loads(path.read_text())
+        assert data["nodes"][a]["status"] == "revoked"
+
+    def test_reconfirm_persists(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        log = DecisionLog(path=path)
+        a = log.add(question="Q", choice="A", category="model")
+        b = log.add(question="Q", choice="B", category="method", premises=[a])
+        log.revoke(a)
+        log.reconfirm(b)
+        data = json.loads(path.read_text())
+        assert data["nodes"][b]["status"] == "active"
+        assert data["nodes"][b]["premises"] == []
+
+    def test_atomic_save_leaves_no_tmp(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        log = DecisionLog(path=path)
+        log.add(question="Q", choice="A", category="model")
+        log.add(question="Q", choice="B", category="dataset")
+        files = sorted(p.name for p in tmp_path.iterdir())
+        assert files == ["decisions.json"]
+
+    def test_partial_tmp_does_not_corrupt(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        log1 = DecisionLog(path=path)
+        a = log1.add(question="Q", choice="A", category="model")
+        # Simulate a crashed mid-write leaving an orphan .tmp
+        (path.parent / "decisions.json.tmp").write_text("{ not valid json")
+        log2 = DecisionLog(path=path)
+        assert log2.get(a).choice == "A"
+
+    def test_revoked_only_graph_round_trips(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        log1 = DecisionLog(path=path)
+        a = log1.add(question="Q", choice="A", category="model")
+        log1.revoke(a, reason="rethinking")
+        log2 = DecisionLog(path=path)
+        assert log2.find() == []
+        all_ = log2.find(active_only=False)
+        assert len(all_) == 1
+        assert all_[0].status == "revoked"
+
+    def test_lists_round_trip(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        log1 = DecisionLog(path=path)
+        a = log1.add(question="Q", choice="A", category="model")
+        b = log1.add(question="Q", choice="B", category="dataset")
+        c = log1.add(question="Q", choice="C", category="hyperparam",
+                     premises=[a, b], alternatives=["alt1", "alt2", "alt3"])
+        log2 = DecisionLog(path=path)
+        assert log2.get(c).premises == [a, b]
+        assert log2.get(c).alternatives == ["alt1", "alt2", "alt3"]
+
+
+# =============================================================
+class TestSlugPolish:
+    def test_collapses_consecutive_dashes(self):
+        log = DecisionLog()
+        aid = log.add(question="Q", choice="16 frames @ 4 fps", category="hyperparam")
+        assert "--" not in aid
+
+    def test_collapses_adjacent_special_runs(self):
+        log = DecisionLog()
+        aid = log.add(question="Q", choice="VideoMAE-L (v2)!", category="model")
+        assert "--" not in aid
+
+    def test_slug_only_alnum_and_single_dashes(self):
+        log = DecisionLog()
+        aid = log.add(question="Q", choice="x@@y!!z", category="model")
+        assert all(c.isalnum() or c == "-" for c in aid)
+        assert "--" not in aid
+
+    def test_collision_after_collapse_still_suffixes(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="X Y Z", category="model")
+        b = log.add(question="Q", choice="X--Y--Z", category="model")
+        assert a != b
+        assert b.endswith("-2")
+
+
+# =============================================================
+class TestObservations:
+    def test_observe_creates_observation_node(self):
+        log = DecisionLog()
+        oid = log.observe(observation="Class imbalance is 4:1", category="data_property")
+        n = log.get(oid)
+        assert n.node_type == "observation"
+        assert n.choice == "Class imbalance is 4:1"
+        assert n.category == "data_property"
+        assert n.status == "active"
+
+    def test_add_creates_decision_node_by_default(self):
+        log = DecisionLog()
+        did = log.add(question="Q", choice="A", category="model")
+        assert log.get(did).node_type == "decision"
+
+    def test_observe_stores_source_as_rationale(self):
+        log = DecisionLog()
+        oid = log.observe(observation="73K notes after dedup",
+                          category="data_property", source="train.csv inspection")
+        assert log.get(oid).rationale == "train.csv inspection"
+
+    def test_observation_can_be_about_a_decision(self):
+        log = DecisionLog()
+        ds = log.add(question="Dataset?", choice="MIMIC", category="dataset")
+        oid = log.observe(observation="MIMIC has 73K notes",
+                          category="data_property", about=[ds])
+        assert log.get(oid).premises == [ds]
+
+    def test_decision_can_premise_on_observation(self):
+        log = DecisionLog()
+        obs = log.observe(observation="Class imbalance 4:1", category="data_property")
+        met = log.add(question="Metric?", choice="balanced acc",
+                      category="eval", premises=[obs],
+                      rationale="addresses observed imbalance")
+        assert log.get(met).premises == [obs]
+
+    def test_observe_rejects_unknown_category(self):
+        log = DecisionLog()
+        with pytest.raises(ValueError, match="observation category"):
+            log.observe(observation="x", category="bogus")
+
+    def test_observe_rejects_decision_category(self):
+        # `dataset` is a decision category — not allowed for observations.
+        log = DecisionLog()
+        with pytest.raises(ValueError, match="observation category"):
+            log.observe(observation="x", category="dataset")
+
+    def test_add_rejects_observation_category(self):
+        # `paper_finding` is an observation category — not allowed for decisions.
+        log = DecisionLog()
+        with pytest.raises(ValueError, match="decision category"):
+            log.add(question="Q", choice="A", category="paper_finding")
+
+    def test_observe_rejects_non_active_about(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="A", category="model")
+        log.revoke(a)
+        with pytest.raises(ValueError, match="active"):
+            log.observe(observation="x", category="other", about=[a])
+
+    def test_revoke_decision_cascades_to_dependent_observation(self):
+        log = DecisionLog()
+        ds = log.add(question="Dataset?", choice="MIMIC", category="dataset")
+        obs = log.observe(observation="MIMIC has 73K notes",
+                          category="data_property", about=[ds])
+        suspects = log.revoke(ds, reason="switching")
+        assert obs in suspects
+        assert log.get(obs).status == "suspect"
+
+    def test_revoke_observation_cascades_to_dependent_decision(self):
+        log = DecisionLog()
+        obs = log.observe(observation="Class imbalance 4:1", category="data_property")
+        met = log.add(question="Metric?", choice="balanced acc",
+                      category="eval", premises=[obs])
+        suspects = log.revoke(obs, reason="misread")
+        assert met in suspects
+        assert log.get(met).status == "suspect"
+
+    def test_find_filter_by_node_type(self):
+        log = DecisionLog()
+        log.add(question="Q", choice="A", category="model")
+        log.add(question="Q", choice="B", category="dataset")
+        log.observe(observation="X", category="paper_finding")
+        log.observe(observation="Y", category="env_fact")
+        assert len(log.find(node_type="decision")) == 2
+        assert len(log.find(node_type="observation")) == 2
+        assert len(log.find()) == 4
+
+    def test_decisions_and_observations_helpers(self):
+        log = DecisionLog()
+        log.add(question="Q", choice="A", category="model")
+        log.observe(observation="X", category="other")
+        assert len(log.decisions()) == 1
+        assert len(log.observations()) == 1
+
+    def test_find_rejects_unknown_node_type(self):
+        log = DecisionLog()
+        with pytest.raises(ValueError, match="node_type"):
+            log.find(node_type="bogus")
+
+    def test_observation_round_trips_through_persistence(self, tmp_path):
+        path = tmp_path / "decisions.json"
+        log1 = DecisionLog(path=path)
+        ds = log1.add(question="Q", choice="A", category="dataset")
+        oid = log1.observe(observation="finding X", category="paper_finding",
+                           about=[ds], source="paper:Table 2")
+        log2 = DecisionLog(path=path)
+        n = log2.get(oid)
+        assert n.node_type == "observation"
+        assert n.choice == "finding X"
+        assert n.rationale == "paper:Table 2"
+        assert n.premises == [ds]
+
+    def test_mixed_dag_decision_obs_decision(self):
+        log = DecisionLog()
+        ds = log.add(question="Dataset?", choice="MIMIC", category="dataset")
+        obs = log.observe(observation="73K class-imbalanced 4:1",
+                          category="data_property", about=[ds])
+        met = log.add(question="Metric?", choice="balanced acc",
+                      category="eval", premises=[obs])
+        suspects = log.revoke(ds)
+        assert set(suspects) == {obs, met}
+
+    def test_md_export_distinguishes_observations(self):
+        log = DecisionLog()
+        log.add(question="Q", choice="A", category="model")
+        log.observe(observation="X", category="paper_finding")
+        md = log.export("md")
+        assert "OBSERVATION" in md
+        assert "Observation: X" in md
+
+    def test_dot_export_uses_different_shape(self):
+        log = DecisionLog()
+        log.add(question="Q", choice="A", category="model")
+        log.observe(observation="X", category="paper_finding")
+        dot = log.export("dot")
+        assert "shape=box" in dot
+        assert "shape=ellipse" in dot
+
+    @pytest.mark.parametrize("cat", sorted(OBSERVATION_CATEGORIES))
+    def test_each_valid_observation_category(self, cat):
+        log = DecisionLog()
+        log.observe(observation=f"sample {cat}", category=cat)
+        assert len(log.observations()) == 1
+
+
+# =============================================================
+class TestTriageOrder:
+    def test_empty_when_no_suspects(self):
+        log = DecisionLog()
+        log.add(question="Q", choice="A", category="model")
+        assert log.triage_order() == []
+
+    def test_single_suspect_after_middle_revoke(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(b)
+        assert log.triage_order() == [c]
+
+    def test_topological_in_deep_chain(self):
+        log = DecisionLog()
+        ids = []
+        prev = None
+        for i in range(5):
+            kw = dict(question=f"q{i}", choice=f"c{i}", category="hyperparam")
+            if prev is not None:
+                kw["premises"] = [prev]
+            ids.append(log.add(**kw))
+            prev = ids[-1]
+        log.revoke(ids[0])
+        assert log.triage_order() == ids[1:]
+
+    def test_diamond_puts_merge_node_last(self):
+        log = DecisionLog()
+        a = log.add(question="Q", choice="a", category="model")
+        b = log.add(question="Q", choice="b", category="method", premises=[a])
+        c = log.add(question="Q", choice="c", category="method", premises=[a])
+        d = log.add(question="Q", choice="d", category="hyperparam", premises=[b, c])
+        log.revoke(a)
+        order = log.triage_order()
+        assert set(order) == {b, c, d}
+        assert order.index(d) > order.index(b)
+        assert order.index(d) > order.index(c)
+
+    def test_deterministic_by_id(self):
+        log = DecisionLog()
+        a1 = log.add(question="Q", choice="z-first", category="model")
+        a2 = log.add(question="Q", choice="a-second", category="dataset")
+        b1 = log.add(question="Q", choice="b1", category="method", premises=[a1])
+        b2 = log.add(question="Q", choice="b2", category="method", premises=[a2])
+        log.revoke(a1)
+        log.revoke(a2)
+        order = log.triage_order()
+        assert order == sorted([b1, b2])
+
+    def test_shrinks_after_partial_reconfirm(self, chain):
+        log, a, b, c, d = chain
+        log.revoke(a)
+        log.reconfirm(b)
+        order = log.triage_order()
+        assert set(order) == {c, d}

--- a/tests/test_lean_integration.py
+++ b/tests/test_lean_integration.py
@@ -1,0 +1,666 @@
+"""
+Integration tests for the Lean proof feedback loop.
+
+These tests verify the shell-level behaviors that the session_instructions
+template prescribes WITHOUT calling the Claude LLM at all — making them
+free to run in terms of API cost.
+
+Three tiers, by cost/speed:
+
+  Tier 1  lean_binary   — `lean --stdin` only; instant once lean is installed
+  Tier 2  lean_lake     — minimal Lake project (no Mathlib); seconds per test
+  Tier 3  lean_mathlib  — full setup_lean_project.sh with Mathlib; slow
+
+Run fast tests only (default):
+    pytest tests/test_lean_integration.py -m "not lean_mathlib"
+
+Run everything including Mathlib:
+    pytest tests/test_lean_integration.py
+
+Skip all Lean tests (e.g. in CI without lean installed):
+    pytest tests/test_lean_integration.py -m "not lean_binary"
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT    = Path(__file__).parent.parent
+SETUP_SCRIPT = REPO_ROOT / "templates" / "skills" / "lean-prover" / "scripts" / "setup_lean_project.sh"
+
+# ── Pytest marks ──────────────────────────────────────────────────────────────
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "lean_binary: requires lean binary on PATH")
+    config.addinivalue_line("markers", "lean_lake:   requires lean + lake on PATH")
+    config.addinivalue_line("markers", "lean_mathlib: slow — downloads Mathlib cache")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _run(cmd: list[str], cwd=None, input_text=None, timeout=60) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _lean_path() -> str | None:
+    return shutil.which("lean")
+
+
+def _lake_path() -> str | None:
+    return shutil.which("lake")
+
+
+def _elan_path() -> str | None:
+    return shutil.which("elan")
+
+
+# ── Session-level availability checks ────────────────────────────────────────
+
+@pytest.fixture(scope="session")
+def lean_bin():
+    path = _lean_path()
+    if path is None:
+        pytest.skip(
+            "lean binary not found on PATH.\n"
+            "Install with: curl -sSfL https://raw.githubusercontent.com/"
+            "leanprover/elan/master/elan-init.sh | sh -s -- -y"
+        )
+    return path
+
+
+@pytest.fixture(scope="session")
+def lake_bin(lean_bin):
+    path = _lake_path()
+    if path is None:
+        pytest.skip("lake binary not found on PATH (usually installed with elan)")
+    return path
+
+
+# ── Tier 1: lean --stdin (no project, no Mathlib) ────────────────────────────
+
+@pytest.mark.lean_binary
+class TestLeanBinaryFeedbackLoop:
+    """
+    Tests the core sorry/valid/error feedback loop using `lean --stdin`.
+    No project, no Mathlib, no internet needed.
+    Exercises the exact semantics the session_instructions relies on.
+    """
+
+    # ── valid proof ───────────────────────────────────────────────────────────
+
+    def test_valid_proof_exits_zero(self, lean_bin):
+        """A correct proof must exit 0 — the session_instructions 'proof complete' signal."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t (n : Nat) : n + 0 = n := Nat.add_zero n\n",
+        )
+        assert result.returncode == 0, (
+            f"Valid proof should exit 0.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_valid_proof_produces_no_sorry_warning(self, lean_bin):
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t (n : Nat) : n + 0 = n := Nat.add_zero n\n",
+        )
+        combined = result.stdout + result.stderr
+        assert "sorry" not in combined.lower(), (
+            "A proof with no sorry must not produce a 'sorry' warning"
+        )
+
+    def test_omega_proves_linear_arithmetic(self, lean_bin):
+        """omega is a core tactic (no Mathlib) — must close simple linear goals."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t (n : Nat) : n + 1 > n := by omega\n",
+        )
+        assert result.returncode == 0, (
+            f"omega should close 'n + 1 > n'.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_decide_proves_concrete_fact(self, lean_bin):
+        """decide computes decidable propositions — no Mathlib needed."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t : (2 : Nat) + 2 = 4 := by decide\n",
+        )
+        assert result.returncode == 0, (
+            f"decide should close '2 + 2 = 4'.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    # ── sorry behavior ────────────────────────────────────────────────────────
+
+    def test_sorry_exits_zero(self, lean_bin):
+        """sorry must exit 0 (accepted by Lean) so the loop can continue."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t (n : Nat) : n + 0 = n := by sorry\n",
+        )
+        assert result.returncode == 0, (
+            f"sorry should exit 0.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_sorry_produces_warning(self, lean_bin):
+        """sorry must produce a 'declaration uses sorry' warning — the grep target."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t (n : Nat) : n + 0 = n := by sorry\n",
+        )
+        combined = result.stdout + result.stderr
+        assert "sorry" in combined.lower(), (
+            "sorry proof must produce a warning containing 'sorry'"
+        )
+
+    def test_declaration_uses_sorry_message(self, lean_bin):
+        """The specific 'declaration uses sorry' string from the error table in SKILL.md."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t : True := by sorry\n",
+        )
+        combined = result.stdout + result.stderr
+        assert "declaration uses 'sorry'" in combined or "uses sorry" in combined, (
+            "The 'declaration uses sorry' message must appear in Lean's output"
+        )
+
+    # ── type errors ───────────────────────────────────────────────────────────
+
+    def test_type_error_exits_nonzero(self, lean_bin):
+        """A type error must exit non-zero — the agent's signal to fix the proof."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t : (1 : Nat) = 2 := by rfl\n",
+        )
+        assert result.returncode != 0, (
+            f"Type error (1 = 2 by rfl) should exit non-zero.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_type_error_message_in_output(self, lean_bin):
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t : (1 : Nat) = 2 := by rfl\n",
+        )
+        combined = result.stdout + result.stderr
+        assert len(combined) > 0, "Type error must produce output for the agent to read"
+
+    def test_unknown_identifier_error(self, lean_bin):
+        """'unknown identifier' appears when the agent misspells a lemma name."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            input_text="theorem t : True := obviously_true\n",
+        )
+        combined = result.stdout + result.stderr
+        assert result.returncode != 0
+        assert "unknown" in combined.lower() or "identifier" in combined.lower(), (
+            "Using a non-existent identifier must produce an 'unknown identifier' error"
+        )
+
+    def test_unsolved_goals_error(self, lean_bin):
+        """'unsolved goals' appears when a tactic doesn't close the proof."""
+        result = _run(
+            [lean_bin, "--stdin"],
+            # intro doesn't close the goal — leaves a goal open
+            input_text="theorem t (h : True) : True := by intro\n",
+        )
+        combined = result.stdout + result.stderr
+        # Either unsolved goals or a different error — the point is it fails
+        assert result.returncode != 0 or "unsolved" in combined.lower(), (
+            "An incomplete tactic proof must fail"
+        )
+
+
+# ── Tier 2: minimal Lake project (no Mathlib, fast) ───────────────────────────
+
+@pytest.fixture(scope="module")
+def minimal_lake_workspace(tmp_path_factory, lean_bin, lake_bin):
+    """
+    Create a minimal Lake project WITHOUT Mathlib.
+    This mimics the lean_proofs/ structure the session_instructions prescribes,
+    but avoids the Mathlib download so tests run in seconds.
+    """
+    d = tmp_path_factory.mktemp("lean_minimal")
+
+    # Minimal lakefile — no Mathlib dependency
+    (d / "lakefile.lean").write_text(textwrap.dedent("""\
+        import Lake
+        open Lake DSL
+
+        package «proofs» where
+          name := "proofs"
+
+        lean_lib «LeanProofs»
+    """))
+
+    # Root import file (matches session_instructions structure)
+    (d / "LeanProofs.lean").write_text(textwrap.dedent("""\
+        import LeanProofs.Definitions
+        import LeanProofs.Lemmas
+        import LeanProofs.MainTheorem
+    """))
+
+    lib = d / "LeanProofs"
+    lib.mkdir()
+
+    # Starter files with the same content the setup script creates,
+    # but importing core Lean instead of Mathlib
+    (lib / "Definitions.lean").write_text(textwrap.dedent("""\
+        namespace LeanProofs
+
+        /-!
+        ## Definitions and Notation
+        -/
+
+        end LeanProofs
+    """))
+
+    (lib / "Lemmas.lean").write_text(textwrap.dedent("""\
+        import LeanProofs.Definitions
+
+        namespace LeanProofs
+
+        /-!
+        ## Supporting Lemmas
+        -/
+
+        end LeanProofs
+    """))
+
+    (lib / "MainTheorem.lean").write_text(textwrap.dedent("""\
+        import LeanProofs.Lemmas
+
+        namespace LeanProofs
+
+        /-!
+        ## Main Results
+        -/
+
+        end LeanProofs
+    """))
+
+    # Run initial build to ensure the empty project compiles
+    result = _run([lake_bin, "build"], cwd=d, timeout=120)
+    if result.returncode != 0:
+        pytest.skip(
+            f"Initial lake build failed (lean toolchain issue?).\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    return d
+
+
+@pytest.mark.lean_lake
+class TestLakeBuildFeedbackLoop:
+    """
+    Tests the exact `cd lean_proofs && lake build 2>&1 ; cd ..` pattern
+    prescribed by the session_instructions, using a minimal project.
+    """
+
+    def _write_main_theorem(self, workspace: Path, content: str):
+        (workspace / "LeanProofs" / "MainTheorem.lean").write_text(
+            textwrap.dedent(f"""\
+                import LeanProofs.Lemmas
+
+                namespace LeanProofs
+
+                {content}
+
+                end LeanProofs
+            """)
+        )
+
+    # ── valid proofs ──────────────────────────────────────────────────────────
+
+    def test_valid_core_proof_exits_zero(self, minimal_lake_workspace, lake_bin):
+        """A correct proof in MainTheorem.lean must make lake build exit 0."""
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem add_zero (n : Nat) : n + 0 = n := Nat.add_zero n"
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        assert result.returncode == 0, (
+            f"Valid proof must make lake build exit 0.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_omega_proof_exits_zero(self, minimal_lake_workspace, lake_bin):
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem lt_succ (n : Nat) : n < n + 1 := by omega"
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        assert result.returncode == 0, (
+            f"omega proof must make lake build exit 0.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    # ── sorry behavior ────────────────────────────────────────────────────────
+
+    def test_sorry_lake_build_exits_zero(self, minimal_lake_workspace, lake_bin):
+        """sorry must exit 0 so the agent can iterate — not block the loop."""
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem stub (n : Nat) : n + 0 = n := by sorry"
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        assert result.returncode == 0, (
+            f"sorry proof must make lake build exit 0 (warning, not error).\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_sorry_lake_build_produces_warning(self, minimal_lake_workspace, lake_bin):
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem stub (n : Nat) : n + 0 = n := by sorry"
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        combined = result.stdout + result.stderr
+        assert "sorry" in combined.lower(), (
+            "sorry proof must produce a warning in lake build output"
+        )
+
+    # ── grep-sorry completion check ───────────────────────────────────────────
+
+    def test_grep_finds_sorry_in_incomplete_proof(self, minimal_lake_workspace):
+        """The `grep -r sorry lean_proofs/LeanProofs/` check must find sorry."""
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem stub (n : Nat) : n + 0 = n := by sorry"
+        )
+        lean_dir = minimal_lake_workspace / "LeanProofs"
+        result = _run(["grep", "-r", "sorry", str(lean_dir)])
+        assert result.returncode == 0, (
+            "grep must return 0 (found matches) when sorry is present"
+        )
+        assert "sorry" in result.stdout, (
+            "grep output must contain the matched 'sorry' line"
+        )
+
+    def test_grep_returns_nonzero_after_sorry_removed(self, minimal_lake_workspace):
+        """After replacing sorry with a real proof, grep must return non-zero (no match)."""
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem stub (n : Nat) : n + 0 = n := Nat.add_zero n"
+        )
+        lean_dir = minimal_lake_workspace / "LeanProofs"
+        result = _run(["grep", "-r", "sorry", str(lean_dir)])
+        assert result.returncode != 0, (
+            "grep must return non-zero (no matches) when no sorry remains"
+        )
+
+    def test_grep_sorry_or_echo_workflow(self, minimal_lake_workspace):
+        """The exact pipeline pattern:
+            grep -r 'sorry' lean/... && echo INCOMPLETE || echo OK
+        Must print OK when proofs are complete.
+        """
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem done (n : Nat) : n + 0 = n := Nat.add_zero n"
+        )
+        lean_dir = minimal_lake_workspace / "LeanProofs"
+        result = _run(
+            ["bash", "-c",
+             f'grep -r "sorry" {lean_dir} && echo "INCOMPLETE PROOFS FOUND" || echo "All proofs complete"'],
+        )
+        assert "All proofs complete" in result.stdout, (
+            f"Workflow should print 'All proofs complete' when no sorry.\n"
+            f"stdout: {result.stdout}"
+        )
+
+    # ── type error handling ───────────────────────────────────────────────────
+
+    def test_type_error_exits_nonzero(self, minimal_lake_workspace, lake_bin):
+        """A type error in a .lean file must make lake build exit non-zero."""
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem bad : (1 : Nat) = 2 := by rfl"
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        assert result.returncode != 0, (
+            "Type error must make lake build exit non-zero"
+        )
+
+    def test_type_error_produces_output(self, minimal_lake_workspace, lake_bin):
+        """The agent reads stderr to understand what to fix."""
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem bad : (1 : Nat) = 2 := by rfl"
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        combined = result.stdout + result.stderr
+        assert len(combined) > 0, "Type error must produce diagnostic output"
+
+    # ── file structure expected by session instructions ───────────────────────
+
+    def test_import_chain_compiles(self, minimal_lake_workspace, lake_bin):
+        """Definitions ← Lemmas ← MainTheorem import chain must compile clean."""
+        (minimal_lake_workspace / "LeanProofs" / "Definitions.lean").write_text(
+            textwrap.dedent("""\
+                namespace LeanProofs
+                def myConst : Nat := 42
+                end LeanProofs
+            """)
+        )
+        (minimal_lake_workspace / "LeanProofs" / "Lemmas.lean").write_text(
+            textwrap.dedent("""\
+                import LeanProofs.Definitions
+                namespace LeanProofs
+                theorem myConst_pos : myConst > 0 := by unfold myConst; omega
+                end LeanProofs
+            """)
+        )
+        (minimal_lake_workspace / "LeanProofs" / "MainTheorem.lean").write_text(
+            textwrap.dedent("""\
+                import LeanProofs.Lemmas
+                namespace LeanProofs
+                theorem myConst_nonzero : myConst ≠ 0 := by
+                  have := myConst_pos; omega
+                end LeanProofs
+            """)
+        )
+        result = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=120)
+        assert result.returncode == 0, (
+            f"3-file import chain must compile.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_lake_clean_then_build(self, minimal_lake_workspace, lake_bin):
+        """The session instructions prescribe `lake clean && lake build` for Phase 4.
+        Verify clean + fresh build succeeds.
+        """
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem t (n : Nat) : n + 0 = n := Nat.add_zero n"
+        )
+        clean = _run([lake_bin, "clean"], cwd=minimal_lake_workspace, timeout=30)
+        assert clean.returncode == 0, "lake clean should succeed"
+
+        build = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=120)
+        assert build.returncode == 0, (
+            f"lake build after clean must succeed.\n"
+            f"stdout: {build.stdout}\nstderr: {build.stderr}"
+        )
+
+    def test_verification_md_content(self, minimal_lake_workspace, lake_bin):
+        """The session_instructions prescribes writing results/verification.md with
+        the lake build output and grep-sorry result. Verify we can produce that content.
+        """
+        self._write_main_theorem(
+            minimal_lake_workspace,
+            "theorem t (n : Nat) : n + 0 = n := Nat.add_zero n"
+        )
+        build = _run([lake_bin, "build"], cwd=minimal_lake_workspace, timeout=60)
+        lean_dir = minimal_lake_workspace / "LeanProofs"
+        grep = _run(["grep", "-r", "sorry", str(lean_dir)])
+
+        results_dir = minimal_lake_workspace / "results"
+        results_dir.mkdir(exist_ok=True)
+
+        verification_md = results_dir / "verification.md"
+        verification_md.write_text(
+            f"# Verification\n\n"
+            f"## lake build exit code\n{build.returncode}\n\n"
+            f"## grep sorry output\n"
+            f"{'No sorry found (exit {})'.format(grep.returncode) if grep.returncode != 0 else grep.stdout}\n"
+        )
+
+        content = verification_md.read_text()
+        assert "lake build exit code" in content
+        assert "grep sorry" in content
+        assert str(build.returncode) in content
+
+
+# ── Tier 3: full setup_lean_project.sh with Mathlib (slow) ───────────────────
+
+@pytest.fixture(scope="module")
+def mathlib_workspace(tmp_path_factory, lean_bin, lake_bin):
+    """
+    Run the actual setup_lean_project.sh to create a full Mathlib workspace.
+    This is slow (5-30 min on first run) — only used for lean_mathlib tests.
+    """
+    d = tmp_path_factory.mktemp("lean_mathlib")
+
+    result = _run(
+        ["bash", str(SETUP_SCRIPT)],
+        cwd=d,
+        timeout=3600,  # allow up to 1 hour for Mathlib cache download
+    )
+
+    if result.returncode != 0:
+        pytest.skip(
+            f"setup_lean_project.sh failed (no network? wrong toolchain?).\n"
+            f"stdout: {result.stdout[-2000:]}\nstderr: {result.stderr[-2000:]}"
+        )
+
+    lean_proofs = d / "lean_proofs"
+    if not lean_proofs.exists():
+        pytest.skip("setup_lean_project.sh ran but lean_proofs/ was not created")
+
+    return lean_proofs
+
+
+@pytest.mark.lean_mathlib
+@pytest.mark.slow
+class TestMathlibWorkflow:
+    """Full Mathlib integration — runs the actual setup script and proves a theorem."""
+
+    def test_project_structure_created(self, mathlib_workspace):
+        assert (mathlib_workspace / "lakefile.lean").exists()
+        assert (mathlib_workspace / "lean-toolchain").exists()
+        assert (mathlib_workspace / "LeanProofs").is_dir()
+        assert (mathlib_workspace / "LeanProofs" / "Definitions.lean").exists()
+        assert (mathlib_workspace / "LeanProofs" / "Lemmas.lean").exists()
+        assert (mathlib_workspace / "LeanProofs" / "MainTheorem.lean").exists()
+
+    def test_initial_build_succeeds(self, mathlib_workspace, lake_bin):
+        result = _run([lake_bin, "build"], cwd=mathlib_workspace, timeout=600)
+        assert result.returncode == 0, (
+            f"Initial Mathlib project build must succeed.\n"
+            f"stdout: {result.stdout[-1000:]}\nstderr: {result.stderr[-1000:]}"
+        )
+
+    def test_ring_tactic_proves_arithmetic(self, mathlib_workspace, lake_bin):
+        """ring is the canonical Mathlib automation tactic mentioned in SKILL.md."""
+        (mathlib_workspace / "LeanProofs" / "MainTheorem.lean").write_text(
+            textwrap.dedent("""\
+                import LeanProofs.Lemmas
+
+                namespace LeanProofs
+
+                -- Simple question: prove n^2 + 2n + 1 = (n+1)^2
+                theorem sq_expand (n : ℕ) : n ^ 2 + 2 * n + 1 = (n + 1) ^ 2 := by ring
+
+                end LeanProofs
+            """)
+        )
+        result = _run([lake_bin, "build"], cwd=mathlib_workspace, timeout=300)
+        assert result.returncode == 0, (
+            f"'ring' should prove n² + 2n + 1 = (n+1)².\n"
+            f"stdout: {result.stdout[-1000:]}\nstderr: {result.stderr[-1000:]}"
+        )
+
+    def test_norm_num_proves_concrete_fact(self, mathlib_workspace, lake_bin):
+        """norm_num is the Mathlib tactic for concrete numerical goals."""
+        (mathlib_workspace / "LeanProofs" / "MainTheorem.lean").write_text(
+            textwrap.dedent("""\
+                import LeanProofs.Lemmas
+
+                namespace LeanProofs
+
+                theorem two_pow_10 : (2 : ℕ) ^ 10 = 1024 := by norm_num
+
+                end LeanProofs
+            """)
+        )
+        result = _run([lake_bin, "build"], cwd=mathlib_workspace, timeout=300)
+        assert result.returncode == 0, (
+            f"norm_num should prove 2^10 = 1024.\n"
+            f"stdout: {result.stdout[-1000:]}\nstderr: {result.stderr[-1000:]}"
+        )
+
+    def test_mathlib_lemma_cite_works(self, mathlib_workspace, lake_bin):
+        """Citing Nat.add_comm by name (as the resource finder catalogs) must compile."""
+        (mathlib_workspace / "LeanProofs" / "MainTheorem.lean").write_text(
+            textwrap.dedent("""\
+                import LeanProofs.Lemmas
+
+                namespace LeanProofs
+
+                -- Cite a Mathlib lemma by name (as the resource finder catalogs it)
+                theorem comm_example (n m : ℕ) : n + m = m + n :=
+                  Nat.add_comm n m
+
+                end LeanProofs
+            """)
+        )
+        result = _run([lake_bin, "build"], cwd=mathlib_workspace, timeout=300)
+        assert result.returncode == 0, (
+            f"Nat.add_comm cited by name must compile.\n"
+            f"stdout: {result.stdout[-1000:]}\nstderr: {result.stderr[-1000:]}"
+        )
+
+    def test_sorry_and_grep_workflow(self, mathlib_workspace, lake_bin):
+        """End-to-end: sorry → lake build exits 0 → grep finds sorry → replace → clean."""
+        lean_dir = mathlib_workspace / "LeanProofs"
+        main = lean_dir / "MainTheorem.lean"
+
+        # Step 1: write sorry stub
+        main.write_text(textwrap.dedent("""\
+            import LeanProofs.Lemmas
+            namespace LeanProofs
+            theorem my_result (n : ℕ) : n ^ 2 + 2 * n + 1 = (n + 1) ^ 2 := by sorry
+            end LeanProofs
+        """))
+
+        build1 = _run([lake_bin, "build"], cwd=mathlib_workspace, timeout=300)
+        assert build1.returncode == 0, "sorry stub must exit 0"
+
+        grep1 = _run(["grep", "-r", "sorry", str(lean_dir)])
+        assert grep1.returncode == 0, "grep must find sorry in stub"
+
+        # Step 2: replace sorry with real proof
+        main.write_text(textwrap.dedent("""\
+            import LeanProofs.Lemmas
+            namespace LeanProofs
+            theorem my_result (n : ℕ) : n ^ 2 + 2 * n + 1 = (n + 1) ^ 2 := by ring
+            end LeanProofs
+        """))
+
+        build2 = _run([lake_bin, "build"], cwd=mathlib_workspace, timeout=300)
+        assert build2.returncode == 0, "completed proof must exit 0"
+
+        grep2 = _run(["grep", "-r", "sorry", str(lean_dir)])
+        assert grep2.returncode != 0, "grep must return non-zero when no sorry remains"

--- a/tests/test_lean_llm_smoke.py
+++ b/tests/test_lean_llm_smoke.py
@@ -1,0 +1,469 @@
+"""
+Lean pipeline smoke test with real LLM feedback.
+
+Bypasses all three pipeline stages except the core Lean proof loop:
+
+  ┌─────────────────────────────────────────────────────────────────┐
+  │  FULL PIPELINE          │  THIS TEST                            │
+  ├─────────────────────────┼───────────────────────────────────────┤
+  │  Stage 1: resource finder│  pre-supplied workspace (stub files)  │
+  │  Stage 2: expr runner   │  focused 5-step prompt, 15 min limit  │
+  │  Stage 3: paper writer  │  skipped                              │
+  └─────────────────────────┴───────────────────────────────────────┘
+
+What is actually tested:
+  1. setup_lean_project.sh runs successfully in the workspace
+  2. The LLM writes a valid .lean file with a specific theorem
+  3. lake build exits 0 (type checker accepts the proof)
+  4. grep -r "sorry" finds nothing (proof is complete, not stubbed)
+  5. The verification.md deliverable is produced
+
+Runtime:  ~10-15 min (Lean setup + first lake build + a few LLM turns)
+Cost:     ~$0.10-0.50 (a handful of Claude turns on a trivial problem)
+
+Not run by default — requires claude CLI and valid credentials.
+
+Run:
+    pytest tests/test_lean_llm_smoke.py -v -s
+
+Skip all LLM tests:
+    pytest -m "not lean_llm" tests/
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+TEMPLATES  = REPO_ROOT / "templates"
+
+
+# ── Pytest mark ───────────────────────────────────────────────────────────────
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "lean_llm: LLM smoke test — requires claude CLI + credentials, ~10-15 min"
+    )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _claude_available() -> bool:
+    return shutil.which("claude") is not None
+
+
+def _lean_available() -> bool:
+    return shutil.which("lean") is not None or shutil.which("elan") is not None
+
+
+def _build_prompt(work_dir: Path, theorem_name: str, theorem_body: str) -> str:
+    """Minimal focused prompt — exercises only the Lean proof loop, nothing else."""
+    return f"""\
+You are running a Lean 4 proof infrastructure smoke test.
+Work directory: {work_dir}
+
+Complete ONLY these steps, in order. Do nothing else.
+
+════════════════════════════════════════════════════════════════
+STEP 1 — Lean project setup
+════════════════════════════════════════════════════════════════
+
+Run the setup script. It installs elan/lean if absent and creates
+lean_proofs/ with Mathlib.Tactic:
+
+    bash .claude/skills/lean-prover/scripts/setup_lean_project.sh
+
+Wait for it to finish (lake build will run at the end of the script).
+If it succeeds, proceed. If it fails, write the error to
+results/lean_smoke_result.txt and stop.
+
+════════════════════════════════════════════════════════════════
+STEP 2 — Write the theorem
+════════════════════════════════════════════════════════════════
+
+Write EXACTLY this content to lean_proofs/LeanProofs/MainTheorem.lean
+(overwrite the starter file):
+
+import LeanProofs.Lemmas
+
+namespace LeanProofs
+
+{theorem_body}
+
+end LeanProofs
+
+════════════════════════════════════════════════════════════════
+STEP 3 — Verify with lake build
+════════════════════════════════════════════════════════════════
+
+Run:
+    cd lean_proofs && lake build 2>&1 | tail -20; cd ..
+
+Expected: exit code 0.
+If non-zero: the proof has a type error. Read the error, fix the .lean
+file, and rebuild. Try at most 3 times. Stop after 3 failures.
+
+════════════════════════════════════════════════════════════════
+STEP 4 — Confirm no sorry
+════════════════════════════════════════════════════════════════
+
+Run:
+    grep -r "sorry" lean_proofs/LeanProofs/ \\
+      && echo "INCOMPLETE — sorry found" \\
+      || echo "PROVED — no sorry"
+
+════════════════════════════════════════════════════════════════
+STEP 5 — Write result
+════════════════════════════════════════════════════════════════
+
+Create results/lean_smoke_result.txt with:
+- theorem name: {theorem_name}
+- lake build exit code: <value>
+- sorry check: PROVED or INCOMPLETE
+- lean version: output of `lean --version`
+
+That is all. Do not run any other commands or create any other files.
+"""
+
+
+# ── Workspace fixture ─────────────────────────────────────────────────────────
+
+@pytest.fixture
+def smoke_workspace(tmp_path):
+    """
+    Pre-created workspace that mimics what the resource finder would produce.
+    The experiment runner reads these files before starting; providing stubs
+    lets us skip Stage 1 entirely.
+    """
+    work_dir = tmp_path / "lean_smoke"
+    work_dir.mkdir()
+
+    # Directories the runner and agent expect
+    for d in ["logs", "results", "papers", "src"]:
+        (work_dir / d).mkdir()
+
+    # ── Stub resource finder outputs ─────────────────────────────────────────
+    (work_dir / "literature_review.md").write_text("""\
+# Literature Review (smoke test stub)
+
+## Research Area Overview
+Testing Lean 4 proof infrastructure for basic natural number arithmetic.
+
+## Key Definitions
+- ℕ: the natural numbers
+- Addition on ℕ is commutative
+
+## Mathlib Lemma Catalog
+| Informal Result      | Mathlib Name   | Verified? |
+|----------------------|----------------|-----------|
+| n + m = m + n        | Nat.add_comm   | ✓         |
+
+## Recommendations for Proof Strategy
+- Use `ring` tactic for arithmetic equalities (requires Mathlib.Tactic)
+- Alternatively: `Nat.add_comm n m` as an exact term proof
+""")
+
+    (work_dir / "resources.md").write_text("""\
+# Resources (smoke test stub)
+
+## Mathlib Prerequisites
+| Result          | Mathlib Name | Used For          |
+|-----------------|--------------|-------------------|
+| Commutativity + | Nat.add_comm | Main theorem proof |
+
+## Recommendations for Proof Construction
+1. Proof strategy: direct proof using ring tactic
+2. Mathlib lemmas to cite: Nat.add_comm
+3. Lemmas to prove from scratch: none
+""")
+
+    # ── Copy lean-prover skill (setup_lean_project.sh lives here) ────────────
+    skills_src = TEMPLATES / "skills"
+    skills_dst = work_dir / ".claude" / "skills"
+    skills_dst.mkdir(parents=True)
+    for skill_dir in skills_src.iterdir():
+        if skill_dir.is_dir():
+            shutil.copytree(skill_dir, skills_dst / skill_dir.name)
+
+    return work_dir
+
+
+# ── Main smoke test ───────────────────────────────────────────────────────────
+
+@pytest.mark.lean_llm
+class TestLeanLLMSmoke:
+
+    THEOREM_NAME = "add_comm_smoke"
+    THEOREM_BODY = (
+        "/-- Commutativity of addition on ℕ — proved by ring tactic. -/\n"
+        "theorem add_comm_smoke (a b : ℕ) : a + b = b + a := by ring"
+    )
+    TIMEOUT = 900  # 15 minutes
+
+    @pytest.fixture(autouse=True)
+    def require_claude(self):
+        if not _claude_available():
+            pytest.skip("claude CLI not found on PATH")
+
+    def _run_agent(self, work_dir: Path, prompt: str) -> subprocess.CompletedProcess:
+        """Launch claude -p with the smoke prompt, stream output."""
+        cmd = [
+            "claude", "-p",
+            "--dangerously-skip-permissions",
+            "--verbose",
+            "--output-format", "stream-json",
+        ]
+
+        log_file = work_dir / "logs" / "lean_smoke.log"
+        start = time.time()
+
+        with open(log_file, "w") as log_f:
+            proc = subprocess.Popen(
+                cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                cwd=str(work_dir),
+            )
+            proc.stdin.write(prompt)
+            proc.stdin.close()
+
+            for line in iter(proc.stdout.readline, ""):
+                if line:
+                    print(line, end="", flush=True)
+                    log_f.write(line)
+
+            try:
+                return_code = proc.wait(timeout=self.TIMEOUT)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                elapsed = time.time() - start
+                pytest.fail(
+                    f"Agent timed out after {elapsed:.0f}s "
+                    f"(limit: {self.TIMEOUT}s).\n"
+                    f"Log: {log_file}"
+                )
+
+        elapsed = time.time() - start
+        print(f"\n⏱  Agent finished in {elapsed:.0f}s (return code {return_code})")
+        return subprocess.CompletedProcess(cmd, return_code)
+
+    # ── Test 1: lean project setup ────────────────────────────────────────────
+
+    def test_lean_project_created(self, smoke_workspace):
+        """After the smoke run, lean_proofs/ must exist with the full structure."""
+        prompt = _build_prompt(smoke_workspace, self.THEOREM_NAME, self.THEOREM_BODY)
+        self._run_agent(smoke_workspace, prompt)
+
+        lean_proofs = smoke_workspace / "lean_proofs"
+        assert lean_proofs.exists(), (
+            "lean_proofs/ was not created — setup_lean_project.sh may have failed.\n"
+            f"Logs: {smoke_workspace / 'logs' / 'lean_smoke.log'}"
+        )
+        assert (lean_proofs / "lakefile.lean").exists(), "lakefile.lean missing"
+        assert (lean_proofs / "lean-toolchain").exists(), "lean-toolchain missing"
+        assert (lean_proofs / "LeanProofs").is_dir(), "LeanProofs/ directory missing"
+
+    # ── Test 2: theorem was written ───────────────────────────────────────────
+
+    def test_theorem_written_to_main_file(self, smoke_workspace):
+        """The agent must have written the theorem to MainTheorem.lean."""
+        prompt = _build_prompt(smoke_workspace, self.THEOREM_NAME, self.THEOREM_BODY)
+        self._run_agent(smoke_workspace, prompt)
+
+        main_theorem = smoke_workspace / "lean_proofs" / "LeanProofs" / "MainTheorem.lean"
+        assert main_theorem.exists(), "MainTheorem.lean not found"
+
+        content = main_theorem.read_text()
+        assert self.THEOREM_NAME in content, (
+            f"Theorem '{self.THEOREM_NAME}' not found in MainTheorem.lean.\n"
+            f"File content:\n{content}"
+        )
+
+    # ── Test 3: lake build passes ─────────────────────────────────────────────
+
+    def test_lake_build_exits_zero(self, smoke_workspace):
+        """After the agent run, independently verify lake build exits 0."""
+        prompt = _build_prompt(smoke_workspace, self.THEOREM_NAME, self.THEOREM_BODY)
+        self._run_agent(smoke_workspace, prompt)
+
+        lean_proofs = smoke_workspace / "lean_proofs"
+        if not lean_proofs.exists():
+            pytest.skip("lean_proofs/ not created — cannot verify lake build")
+
+        result = subprocess.run(
+            ["lake", "build"],
+            cwd=lean_proofs,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        assert result.returncode == 0, (
+            f"lake build failed after agent run (exit {result.returncode}).\n"
+            f"stdout: {result.stdout[-1000:]}\n"
+            f"stderr: {result.stderr[-1000:]}"
+        )
+
+    # ── Test 4: no sorry in final state ──────────────────────────────────────
+
+    def test_no_sorry_in_lean_files(self, smoke_workspace):
+        """The proof must be complete — no sorry placeholders remaining."""
+        prompt = _build_prompt(smoke_workspace, self.THEOREM_NAME, self.THEOREM_BODY)
+        self._run_agent(smoke_workspace, prompt)
+
+        lean_dir = smoke_workspace / "lean_proofs" / "LeanProofs"
+        if not lean_dir.exists():
+            pytest.skip("LeanProofs/ not created — cannot grep for sorry")
+
+        result = subprocess.run(
+            ["grep", "-r", "sorry", str(lean_dir)],
+            capture_output=True,
+            text=True,
+        )
+        # grep exits non-zero when nothing is found — that is what we want
+        assert result.returncode != 0, (
+            f"sorry found in lean files — proof is incomplete.\n"
+            f"Matches:\n{result.stdout}"
+        )
+
+    # ── Test 5: verification.md was produced ──────────────────────────────────
+
+    def test_verification_result_written(self, smoke_workspace):
+        """The agent must write results/lean_smoke_result.txt as instructed."""
+        prompt = _build_prompt(smoke_workspace, self.THEOREM_NAME, self.THEOREM_BODY)
+        self._run_agent(smoke_workspace, prompt)
+
+        result_file = smoke_workspace / "results" / "lean_smoke_result.txt"
+        assert result_file.exists(), (
+            "results/lean_smoke_result.txt not found — agent may not have "
+            "completed all steps.\n"
+            f"Logs: {smoke_workspace / 'logs' / 'lean_smoke.log'}"
+        )
+        content = result_file.read_text()
+        # Must contain the theorem name and a verdict
+        assert self.THEOREM_NAME in content or "PROVED" in content or "lake" in content, (
+            f"Result file exists but content looks wrong:\n{content}"
+        )
+
+
+# ── Consolidated run (one agent call, all assertions) ─────────────────────────
+
+@pytest.mark.lean_llm
+class TestLeanLLMSmokeConsolidated:
+    """
+    Single-agent-call variant: runs the agent ONCE and checks all assertions.
+    Use this to avoid 5 separate agent invocations if running the full class above.
+
+    Run:
+        pytest tests/test_lean_llm_smoke.py::TestLeanLLMSmokeConsolidated -v -s
+    """
+
+    THEOREM_NAME = "add_comm_smoke"
+    THEOREM_BODY = (
+        "/-- Commutativity of addition on ℕ — proved by ring tactic. -/\n"
+        "theorem add_comm_smoke (a b : ℕ) : a + b = b + a := by ring"
+    )
+    TIMEOUT = 900
+
+    @pytest.fixture(autouse=True)
+    def require_claude(self):
+        if not _claude_available():
+            pytest.skip("claude CLI not found on PATH")
+
+    @pytest.fixture(scope="class")
+    def completed_workspace(self, tmp_path_factory):
+        """Runs the agent ONCE; all tests in this class share the result."""
+        # Check here too — scope="class" runs before autouse method fixtures
+        if not _claude_available():
+            pytest.skip("claude CLI not found on PATH")
+
+        work_dir = tmp_path_factory.mktemp("lean_smoke_consolidated")
+        for d in ["logs", "results", "papers", "src"]:
+            (work_dir / d).mkdir()
+
+        # Stub resource finder files
+        (work_dir / "literature_review.md").write_text(
+            "# Stub\n\n## Mathlib Lemma Catalog\n"
+            "| n+m=m+n | Nat.add_comm | ✓ |\n"
+        )
+        (work_dir / "resources.md").write_text(
+            "# Stub\n\n## Mathlib Prerequisites\n"
+            "| Commutativity | Nat.add_comm | main proof |\n"
+        )
+
+        skills_src = TEMPLATES / "skills"
+        skills_dst = work_dir / ".claude" / "skills"
+        skills_dst.mkdir(parents=True)
+        for skill_dir in skills_src.iterdir():
+            if skill_dir.is_dir():
+                shutil.copytree(skill_dir, skills_dst / skill_dir.name)
+
+        # Run agent once
+        prompt = _build_prompt(work_dir, self.THEOREM_NAME, self.THEOREM_BODY)
+        cmd = [
+            "claude", "-p",
+            "--dangerously-skip-permissions",
+            "--verbose", "--output-format", "stream-json",
+        ]
+        log = work_dir / "logs" / "lean_smoke.log"
+        with open(log, "w") as log_f:
+            proc = subprocess.Popen(
+                cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT, text=True, cwd=str(work_dir),
+            )
+            proc.stdin.write(prompt)
+            proc.stdin.close()
+            for line in iter(proc.stdout.readline, ""):
+                if line:
+                    print(line, end="", flush=True)
+                    log_f.write(line)
+            try:
+                proc.wait(timeout=self.TIMEOUT)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                pytest.fail(f"Agent timed out. Log: {log}")
+
+        return work_dir
+
+    def test_lean_project_structure(self, completed_workspace):
+        lp = completed_workspace / "lean_proofs"
+        assert lp.exists(), "lean_proofs/ not created"
+        assert (lp / "lakefile.lean").exists()
+        assert (lp / "lean-toolchain").exists()
+        assert (lp / "LeanProofs").is_dir()
+
+    def test_theorem_in_main_file(self, completed_workspace):
+        f = completed_workspace / "lean_proofs" / "LeanProofs" / "MainTheorem.lean"
+        assert f.exists(), "MainTheorem.lean not found"
+        assert self.THEOREM_NAME in f.read_text()
+
+    def test_lake_build_passes(self, completed_workspace):
+        lp = completed_workspace / "lean_proofs"
+        if not lp.exists():
+            pytest.skip("lean_proofs/ absent")
+        r = subprocess.run(["lake", "build"], cwd=lp,
+                           capture_output=True, text=True, timeout=300)
+        assert r.returncode == 0, (
+            f"lake build failed\nstdout:{r.stdout[-500:]}\nstderr:{r.stderr[-500:]}"
+        )
+
+    def test_no_sorry_remaining(self, completed_workspace):
+        lean_dir = completed_workspace / "lean_proofs" / "LeanProofs"
+        if not lean_dir.exists():
+            pytest.skip("LeanProofs/ absent")
+        r = subprocess.run(["grep", "-r", "sorry", str(lean_dir)],
+                           capture_output=True, text=True)
+        assert r.returncode != 0, f"sorry found:\n{r.stdout}"
+
+    def test_result_file_written(self, completed_workspace):
+        f = completed_workspace / "results" / "lean_smoke_result.txt"
+        assert f.exists(), "lean_smoke_result.txt not written"
+        content = f.read_text()
+        assert len(content) > 20, f"Result file is too short:\n{content}"

--- a/tests/test_lean_resource_finder.py
+++ b/tests/test_lean_resource_finder.py
@@ -1,0 +1,415 @@
+"""
+Unit tests for the mathematics_lean resource finder template.
+
+The resource finder is the first agent in the pipeline. For mathematics_lean
+it has an extra Phase 3 (Mathlib Lemma Catalog) not present in other domains.
+These tests verify:
+
+  1. Domain override resolution  — mathematics_lean loads its own template
+  2. Template rendering          — idea content is injected; no bare {{ }}
+  3. Phase 3 (Mathlib catalog)   — heading, all four steps, naming conventions,
+                                   #check workflow, fallback guidance
+  4. Lean project boundary       — resource finder must NOT set up Lean project
+  5. Phase ordering              — 1 → 2 → 3 → 4 → 5 in rendered text
+  6. literature_review.md format — Mathlib Lemma Catalog section is specified
+  7. resources.md format         — Mathlib Prerequisites table is specified
+  8. Completion marker           — counts Mathlib lemmas (not just papers)
+  9. Differences from baselines  — generic and plain-math templates lack Phase 3
+"""
+
+import sys
+import re
+import pytest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from templates.prompt_generator import PromptGenerator
+
+TEMPLATES_DIR = REPO_ROOT / "templates"
+LEAN_RF_PATH  = TEMPLATES_DIR / "domains" / "mathematics_lean" / "resource_finder.txt"
+
+# ── Sample ideas ───────────────────────────────────────────────────────────────
+
+LEAN_IDEA = {
+    "idea": {
+        "title": "Formal verification of Ramsey-type bounds",
+        "domain": "mathematics_lean",
+        "hypothesis": "For every graph G with chromatic number > k, G contains K_{k+1} as a minor.",
+        "background": {},
+    }
+}
+
+MATH_IDEA = {
+    "idea": {
+        "title": "Ramsey bounds via probabilistic method",
+        "domain": "mathematics",
+        "hypothesis": "Same hypothesis — plain math domain.",
+        "background": {},
+    }
+}
+
+GENERIC_IDEA = {
+    "idea": {
+        "title": "A machine learning experiment",
+        "domain": "machine_learning",
+        "hypothesis": "Fine-tuning beats RAG for domain-specific tasks.",
+        "background": {},
+    }
+}
+
+
+@pytest.fixture
+def gen():
+    return PromptGenerator(TEMPLATES_DIR)
+
+
+@pytest.fixture
+def rendered(gen):
+    return gen.generate_resource_finder_prompt(LEAN_IDEA)
+
+
+@pytest.fixture
+def rendered_math(gen):
+    return gen.generate_resource_finder_prompt(MATH_IDEA)
+
+
+@pytest.fixture
+def rendered_generic(gen):
+    return gen.generate_resource_finder_prompt(GENERIC_IDEA)
+
+
+# ── 1. Domain override resolution ─────────────────────────────────────────────
+
+class TestDomainOverrideResolution:
+    def test_lean_override_file_exists(self):
+        assert LEAN_RF_PATH.exists(), f"Override not found: {LEAN_RF_PATH}"
+
+    def test_lean_template_differs_from_generic_fallback(self, gen):
+        lean    = gen._load_template_with_domain_override(
+            "agents/resource_finder.txt", "mathematics_lean"
+        )
+        generic = gen.load_template("agents/resource_finder.txt")
+        assert lean != generic
+
+    def test_lean_template_differs_from_plain_math(self, gen):
+        lean = gen._load_template_with_domain_override(
+            "agents/resource_finder.txt", "mathematics_lean"
+        )
+        math = gen._load_template_with_domain_override(
+            "agents/resource_finder.txt", "mathematics"
+        )
+        assert lean != math
+
+
+# ── 2. Template rendering ──────────────────────────────────────────────────────
+
+class TestTemplateRendering:
+    def test_no_jinja_placeholders_remain(self, rendered):
+        assert "{{" not in rendered and "}}" not in rendered
+
+    def test_idea_title_injected(self, rendered):
+        assert "Ramsey-type bounds" in rendered
+
+    def test_idea_hypothesis_injected(self, rendered):
+        assert "chromatic number" in rendered
+
+    def test_idea_domain_injected(self, rendered):
+        assert "mathematics_lean" in rendered
+
+    def test_result_is_substantial_string(self, rendered):
+        assert isinstance(rendered, str) and len(rendered) > 1000
+
+
+# ── 3. Phase 3 — Mathlib Lemma Catalog ────────────────────────────────────────
+
+class TestMathlibCatalogPhase:
+    def test_phase3_heading_present(self, rendered):
+        assert "PHASE 3" in rendered, "Phase 3 heading must be in rendered output"
+
+    def test_phase3_mathlib_label(self, rendered):
+        assert "MATHLIB" in rendered.upper() or "Mathlib Lemma Catalog" in rendered, (
+            "Phase 3 must be labelled as the Mathlib lemma catalog"
+        )
+
+    def test_phase3_step1_naming_conventions(self, rendered):
+        """Step 1 documents Mathlib naming conventions."""
+        assert "Nat." in rendered or "Nat.*" in rendered, (
+            "Mathlib Nat.* namespace convention must be documented"
+        )
+        assert "add_comm" in rendered, (
+            "Example lemma name (add_comm) must appear in naming conventions"
+        )
+
+    def test_phase3_step1_multiple_namespaces(self, rendered):
+        """Several type namespaces must be shown, not just Nat."""
+        for ns in ["Nat.", "Int.", "Real.", "Finset.", "List."]:
+            assert ns in rendered, f"Namespace '{ns}' missing from naming conventions"
+
+    def test_phase3_step2_hash_check_verification(self, rendered):
+        """Step 2 must show the #check approach for verifying lemma names."""
+        assert "#check" in rendered, (
+            "#check must be documented as the lemma-name verification tool"
+        )
+        assert "Nat.add_comm" in rendered, (
+            "A concrete #check example (Nat.add_comm) must be shown"
+        )
+
+    def test_phase3_step2_lean_scratch_file(self, rendered):
+        """Step 2 must show the lean_scratch / Check.lean workflow."""
+        assert "lean_scratch" in rendered, (
+            "lean_scratch directory must be part of the #check workflow"
+        )
+        assert "Check.lean" in rendered, (
+            "Check.lean scratch file must be shown in Phase 3 Step 2"
+        )
+
+    def test_phase3_step2_fallback_when_lean_unavailable(self, rendered):
+        """When lean binary is absent, web search is the documented fallback."""
+        assert "leanprover-community.github.io/mathlib4_docs" in rendered, (
+            "Web search fallback URL must be present for when lean is unavailable"
+        )
+
+    def test_phase3_step3_search_for_formalizations(self, rendered):
+        """Step 3 must instruct searching for existing Lean formalizations."""
+        lower = rendered.lower()
+        assert "lean formalization" in lower or "existing lean" in lower, (
+            "Phase 3 Step 3 must tell the agent to search for existing formalizations"
+        )
+
+    def test_phase3_step3_mathlib4_github_mentioned(self, rendered):
+        assert "leanprover-community/mathlib4" in rendered, (
+            "Mathlib4 GitHub URL must be referenced for formalization search"
+        )
+
+    def test_phase3_step4_lemma_table_format(self, rendered):
+        """Step 4 must show the Mathlib lemma table with the required columns."""
+        assert "Mathlib Name" in rendered, "Table column 'Mathlib Name' must be shown"
+        assert "Informal Result" in rendered or "Informal" in rendered, (
+            "Table column for informal result must be shown"
+        )
+        # Verified / Not in Mathlib status symbols
+        assert "✓" in rendered and "✗" in rendered, (
+            "Table must show ✓ (in Mathlib) and ✗ (not in Mathlib) status symbols"
+        )
+
+    def test_phase3_step4_table_has_concrete_examples(self, rendered):
+        """The table must contain at least one worked example row."""
+        assert "Nat.add_comm" in rendered or "Finset.sum_range_succ" in rendered, (
+            "Phase 3 Step 4 table must contain a concrete Mathlib lemma example"
+        )
+
+    def test_phase3_critical_label(self, rendered):
+        """Phase 3 must be marked as CRITICAL (it's unique to this domain)."""
+        # Find Phase 3 section and check nearby text
+        idx = rendered.upper().find("PHASE 3")
+        assert idx != -1
+        window = rendered[idx:idx + 300].upper()
+        assert "CRITICAL" in window, (
+            "Phase 3 must be labelled CRITICAL to signal its importance"
+        )
+
+
+# ── 4. Lean project boundary ───────────────────────────────────────────────────
+
+class TestLeanProjectBoundary:
+    def test_explicit_do_not_setup_lean(self, rendered):
+        """The resource finder must explicitly tell the agent NOT to set up Lean."""
+        lower = rendered.lower()
+        assert "do not set up the lean project" in lower or (
+            "do not" in lower and "lean" in lower and "setup" in lower
+        ) or "experiment runner" in lower and "lean setup" in lower.replace("\n", " "), (
+            "Resource finder must explicitly state Lean project setup is NOT its job"
+        )
+
+    def test_no_lake_build_in_resource_finder(self, rendered):
+        """lake build must NOT be a primary instruction — that belongs to the
+        experiment runner. Only the lean_scratch verification snippet may run lean."""
+        # lake build should not appear as a primary step
+        # It may appear inside the scratch-file snippet (lean lean_scratch/...)
+        # but should NOT appear as a phase instruction
+        occurrences = [m.start() for m in re.finditer(r"lake build", rendered)]
+        # If it appears at all, it must only be inside the scratch-file context
+        # (i.e. not as a standalone phase step)
+        for pos in occurrences:
+            window = rendered[max(0, pos - 100):pos + 100]
+            assert "scratch" in window.lower() or "setup" in window.lower() or \
+                   "verify" in window.lower(), (
+                "'lake build' should only appear in a scratch/verification context "
+                "inside the resource finder, not as a phase instruction"
+            )
+
+    def test_experiment_runner_owns_lean_setup(self, rendered):
+        """The boundary must explicitly name the experiment runner as owner."""
+        assert "experiment runner" in rendered.lower(), (
+            "Resource finder must reference the experiment runner as responsible for Lean setup"
+        )
+
+    def test_dont_list_mentions_lean_project(self, rendered):
+        """The DON'T list must warn against setting up the Lean project."""
+        lower = rendered.lower()
+        assert "don't" in lower or "dont" in lower or "✗" in rendered, (
+            "A DON'T / best-practice list must exist"
+        )
+        # The lean-project warning must exist somewhere
+        assert "lean project" in lower or ("set up" in lower and "lean" in lower), (
+            "DON'T list must warn against setting up the Lean project"
+        )
+
+
+# ── 5. Phase ordering ─────────────────────────────────────────────────────────
+
+class TestPhaseOrdering:
+    """Phases must appear in the correct order in the rendered text."""
+
+    def _phase_position(self, rendered: str, n: int) -> int:
+        match = re.search(rf"PHASE {n}[^0-9]", rendered)
+        assert match, f"PHASE {n} not found in rendered output"
+        return match.start()
+
+    def test_phase1_before_phase2(self, rendered):
+        assert self._phase_position(rendered, 1) < self._phase_position(rendered, 2)
+
+    def test_phase2_before_phase3(self, rendered):
+        assert self._phase_position(rendered, 2) < self._phase_position(rendered, 3)
+
+    def test_phase3_before_phase4(self, rendered):
+        assert self._phase_position(rendered, 3) < self._phase_position(rendered, 4)
+
+    def test_phase4_before_phase5(self, rendered):
+        assert self._phase_position(rendered, 4) < self._phase_position(rendered, 5)
+
+    def test_phase3_is_mathlib_not_tools(self, rendered):
+        """Phase 3 must be the Mathlib catalog, Phase 4 must be computational tools."""
+        p3_start = self._phase_position(rendered, 3)
+        p4_start = self._phase_position(rendered, 4)
+        phase3_text = rendered[p3_start:p4_start].upper()
+        assert "MATHLIB" in phase3_text, (
+            "Phase 3 content must be about Mathlib, not computational tools"
+        )
+
+    def test_phase4_is_computational_tools(self, rendered):
+        p4_start = self._phase_position(rendered, 4)
+        p5_start = self._phase_position(rendered, 5)
+        phase4_text = rendered[p4_start:p5_start].upper()
+        assert "TOOL" in phase4_text or "SYMPY" in phase4_text or "PYTHON" in phase4_text, (
+            "Phase 4 content must be about computational tools"
+        )
+
+
+# ── 6. literature_review.md output format ─────────────────────────────────────
+
+class TestLiteratureReviewFormat:
+    def test_mathlib_lemma_catalog_section_specified(self, rendered):
+        """The literature_review.md template must include a Mathlib Lemma Catalog section."""
+        assert "Mathlib Lemma Catalog" in rendered, (
+            "literature_review.md format must include a 'Mathlib Lemma Catalog' section"
+        )
+
+    def test_existing_lean_formalizations_section_specified(self, rendered):
+        assert "Existing Lean Formalizations" in rendered, (
+            "literature_review.md format must include 'Existing Lean Formalizations' section"
+        )
+
+    def test_recommendations_split_mathlib_vs_scratch(self, rendered):
+        """Recommendations must distinguish 'cite from Mathlib' vs 'prove from scratch'."""
+        lower = rendered.lower()
+        assert "cite" in lower and "mathlib" in lower, (
+            "Recommendations section must mention citing from Mathlib"
+        )
+        assert "prove from scratch" in lower or "prove" in lower and "scratch" in lower, (
+            "Recommendations section must mention what must be proved from scratch"
+        )
+
+    def test_lean_tactics_mentioned_in_recommendations(self, rendered):
+        """The proof strategy recommendation must mention Lean tactics."""
+        lower = rendered.lower()
+        assert "lean tactic" in lower or "tactic" in lower, (
+            "Recommendations must mention Lean tactics likely useful for each step"
+        )
+
+
+# ── 7. resources.md format ────────────────────────────────────────────────────
+
+class TestResourcesMdFormat:
+    def test_mathlib_prerequisites_table_specified(self, rendered):
+        assert "Mathlib Prerequisites" in rendered, (
+            "resources.md format must include a 'Mathlib Prerequisites' table"
+        )
+
+    def test_mathlib_prerequisites_table_has_columns(self, rendered):
+        """The Mathlib Prerequisites table must have the right columns."""
+        assert "Mathlib Name" in rendered, "Column 'Mathlib Name' must appear in table"
+        assert "Used For" in rendered, "Column 'Used For' must appear in table"
+
+    def test_recommendations_split_cite_vs_prove(self, rendered):
+        """resources.md recommendations must split Mathlib cites from scratch proofs."""
+        assert "Mathlib lemmas to cite" in rendered or (
+            "cite directly" in rendered.lower()
+        ), "Recommendations must list Mathlib lemmas to cite"
+        assert "proved from scratch" in rendered.lower() or (
+            "prove from scratch" in rendered.lower()
+        ), "Recommendations must list lemmas to prove from scratch"
+
+
+# ── 8. Completion marker ──────────────────────────────────────────────────────
+
+class TestCompletionMarker:
+    def test_completion_marker_file_present(self, rendered):
+        assert ".resource_finder_complete" in rendered, (
+            "Completion marker file must be mentioned"
+        )
+
+    def test_completion_marker_counts_mathlib_lemmas(self, rendered):
+        """The marker must record Mathlib lemma count, not just papers."""
+        assert "Mathlib lemmas identified" in rendered, (
+            "Completion marker must count Mathlib lemmas found, "
+            "not just papers downloaded"
+        )
+
+    def test_final_checklist_includes_mathlib_check(self, rendered):
+        """The final checklist must include a Mathlib-specific verification step."""
+        lower = rendered.lower()
+        assert "#check" in rendered and "checklist" in lower or (
+            "mathlib lemma" in lower and ("✓" in rendered or "verified" in lower)
+        ), "Final checklist must include the Mathlib lemma #check step"
+
+
+# ── 9. Differences from baselines ─────────────────────────────────────────────
+
+class TestBaselineDifferences:
+    def test_phase3_absent_from_generic_resource_finder(self, rendered_generic):
+        """Generic (ML) resource finder must NOT have the Mathlib catalog phase."""
+        assert "Mathlib Lemma Catalog" not in rendered_generic, (
+            "Mathlib Lemma Catalog must be unique to mathematics_lean"
+        )
+        assert "#check" not in rendered_generic, (
+            "#check verification must be absent from generic resource finder"
+        )
+
+    def test_phase3_absent_from_plain_math_resource_finder(self, rendered_math):
+        """Plain mathematics resource finder must NOT have Phase 3 Mathlib catalog."""
+        assert "Mathlib Lemma Catalog" not in rendered_math, (
+            "Mathlib Lemma Catalog must be unique to mathematics_lean, not plain mathematics"
+        )
+
+    def test_lean_domain_has_more_mathlib_references(self, rendered, rendered_math):
+        lean_count = rendered.count("Mathlib")
+        math_count = rendered_math.count("Mathlib")
+        assert lean_count > math_count, (
+            f"mathematics_lean ({lean_count} refs) should mention Mathlib more "
+            f"than plain mathematics ({math_count} refs)"
+        )
+
+    def test_do_not_setup_lean_absent_from_plain_math(self, rendered_math):
+        """The specific 'Do NOT set up the Lean project here' boundary note
+        must not appear in the plain mathematics resource finder."""
+        lower = rendered_math.lower()
+        # The exact boundary phrase unique to mathematics_lean
+        assert "do not set up the lean project" not in lower and (
+            "experiment runner phase handles lean setup" not in lower
+        ), (
+            "The Lean-project boundary note should only appear in mathematics_lean, "
+            "not in plain mathematics"
+        )

--- a/tests/test_lean_session_instructions.py
+++ b/tests/test_lean_session_instructions.py
@@ -1,0 +1,277 @@
+"""
+Unit tests for the mathematics_lean domain session instructions template.
+
+Tests cover:
+  1. Domain override resolution  — the correct template file is loaded
+  2. Template rendering          — all Jinja2 variables are substituted
+  3. Lean content presence       — key Lean workflow phrases exist in output
+  4. Lean-as-verifier framing    — lake build is the verification signal,
+                                   not just a Python check
+  5. Python-exploration framing  — Python/SymPy is present but scoped to
+                                   exploration, NOT proof validity
+  6. No unrendered placeholders  — no {{ ... }} tokens remain in output
+"""
+
+import sys
+import pytest
+from pathlib import Path
+
+# Make src/ importable without an install
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from templates.prompt_generator import PromptGenerator
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+TEMPLATES_DIR = REPO_ROOT / "templates"
+
+SAMPLE_PROMPT = (
+    "Prove that for every n ≥ 1 the sum of the first n odd numbers equals n²."
+)
+SAMPLE_WORK_DIR = "/workspaces/test-lean-workspace"
+
+
+@pytest.fixture
+def generator():
+    return PromptGenerator(TEMPLATES_DIR)
+
+
+@pytest.fixture
+def rendered(generator):
+    """Rendered session instructions for the mathematics_lean domain."""
+    return generator.generate_session_instructions(
+        prompt=SAMPLE_PROMPT,
+        work_dir=SAMPLE_WORK_DIR,
+        use_scribe=False,
+        domain="mathematics_lean",
+    )
+
+
+@pytest.fixture
+def rendered_scribe(generator):
+    """Rendered session instructions with use_scribe=True (notebook mode)."""
+    return generator.generate_session_instructions(
+        prompt=SAMPLE_PROMPT,
+        work_dir=SAMPLE_WORK_DIR,
+        use_scribe=True,
+        domain="mathematics_lean",
+    )
+
+
+@pytest.fixture
+def rendered_generic(generator):
+    """Rendered session instructions for the plain mathematics domain (baseline)."""
+    return generator.generate_session_instructions(
+        prompt=SAMPLE_PROMPT,
+        work_dir=SAMPLE_WORK_DIR,
+        use_scribe=False,
+        domain="mathematics",
+    )
+
+
+# ── 1. Domain override resolution ─────────────────────────────────────────────
+
+class TestDomainOverrideResolution:
+    def test_lean_template_is_loaded_not_generic(self, generator):
+        """_load_template_with_domain_override picks mathematics_lean over agents/ fallback."""
+        lean_content = generator._load_template_with_domain_override(
+            "agents/session_instructions.txt", "mathematics_lean"
+        )
+        generic_content = generator.load_template("agents/session_instructions.txt")
+
+        # The two templates must be different files
+        assert lean_content != generic_content, (
+            "mathematics_lean should have its own session_instructions.txt override"
+        )
+
+    def test_lean_override_file_exists(self):
+        override_path = TEMPLATES_DIR / "domains" / "mathematics_lean" / "session_instructions.txt"
+        assert override_path.exists(), (
+            f"Override template not found at {override_path}"
+        )
+
+    def test_mathematics_domain_uses_different_template(self, generator):
+        """mathematics and mathematics_lean load distinct session instructions."""
+        lean = generator._load_template_with_domain_override(
+            "agents/session_instructions.txt", "mathematics_lean"
+        )
+        math = generator._load_template_with_domain_override(
+            "agents/session_instructions.txt", "mathematics"
+        )
+        assert lean != math, (
+            "mathematics_lean session_instructions must differ from mathematics"
+        )
+
+
+# ── 2. Template rendering (variable substitution) ─────────────────────────────
+
+class TestTemplateRendering:
+    def test_no_jinja_placeholders_remain(self, rendered):
+        """No {{ variable }} tokens should survive rendering."""
+        assert "{{" not in rendered, "Unrendered Jinja2 opening tag found"
+        assert "}}" not in rendered, "Unrendered Jinja2 closing tag found"
+
+    def test_work_dir_injected(self, rendered):
+        assert SAMPLE_WORK_DIR in rendered, (
+            "work_dir value should appear in rendered output"
+        )
+
+    def test_research_prompt_injected(self, rendered):
+        assert SAMPLE_PROMPT in rendered, (
+            "The research prompt should be embedded in session instructions"
+        )
+
+    def test_renders_as_string(self, rendered):
+        assert isinstance(rendered, str) and len(rendered) > 500, (
+            "Rendered output should be a non-trivial string"
+        )
+
+    def test_scribe_mode_differs_from_script_mode(self, rendered, rendered_scribe):
+        """use_scribe=True should change the code_workflow injection."""
+        assert rendered != rendered_scribe, (
+            "Scribe and non-scribe renders should differ"
+        )
+
+    def test_scribe_mode_mentions_notebooks(self, rendered_scribe):
+        assert "notebook" in rendered_scribe.lower(), (
+            "Scribe mode should reference Jupyter notebooks"
+        )
+
+    def test_script_mode_mentions_scripts(self, rendered):
+        assert "script" in rendered.lower() or "src/" in rendered, (
+            "Non-scribe mode should reference Python scripts or src/"
+        )
+
+
+# ── 3. Lean content presence ──────────────────────────────────────────────────
+
+class TestLeanContentPresence:
+    @pytest.mark.parametrize("phrase", [
+        "lake build",
+        "lean_proofs",
+        "sorry",
+        "elan",
+        "lake-manifest",   # referenced in Phase 4 verification step
+        "Mathlib",
+        "LeanProofs",
+    ])
+    def test_lean_phrase_present(self, rendered, phrase):
+        assert phrase in rendered, (
+            f"Expected Lean phrase '{phrase}' not found in rendered output"
+        )
+
+    def test_phase_lean_setup_present(self, rendered):
+        """Phase 2 should contain Lean/elan setup instructions."""
+        assert "Phase 2" in rendered, "Phase 2 heading missing"
+        # elan or lean setup should appear somewhere in the text
+        assert "elan" in rendered or "lean-prover" in rendered, (
+            "Phase 2 should reference Lean/elan setup"
+        )
+
+    def test_phase_proof_construction_present(self, rendered):
+        assert "Phase 3" in rendered, "Phase 3 heading missing"
+
+    def test_phase_verification_present(self, rendered):
+        assert "Phase 4" in rendered, "Phase 4 heading missing"
+
+    def test_skill_script_referenced(self, rendered):
+        """The setup_lean_project.sh skill script should be mentioned."""
+        assert "setup_lean_project.sh" in rendered or "lean-prover" in rendered, (
+            "Lean setup script or skill should be referenced"
+        )
+
+    def test_grep_sorry_check_present(self, rendered):
+        """The grep-for-sorry completion check must be in the output."""
+        assert "grep" in rendered and "sorry" in rendered, (
+            "Completion check via 'grep sorry' should be present"
+        )
+
+    def test_lake_build_exit_code_mentioned(self, rendered):
+        """Exit code semantics (how to interpret lake build result) should appear."""
+        lower = rendered.lower()
+        assert "exit" in lower or "exit code" in lower or "exit 0" in lower, (
+            "lake build exit code interpretation should be mentioned"
+        )
+
+
+# ── 4. Lean-as-verifier framing ────────────────────────────────────────────────
+
+class TestLeanAsVerifier:
+    def test_lake_build_is_ground_truth(self, rendered):
+        """'lake build' should appear multiple times — it's the core feedback loop."""
+        count = rendered.count("lake build")
+        assert count >= 2, (
+            f"'lake build' appears only {count} time(s); expected ≥2 as the repeated verification step"
+        )
+
+    def test_sorry_is_incomplete_signal(self, rendered):
+        """sorry should be framed as an incompleteness marker, not a valid proof."""
+        # The instructions should warn that sorry means incomplete
+        assert "sorry" in rendered
+        # Some negative framing around sorry
+        lower = rendered.lower()
+        assert any(phrase in lower for phrase in [
+            "no sorry",
+            "not a proof",
+            "incomplete",
+            "remains",
+            "sorry warning",
+        ]), "sorry should be framed as an incompleteness signal"
+
+    def test_proof_complete_condition_is_lake_build(self, rendered):
+        """The proof completion signal should be lake build exit 0 + no sorry."""
+        assert "exit 0" in rendered or "exits 0" in rendered or "exit code" in rendered.lower(), (
+            "Proof completion should be tied to lake build exit code"
+        )
+
+
+# ── 5. Python-exploration framing ─────────────────────────────────────────────
+
+class TestPythonExplorationFraming:
+    def test_python_present_but_scoped(self, rendered):
+        """Python/SymPy should appear but be labelled as exploration, not verification."""
+        assert "Python" in rendered or "SymPy" in rendered or "sympy" in rendered, (
+            "Python tools should still be mentioned for conjecture exploration"
+        )
+
+    def test_python_not_sole_verifier(self, rendered):
+        """Python should not be described as the proof verification tool."""
+        lower = rendered.lower()
+        # The word 'verify' near 'python' should not be the primary framing
+        # Lean / lake build should be the verification path
+        assert "lake build" in rendered, (
+            "lake build must be present as the actual verification mechanism"
+        )
+
+    def test_exploration_label_near_python(self, rendered):
+        """Python usage should be labelled exploratory."""
+        lower = rendered.lower()
+        assert "explor" in lower, (
+            "Python role should be labelled as 'exploration' or 'exploratory'"
+        )
+
+
+# ── 6. mathematics_lean differs from mathematics baseline ─────────────────────
+
+class TestDifferenceFromMathematicsDomain:
+    def test_lean_specific_content_absent_from_math_domain(self, rendered_generic):
+        """The plain mathematics template should NOT mention lake build."""
+        assert "lake build" not in rendered_generic, (
+            "lake build should not appear in the plain mathematics domain output"
+        )
+
+    def test_lean_domain_output_longer_or_different(self, rendered, rendered_generic):
+        """mathematics_lean output should be meaningfully different from mathematics."""
+        assert rendered != rendered_generic, (
+            "mathematics_lean and mathematics should produce different session instructions"
+        )
+
+    def test_lean_domain_has_more_lean_references(self, rendered, rendered_generic):
+        lean_count = rendered.lower().count("lean")
+        math_count = rendered_generic.lower().count("lean")
+        assert lean_count > math_count, (
+            f"mathematics_lean output ({lean_count} 'lean' refs) should mention "
+            f"Lean more than mathematics output ({math_count} refs)"
+        )

--- a/tests/test_lean_skill.py
+++ b/tests/test_lean_skill.py
@@ -1,0 +1,488 @@
+"""
+Unit tests for the lean-prover skill.
+
+Covers three components:
+  1. SKILL.md structure & content
+       — frontmatter validity, required sections, tactic table,
+         verification workflow, error message table
+  2. setup_lean_project.sh content
+       — safety flags, elan conditional install, file structure
+         it creates, cache step ordering, argument handling
+  3. Cross-file consistency
+       — names and paths referenced in SKILL.md match what the
+         script actually produces; setup command in SKILL.md
+         points at a file that exists on disk
+  4. Workspace copy
+       — _copy_workspace_resources copies both files into
+         .claude/skills/lean-prover/ as the agent expects
+"""
+
+import os
+import re
+import shutil
+import stat
+import sys
+import tempfile
+import yaml
+import pytest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+SKILL_DIR    = REPO_ROOT / "templates" / "skills" / "lean-prover"
+SKILL_MD     = SKILL_DIR / "SKILL.md"
+SETUP_SCRIPT = SKILL_DIR / "scripts" / "setup_lean_project.sh"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def parse_frontmatter(path: Path) -> dict:
+    """Return the YAML frontmatter dict from a file with --- delimiters."""
+    text = path.read_text()
+    lines = text.splitlines()
+    if lines[0].strip() != "---":
+        return {}
+    end = next(i for i, l in enumerate(lines[1:], 1) if l.strip() == "---")
+    return yaml.safe_load("\n".join(lines[1:end]))
+
+
+def markdown_sections(path: Path) -> list[str]:
+    """Return list of section heading strings (stripped of # prefix)."""
+    return [
+        line.lstrip("#").strip()
+        for line in path.read_text().splitlines()
+        if line.startswith("#")
+    ]
+
+
+def script_text() -> str:
+    return SETUP_SCRIPT.read_text()
+
+
+# ── 1. SKILL.md — frontmatter ─────────────────────────────────────────────────
+
+class TestSkillFrontmatter:
+    def test_frontmatter_is_valid_yaml(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert isinstance(fm, dict), "Frontmatter must parse as a YAML mapping"
+
+    def test_name_field_present(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert "name" in fm, "Frontmatter must have a 'name' field"
+
+    def test_name_matches_directory(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert fm["name"] == "lean-prover", (
+            f"name '{fm['name']}' does not match directory name 'lean-prover'"
+        )
+
+    def test_description_field_present(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert "description" in fm and fm["description"], (
+            "Frontmatter must have a non-empty 'description' field"
+        )
+
+    def test_description_mentions_lean4(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert "Lean 4" in fm["description"] or "Lean4" in fm["description"], (
+            "description should explicitly mention 'Lean 4'"
+        )
+
+    def test_description_mentions_mathlib(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert "Mathlib" in fm["description"], (
+            "description should mention 'Mathlib'"
+        )
+
+    def test_description_mentions_mathematics_lean_domain(self):
+        fm = parse_frontmatter(SKILL_MD)
+        assert "mathematics_lean" in fm["description"], (
+            "description should reference the 'mathematics_lean' domain"
+        )
+
+
+# ── 2. SKILL.md — required sections ──────────────────────────────────────────
+
+REQUIRED_SECTIONS = [
+    "When to Use",
+    "Project Setup",
+    "Project Structure",
+    "Writing Proofs",
+    "Core Tactic Reference",
+    "Searching Mathlib",
+    "Verification Workflow",
+    "Interpreting Lean Error Messages",
+    "Proof Skeleton Template",
+    "Common Mathlib Imports by Area",
+]
+
+class TestSkillSections:
+    @pytest.mark.parametrize("section", REQUIRED_SECTIONS)
+    def test_required_section_exists(self, section):
+        sections = markdown_sections(SKILL_MD)
+        # Allow the heading to have a suffix (e.g. "Verification Workflow (Per Proof)")
+        assert any(s.startswith(section) for s in sections), (
+            f"Required section '{section}' not found in SKILL.md.\n"
+            f"Found sections: {sections}"
+        )
+
+    def test_when_to_use_mentions_mathematics_lean(self):
+        text = SKILL_MD.read_text()
+        # Find the When to Use section content
+        assert "mathematics_lean" in text, (
+            "'mathematics_lean' domain should appear in When to Use section"
+        )
+
+    def test_setup_script_path_in_skill_md(self):
+        """The path referenced in SKILL.md for the setup script must exist."""
+        text = SKILL_MD.read_text()
+        # The skill references: .claude/skills/lean-prover/scripts/setup_lean_project.sh
+        assert "setup_lean_project.sh" in text, (
+            "SKILL.md must reference the setup script"
+        )
+        # The actual file must also exist at the template level
+        assert SETUP_SCRIPT.exists(), (
+            f"setup_lean_project.sh not found at {SETUP_SCRIPT}"
+        )
+
+
+# ── 3. SKILL.md — tactic table ────────────────────────────────────────────────
+
+# Automation tactics the agent should try first (they appear most often)
+AUTOMATION_TACTICS = ["ring", "omega", "linarith", "norm_num", "simp", "decide"]
+# Manual tactics for structural proofs
+STRUCTURAL_TACTICS = ["exact", "apply", "rw", "intro", "cases", "induction", "by_contra", "use"]
+# Tactics that only work interactively — must be flagged as such
+INTERACTIVE_ONLY_TACTICS = ["exact?", "apply?", "simp?"]
+
+class TestTacticTable:
+    @pytest.mark.parametrize("tactic", AUTOMATION_TACTICS)
+    def test_automation_tactic_present(self, tactic):
+        assert f"`{tactic}`" in SKILL_MD.read_text(), (
+            f"Automation tactic '{tactic}' missing from tactic table"
+        )
+
+    @pytest.mark.parametrize("tactic", STRUCTURAL_TACTICS)
+    def test_structural_tactic_present(self, tactic):
+        text = SKILL_MD.read_text()
+        assert f"`{tactic}`" in text or f"`{tactic} " in text, (
+            f"Structural tactic '{tactic}' missing from tactic table"
+        )
+
+    @pytest.mark.parametrize("tactic", INTERACTIVE_ONLY_TACTICS)
+    def test_interactive_tactic_flagged(self, tactic):
+        text = SKILL_MD.read_text()
+        assert tactic in text, f"Interactive tactic '{tactic}' not mentioned"
+        # Must be accompanied by a warning that it's interactive-only
+        assert "Interactive only" in text or "interactive" in text.lower(), (
+            f"Interactive-only tactic '{tactic}' must be flagged as interactive-only"
+        )
+
+
+# ── 4. SKILL.md — verification workflow ──────────────────────────────────────
+
+class TestVerificationWorkflow:
+    def test_lake_build_command_shown(self):
+        assert "lake build" in SKILL_MD.read_text()
+
+    def test_grep_sorry_command_shown(self):
+        text = SKILL_MD.read_text()
+        assert "grep" in text and "sorry" in text, (
+            "Verification workflow must show the grep-sorry completion check"
+        )
+
+    def test_exit_code_semantics_documented(self):
+        text = SKILL_MD.read_text()
+        # Both outcomes must be documented
+        assert "exit code" in text.lower() or ("0" in text and "non-zero" in text), (
+            "lake build exit code semantics (0 vs non-zero) must be documented"
+        )
+
+    def test_sorry_declaration_warning_documented(self):
+        """'declaration uses sorry' is the Lean warning agents will see most often."""
+        assert "declaration uses sorry" in SKILL_MD.read_text(), (
+            "'declaration uses sorry' must appear in the error message table"
+        )
+
+    def test_stub_then_prove_workflow_documented(self):
+        """The sorry-stub → build → replace workflow must be present."""
+        text = SKILL_MD.read_text()
+        assert "sorry" in text
+        # The workflow shows using sorry first to check the type, then replacing
+        assert "stub" in text.lower() or "placeholder" in text.lower() or (
+            "sorry" in text and "replace" in text.lower()
+        ), "Sorry-stub workflow (use sorry first, then replace) must be documented"
+
+
+# ── 5. SKILL.md — error message table ────────────────────────────────────────
+
+REQUIRED_ERRORS = [
+    "unknown identifier",
+    "type mismatch",
+    "unsolved goals",
+    "declaration uses sorry",
+    "failed to synthesize instance",
+]
+
+class TestErrorMessageTable:
+    @pytest.mark.parametrize("error", REQUIRED_ERRORS)
+    def test_error_message_documented(self, error):
+        assert error in SKILL_MD.read_text(), (
+            f"Error message '{error}' not documented in SKILL.md"
+        )
+
+
+# ── 6. setup_lean_project.sh — safety & structure ────────────────────────────
+
+class TestSetupScriptSafety:
+    def test_shebang_is_env_bash(self):
+        first_line = SETUP_SCRIPT.read_text().splitlines()[0]
+        assert first_line == "#!/usr/bin/env bash", (
+            f"Script must start with '#!/usr/bin/env bash', got: '{first_line}'"
+        )
+
+    def test_errexit_set(self):
+        assert "set -euo pipefail" in script_text(), (
+            "Script must have 'set -euo pipefail' for safety"
+        )
+
+    def test_elan_install_is_conditional(self):
+        text = script_text()
+        # elan installation must be inside an if block, not unconditional
+        assert "command -v elan" in text or "command -v lean" in text, (
+            "Script must check if elan/lean is already installed before installing"
+        )
+
+    def test_cache_step_before_build(self):
+        text = script_text()
+        cache_pos = text.find("cache get")
+        build_pos = text.find("lake build")
+        assert cache_pos != -1, "Script must call 'lake exe cache get'"
+        assert build_pos != -1, "Script must call 'lake build'"
+        assert cache_pos < build_pos, (
+            "Cache download must happen before the initial lake build"
+        )
+
+    def test_build_failure_exits_nonzero(self):
+        text = script_text()
+        assert "exit 1" in text, (
+            "Script must exit 1 if lake build fails (not silently succeed)"
+        )
+
+    def test_accepts_custom_project_dir_argument(self):
+        text = script_text()
+        # PROJECT_DIR="${1:-lean_proofs}" pattern
+        assert '${1:-' in text or '"$1"' in text, (
+            "Script must accept a custom project directory as $1"
+        )
+
+    def test_default_project_dir_is_lean_proofs(self):
+        text = script_text()
+        assert '"${1:-lean_proofs}"' in text or "lean_proofs}" in text, (
+            "Default project directory must be 'lean_proofs'"
+        )
+
+
+# ── 7. setup_lean_project.sh — file structure created ────────────────────────
+
+class TestSetupScriptFileStructure:
+    def test_creates_definitions_lean(self):
+        assert "Definitions.lean" in script_text()
+
+    def test_creates_lemmas_lean(self):
+        assert "Lemmas.lean" in script_text()
+
+    def test_creates_main_theorem_lean(self):
+        assert "MainTheorem.lean" in script_text()
+
+    def test_lib_name_is_LeanProofs(self):
+        assert 'LIB_NAME="LeanProofs"' in script_text(), (
+            "Library name must be 'LeanProofs'"
+        )
+
+    def test_root_import_file_created(self):
+        text = script_text()
+        # The root import file uses the $LIB_NAME shell variable, so the
+        # script contains "${LIB_NAME}.Definitions" rather than the literal
+        # expanded form.  Check for the variable-expanded pattern.
+        assert "${LIB_NAME}.Definitions" in text or "LeanProofs.Definitions" in text
+        assert "${LIB_NAME}.Lemmas" in text      or "LeanProofs.Lemmas" in text
+        assert "${LIB_NAME}.MainTheorem" in text or "LeanProofs.MainTheorem" in text
+
+    def test_starter_files_are_idempotent(self):
+        """Files should only be written if they don't already exist."""
+        text = script_text()
+        # Each write should be guarded by [ ! -f ... ]
+        assert '[ ! -f' in text or "! -f" in text, (
+            "Starter file creation must be guarded against overwriting existing files"
+        )
+
+    def test_definitions_lean_imports_mathlib_tactic(self):
+        """Definitions.lean starter must use import Mathlib.Tactic (not full import Mathlib).
+        Mathlib.Tactic provides all tactics at ~1-2GB cache cost vs 5GB for import Mathlib."""
+        text = script_text()
+        assert "import Mathlib.Tactic" in text, (
+            "Starter file must use 'import Mathlib.Tactic', not bare 'import Mathlib'"
+        )
+
+    def test_definitions_lean_does_not_use_bare_import_mathlib(self):
+        """Bare 'import Mathlib' must not appear in the starter Definitions.lean heredoc —
+        it triggers a full 5GB cache download unnecessarily."""
+        text = script_text()
+        # Find the heredoc block for Definitions.lean
+        start = text.find("Definitions.lean")
+        heredoc_block = text[start:start + 400]  # just the heredoc content
+        assert "import Mathlib\n" not in heredoc_block, (
+            "Starter Definitions.lean must not use bare 'import Mathlib' — "
+            "use 'import Mathlib.Tactic' instead"
+        )
+
+    def test_lemmas_lean_imports_definitions(self):
+        """Lemmas.lean starter content must import Definitions (not raw Mathlib)."""
+        assert "import LeanProofs.Definitions" in script_text()
+
+    def test_main_theorem_lean_imports_lemmas(self):
+        """MainTheorem.lean must import Lemmas to complete the dependency chain."""
+        assert "import LeanProofs.Lemmas" in script_text()
+
+    def test_uses_mathlib_lake_template(self):
+        """Must use the official Mathlib lake template, not a bare init."""
+        text = script_text()
+        assert "mathlib4" in text and "math" in text, (
+            "Project must be created with the Mathlib lake template"
+        )
+
+
+# ── 8. Cross-file consistency ─────────────────────────────────────────────────
+
+class TestCrossFileConsistency:
+    def test_skill_md_project_dir_matches_script_default(self):
+        """SKILL.md shows 'lean_proofs/' — must match script's default."""
+        skill_text = SKILL_MD.read_text()
+        assert "lean_proofs" in skill_text, (
+            "SKILL.md must reference 'lean_proofs' as the project directory"
+        )
+        assert "lean_proofs}" in script_text() or '"lean_proofs"' in script_text(), (
+            "Script default must be 'lean_proofs'"
+        )
+
+    def test_skill_md_lib_name_matches_script(self):
+        """SKILL.md shows 'LeanProofs/' — must match script's LIB_NAME."""
+        assert "LeanProofs" in SKILL_MD.read_text(), (
+            "SKILL.md must reference 'LeanProofs' as the library name"
+        )
+        assert "LeanProofs" in script_text(), (
+            "Script must use 'LeanProofs' as the library name"
+        )
+
+    def test_skill_md_file_layout_matches_script_output(self):
+        """All three files in SKILL.md's Project Structure exist in the script."""
+        skill_text = SKILL_MD.read_text()
+        for filename in ["Definitions.lean", "Lemmas.lean", "MainTheorem.lean"]:
+            assert filename in skill_text, (
+                f"{filename} missing from SKILL.md Project Structure"
+            )
+            assert filename in script_text(), (
+                f"{filename} not created by setup_lean_project.sh"
+            )
+
+    def test_setup_command_in_skill_md_matches_actual_path(self):
+        """The 'bash ...setup_lean_project.sh' command in SKILL.md must point
+        to a file that exists under templates/skills/."""
+        skill_text = SKILL_MD.read_text()
+        # Extract the referenced script path
+        match = re.search(r'bash\s+([\w./-]+setup_lean_project\.sh)', skill_text)
+        assert match, "SKILL.md must show a 'bash ...setup_lean_project.sh' command"
+
+        relative_path = match.group(1)
+        # The path is relative to the workspace root at runtime:
+        #   .claude/skills/lean-prover/scripts/setup_lean_project.sh
+        # At template level it lives at:
+        #   templates/skills/lean-prover/scripts/setup_lean_project.sh
+        assert "lean-prover" in relative_path, (
+            f"Path '{relative_path}' must reference the lean-prover skill"
+        )
+        assert "setup_lean_project.sh" in relative_path
+
+    def test_import_chain_is_consistent(self):
+        """Definitions ← Lemmas ← MainTheorem must be present in both files.
+
+        The script uses the shell variable form (${LIB_NAME}.X) while SKILL.md
+        shows the expanded literal form (LeanProofs.X).  Accept either.
+        """
+        script = script_text()
+        skill = SKILL_MD.read_text()
+        for suffix in ["Definitions", "Lemmas", "MainTheorem"]:
+            literal  = f"import LeanProofs.{suffix}"
+            variable = f"import ${{LIB_NAME}}.{suffix}"
+            assert literal in script  or variable in script, (
+                f"Script missing import for LeanProofs.{suffix}"
+            )
+            assert literal in skill, (
+                f"SKILL.md missing: import LeanProofs.{suffix}"
+            )
+
+
+# ── 9. Workspace copy ─────────────────────────────────────────────────────────
+
+class TestWorkspaceCopy:
+    """Verify _copy_workspace_resources plants the lean-prover skill correctly."""
+
+    def test_skill_dir_copied_to_claude_skills(self):
+        """After _copy_workspace_resources, .claude/skills/lean-prover/ exists."""
+        sys.path.insert(0, str(REPO_ROOT / "src"))
+        from core.runner import ResearchRunner
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp)
+            runner = ResearchRunner(project_root=REPO_ROOT, use_github=False)
+            runner._copy_workspace_resources(work_dir)
+
+            skill_dst = work_dir / ".claude" / "skills" / "lean-prover"
+            assert skill_dst.exists(), (
+                f"lean-prover skill not found at {skill_dst} after workspace copy"
+            )
+
+    def test_skill_md_present_after_copy(self):
+        from core.runner import ResearchRunner
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp)
+            runner = ResearchRunner(project_root=REPO_ROOT, use_github=False)
+            runner._copy_workspace_resources(work_dir)
+
+            skill_md_dst = work_dir / ".claude" / "skills" / "lean-prover" / "SKILL.md"
+            assert skill_md_dst.exists(), "SKILL.md must be present after workspace copy"
+
+    def test_setup_script_present_after_copy(self):
+        from core.runner import ResearchRunner
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp)
+            runner = ResearchRunner(project_root=REPO_ROOT, use_github=False)
+            runner._copy_workspace_resources(work_dir)
+
+            script_dst = (
+                work_dir / ".claude" / "skills" / "lean-prover"
+                / "scripts" / "setup_lean_project.sh"
+            )
+            assert script_dst.exists(), (
+                "setup_lean_project.sh must be present after workspace copy"
+            )
+
+    def test_skill_also_copied_to_gemini_and_codex(self):
+        """The skill must land in .gemini/skills/ and .codex/skills/ too."""
+        from core.runner import ResearchRunner
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp)
+            runner = ResearchRunner(project_root=REPO_ROOT, use_github=False)
+            runner._copy_workspace_resources(work_dir)
+
+            for provider_dir in [".gemini", ".codex"]:
+                skill_dst = work_dir / provider_dir / "skills" / "lean-prover"
+                assert skill_dst.exists(), (
+                    f"lean-prover skill missing from {provider_dir}/skills/ — "
+                    "provider-agnostic copy must include lean-prover"
+                )


### PR DESCRIPTION
**(exploratory — not for merge.)** This PR is opened for experiment and discussion. The feature is a prototype of an "agent logic tree" — a per-agent DAG of decisions and observations made during a run — and I want to share the surface area / get feedback before any of it lands. Only `resource_finder` is wired in; every other agent is untouched. Please do **not** merge.

The conceptual goal is to capture the agent's reasoning trail as it unfolds (choices made, evidence noticed, premises connecting them) so the orchestrator and downstream agents can replay the logic. "Decision tree" was the working name; **"agent logic tree" may be clearer** since the structure now holds both decisions and observations. Renaming is on the table.

## What this adds

1. **The skill: `templates/skills/decision-log/`**. Self-contained library + SKILL.md manual. An agent that adopts it instantiates `DecisionLog(path=".neurico/decisions.json")` once and writes to it across turns. The file is auto-created and atomically persisted on every mutation (tmp + `os.replace`).

2. **Two node types in one DAG**:
   - **Decisions** — `log.add(question=, choice=, category=, premises=[...], alternatives=[...], rationale=)` for choices the agent commits to.
   - **Observations** — `log.observe(observation=, category=, about=[...], source=)` for findings worth noting (paper findings, data properties, environment facts, experiment results).
   - Both share the same DAG; a decision can premise on an observation, an observation can pertain to a decision, and revoke cascade works identically for both.

3. **Disjoint category sets per node type**:
   - Decisions: `model` / `dataset` / `hyperparam` / `eval` / `compute` / `method` / `search` / `reading` / `risk` / `other`
   - Observations: `paper_finding` / `data_property` / `env_fact` / `experiment_result` / `code_artifact` / `other`
   - `log.add()` rejects observation categories; `log.observe()` rejects decision categories.

4. **Three states + cascade**: `active` / `suspect` / `revoked`. `revoke(A)` marks A as revoked and every descendant as `suspect` — the agent triages each suspect via `reconfirm()` (with possibly-rewired premises) or another `revoke()`. No node is ever deleted; the log is append-only history.

5. **Wired into resource_finder only**. A cross-cutting `DECISION LOGGING` section in `templates/agents/resource_finder.txt` introduces the skill before the phase methodology, and three per-phase reminders nudge the agent to log search/reading/dataset/method/repo choices when they're committed to. Other agents (autoresearch_proposer, paper_writer, rule_maker, comment_handler) are untouched — they'd each need their own prompt-wiring.

## Schema highlights (see `templates/skills/decision-log/SKILL.md`)

- `node_type` — `decision` | `observation`
- `category` — from the type-specific set above
- `question` (decision) or auto-set `"observation about {category}"` (observation)
- `choice` — the choice text (decision) or the observation text (observation)
- `premises` — upstream node IDs; cycle-checked on add/update
- `alternatives` — sibling options considered; rarely populated on observations
- `rationale` (decision) or `source` (observation: citation / file path / experiment ID)
- `status` — `active` | `suspect` | `revoked`
- `revoked_root` — ID of the revoke that affected this node (self if directly revoked; ancestor if cascade)

## Files

| File | Purpose |
|---|---|
| `templates/skills/decision-log/SKILL.md` | Agent-facing manual: contract, four operations, triage flow, best practices, failure modes |
| `templates/skills/decision-log/scripts/decision_log.py` | Library: `DecisionLog`, `DecisionNode`, `CycleError`, atomic persistence, type-disjoint category validation |
| `tests/test_decision_log.py` | 124-test pytest suite: CRUD, cascade, triage-order, mixed-type DAGs, persistence round-trips, atomic-write recovery |
| `templates/agents/resource_finder.txt` | Cross-cutting `DECISION LOGGING` section + per-phase reminders + completion-checklist line |

## What's been live-tested

Six end-to-end resource_finder runs across different topics, with claude as the CLI agent. Each runs in an isolated workspace under `/tmp/rf-solo-workspace-*/`; the skill scripts get provisioned at `.claude/skills/decision-log/scripts/` the same way the production runner copies them.

| Run | Topic | Duration | Nodes | Obs ratio | Notes |
|---|---|---|---|---|---|
| 1 | TweetEval few-shot prompting | 13 min | 8 | 0% | Pre-observations API |
| 2 | IR retrievers latency Pareto | 25 min | 7 | 0% | New `search` / `reading` categories picked up immediately |
| 3 | Calibration replication | 21 min | 12 | 0% | Claude-CLI socket disconnect mid-write; log persisted intact, recovery property verified |
| 5 | Calibration replication (retry) | 33 min | 15 | 47% | First run with observations; obs → risk → eval reasoning chain |
| 6 | AG News demo ordering | ~30 min | 16 | 44% | Data-inspection observation surfaced (HF label-indexing mismatch); 6 paper findings logged with table refs |

**What worked**:
- In-flight logging confirmed by timestamps (writes spread across the full run, not batched at end)
- Premise quality improved 50% → 75% across runs as categories matured
- Zero internal errors across 64 nodes (no cycles, no validation failures, no torn writes)
- Atomic persistence survived a real network disconnect (Run 3)
- Observations naturally chained: paper finding → risk → eval decision

**What's still unexercised**:
- The `revoke` / `suspect` / `reconfirm` cycle. Fully unit-tested but no live agent backtracked on these topics. A topic that forces a pivot would exercise it.

## How to reproduce a run

The standalone harness below provisions a workspace and calls `run_resource_finder` directly — no docker, no GitHub idea-submission, no orchestrator.

\`\`\`bash
cd \$(git rev-parse --show-toplevel)
pip install pyyaml jinja2   # if not already present
\`\`\`

Save as `rf_decision_log_demo.py` somewhere outside the repo:

\`\`\`python
"""Standalone resource_finder run for the decision-log demo."""
import shutil, sys
from pathlib import Path

NEURICO_ROOT = Path("/path/to/your/neurico/checkout")  # adjust
sys.path.insert(0, str(NEURICO_ROOT / "src"))

WORK_DIR = Path("/tmp/rf-decision-log-demo")
if WORK_DIR.exists():
    shutil.rmtree(WORK_DIR)
WORK_DIR.mkdir(parents=True)
(WORK_DIR / ".neurico").mkdir()

skills_src = NEURICO_ROOT / "templates" / "skills"
for provider_dir in (".claude", ".codex", ".gemini"):
    dst = WORK_DIR / provider_dir / "skills"
    dst.mkdir(parents=True)
    for skill_dir in skills_src.iterdir():
        if skill_dir.is_dir():
            shutil.copytree(skill_dir, dst / skill_dir.name)

IDEA = {"idea": {
    "title": "Few-shot prompt design for binary sentiment classification on tweets",
    "domain": "natural_language_processing",
    "hypothesis": ("Using 4-shot in-context examples drawn from the same domain "
                   "improves binary tweet-sentiment accuracy over zero-shot by "
                   "at least 5 percentage points across 1B-8B model sizes."),
    "background": {
        "papers": [{"title": "What Makes Good In-Context Examples for GPT-3?",
                    "url": "https://arxiv.org/abs/2101.06804"}],
        "datasets": [{"name": "TweetEval sentiment", "source": "HuggingFace"}],
    },
    "constraints": {"compute": "CPU or small GPU", "time_budget": "2 hours"},
}}

from agents.resource_finder import run_resource_finder
run_resource_finder(idea=IDEA, work_dir=WORK_DIR, provider="claude",
                    templates_dir=NEURICO_ROOT / "templates",
                    timeout=2700, full_permissions=True)
print(f"Log at: {WORK_DIR}/.neurico/decisions.json")
\`\`\`

Run it:

\`\`\`bash
python rf_decision_log_demo.py
\`\`\`

The run takes 15-30 minutes depending on topic. While it runs, watch the log populate in another terminal:

\`\`\`bash
watch -n 10 'cat /tmp/rf-decision-log-demo/.neurico/decisions.json | python3 -m json.tool | tail -40'
\`\`\`

After it finishes, summary + full render:

\`\`\`bash
python3 <<'PY'
import sys, json
sys.path.insert(0, "templates/skills/decision-log/scripts")
from decision_log import DecisionLog
log = DecisionLog(path="/tmp/rf-decision-log-demo/.neurico/decisions.json")
print(f"{len(log.find(active_only=False))} nodes total")
print(f"  decisions:    {len(log.decisions())}")
print(f"  observations: {len(log.observations())}")
print(f"  suspect:      {len(log.suspects())}")
print()
print(log.export("md"))
PY
\`\`\`

The dot export pipes to graphviz for a visual:

\`\`\`bash
python3 -c "
import sys; sys.path.insert(0, 'templates/skills/decision-log/scripts')
from decision_log import DecisionLog
print(DecisionLog(path='/tmp/rf-decision-log-demo/.neurico/decisions.json').export('dot'))
" | dot -Tpng > /tmp/decisions.png && open /tmp/decisions.png
\`\`\`

## Open questions / known incomplete bits

- **Name**: "decision-log" describes the prototype; "agent logic tree" might be the better long-term name now that observations are first-class.
- **Revoke path unexercised live**. Unit-tested only.
- **No orchestrator-side consumer yet**. The log is written but nothing reads it across agent boundaries. Surfacing pending observations to the next agent (or to the user mid-run) is the natural follow-up.
- **Per-agent only**. No cross-agent concurrency primitives; per-agent path is the contract.
- **Other agents untouched**. autoresearch_proposer / paper_writer / rule_maker / comment_handler would each need their own prompt-wiring + per-phase reminders.