### PR TITLE
Add Battery Lab (BL) mode: docs, recipe delivery tool, example idea

### DIFF
--- a/BL_MODE_README.md
+++ b/BL_MODE_README.md
@@ -1,0 +1,169 @@
+# NeuriCo — Battery Lab (BL) Mode
+
+BL mode is a battery-lab specialization of NeuriCo. It turns the autonomous
+research framework into a closed loop with a **physical** coin-cell lab: NeuriCo
+designs electrolyte recipes, a human builds and measures them on the
+[BatteryLab](https://github.com/…/BatteryLab) robot, the results come back, and
+NeuriCo decides what to try next. Unlike a normal one-shot NeuriCo run, a BL
+campaign is **long and repeated** — many design → build → measure → interpret
+cycles over a single research idea.
+
+---
+
+## Why BL mode is different
+
+The standard NeuriCo interactive pipeline is *resource finder → experiment runner
+→ paper writer*, all inside Docker. BL mode keeps resource finding and
+computational reasoning, but the **decisive experiment is run by a human on real
+hardware**, not by an in-container agent:
+
+```
+   idea (YAML)
+      │
+      ▼
+   resource finder  ── literature on water activity, Zn electrolytes, co-solvents
+      │
+      ▼
+   experiment runner ── computational design / screening (no wet experiment)
+      │
+      ▼
+   DELIVER RECIPES  ── BatteryLab JSON written to BL-recipes/   ◄── the handoff
+      │
+      ▼
+   (human builds & measures cells on BatteryLab; drops raw data in BL-results/)
+      │
+      ▼
+   INGEST RESULTS   ── read BL-results/, update the world model
+      │
+      └──────────────► design the next batch (repeat, indefinitely)
+```
+
+The physical experiment runner is a **person**. BL mode never asks an in-Docker
+agent to "run" a cell build or an electrochemical measurement — it emits a recipe
+and waits.
+
+---
+
+## The recipe format (BatteryLab solvency JSON)
+
+A recipe file is a JSON **array**; each element is one coin cell. This is the
+exact format BatteryLab's `app.py` **[B]atch** loader accepts:
+
+```json
+[
+  {
+    "recipe_name": "wa_ladder_cell_01",
+    "target_electrolyte": {
+      "name": "wa_ladder_target_01",
+      "volume": 0.05,
+      "v": {"water": 0.8, "propylene glycol": 0.2},
+      "s": {"ZnOTf2": 1.0},
+      "a": {"MnSO4": 0.1}
+    }
+  }
+]
+```
+
+| Field | Meaning | Units / rules |
+|---|---|---|
+| `recipe_name` | Unique, human-readable cell id | string |
+| `target_electrolyte.name` | Name of the formulation | string |
+| `volume` | Total electrolyte volume | **millilitres** (`0.05` = 50 µL), > 0 |
+| `v` | **Solvent** volume fractions | required, non-negative, **must sum to 1.0** |
+| `s` | **Salt** molarities | optional, mol/L |
+| `a` | **Additive** molarities | optional, mol/L |
+
+Mnemonic: **v** = sol**v**ent blend, **s** = **s**alt, **a** = **a**dditive.
+`v` and `s` are independent axes — `v` sets the solvent *proportions*, `s` sets
+the salt *concentration*, and `volume` scales both. There is no manual "v-to-s
+ratio": molarity already fixes the salt amount per unit volume, and the solvent
+fills the rest. The BatteryLab electrolyte planner converts these targets into
+actual pipetting volumes from its stock solutions.
+
+---
+
+## The research target this mode was built for
+
+The driving question is the relationship between **water activity (a_w)** and
+performance — **ionic conductivity** and **Coulombic efficiency (CE)** — in Zn
+batteries, which is still unsettled in the field. We want to identify *when water
+activity is a transferable descriptor and when it fails*, and thereby reveal
+molecular design rules for suppressing parasitic water reactions without
+sacrificing Zn²⁺ transport.
+
+The core trade-off BL campaigns explore (from literature anchors):
+
+| Regime | a_w | Stability window | Conductivity | CE |
+|---|---|---|---|---|
+| Water-rich (dilute ZnSO₄) | ~0.9 | narrow | high | lower |
+| Hydrated eutectics (HDES) | ~0.35–0.65 | medium | medium | high |
+| Deep eutectic / water-in-salt | ~0.02–0.15 | wide | low | highest |
+
+Lowering a_w widens the stability window and raises CE but reduces conductivity —
+so the science lives in finding where the descriptor predicts the sweet spot, and
+where it breaks.
+
+---
+
+## Using BL mode today (normal mode — recipe generation)
+
+The minimum viable loop uses **normal (non-interactive) mode** to generate a batch
+of recipes and stop. No wet-lab automation is required — you relay the recipe to
+the lab yourself.
+
+1. Write an idea (`domain: battery`) whose **deliverable is a recipe file** in the
+   format above (see `ideas/examples/bl_water_activity_ladder.yaml` for a worked example).
+   The idea's `expected_outputs` and `evaluation_criteria` are what steer the agent
+   to emit recipes rather than a computational report.
+2. Submit and run, stopping after the experiment runner:
+
+   ```bash
+   ./neurico submit ideas/<your_idea>.yaml
+   ./neurico run <idea_id> --no-write-paper --no-github --provider claude
+   ```
+
+   - `--no-write-paper` → pipeline stops after the experiment runner.
+   - `--no-github` → stays local.
+   - `--provider claude` → uses the Claude CLI credentials (no API key needed).
+3. The recipe JSON lands in the run's workspace. Copy it out and send it to the
+   lab; results come back into `BL-results/`.
+
+### Grounding recipes in data
+
+Recipe design is far stronger when the idea points the agent at real inputs — a
+trained water-activity dataset, a ranked candidate list, and literature a_w↔
+performance anchors — so the agent *translates* model-ranked candidates into
+BatteryLab recipes (handling mole-fraction → volume-fraction conversion, salt
+identity, and ionic-strength → molarity) rather than inventing compositions from
+scratch.
+
+---
+
+## Closed-loop mode (in progress)
+
+For the full autonomous campaign, BL mode extends **interactive mode** (the manager
++ world-model variant) with a `deliver_recipe` manager tool: it validates a recipe
+batch, writes it to `BL-recipes/round-N/`, shows it to the human, and **pauses** —
+the wet-lab analogue of launching an agent. When results return, an ingest step
+folds them back into the world model and the manager designs the next round. This
+is what makes a BL run "very long and repeated."
+
+Status:
+- [x] Recipe schema + validation (mL units, `v` sums to 1, numeric `s`/`a`).
+- [x] `deliver_recipe` tool (write + pause), battery manager prompt, domain routing.
+- [x] Normal-mode recipe generation via idea `expected_outputs`.
+- [ ] `ingest_results` — read arbitrary files from `BL-results/` (EIS/Nyquist
+      screenshots, CSVs, `.mpr`, photos) and update the world model.
+- [ ] Auto-sync delivered recipes to a shared `BL-recipes/` folder.
+- [ ] Direct link to the BatteryLab robot (today the human relays recipes/results).
+
+---
+
+## Folder conventions
+
+| Path | Contents |
+|---|---|
+| `BL-recipes/` | Recipe batches NeuriCo produces (`idx-N.json` / `round-N/`) |
+| `BL-results/` | Raw wet-lab results the lab returns, one folder per experiment (e.g. `idx-0/`); any file type |
+| `ideas/*.yaml` | Battery-domain ideas whose deliverable is a recipe batch |
+| `templates/domains/battery/` | Battery domain guidance for the agents |

--- a/ideas/examples/bl_water_activity_ladder.yaml
+++ b/ideas/examples/bl_water_activity_ladder.yaml
@@ -1,0 +1,151 @@
+# Battery Lab idea — recipe-generation run (normal mode, RF + ER, stop before paper)
+#
+# Run with:
+#   ./neurico submit ideas/bl_water_activity_ladder.yaml
+#   ./neurico run <printed_idea_id> --no-write-paper --no-github --provider claude
+#
+# The deliverable is a BATCH OF ELECTROLYTE RECIPES in BatteryLab solvency JSON,
+# NOT a computational report. The wet-lab measurements are done later by humans.
+
+idea:
+  title: "Water-activity ladder in aqueous Zn electrolytes: co-solvent fraction vs ionic conductivity"
+
+  domain: battery
+
+  hypothesis: |
+    In an aqueous Zn-ion electrolyte at fixed salt content, progressively
+    replacing water with a water-miscible co-solvent (e.g. propylene glycol)
+    lowers the water activity of the electrolyte. As water activity decreases,
+    ionic conductivity is expected to decrease smoothly and monotonically, while
+    parasitic water reactions at the Zn anode are suppressed. We hypothesize that
+    water activity, estimated from composition, predicts the ionic-conductivity
+    ranking across the series — i.e. it behaves as a transferable descriptor over
+    this range.
+
+  background:
+    description: |
+      GOAL OF THIS RUN — READ CAREFULLY.
+
+      This is a Battery Lab (BL) run. Your job is NOT to run a computational
+      experiment and write a report. Your job is to DESIGN A BATCH OF ELECTROLYTE
+      RECIPES that a human will physically build and measure on the BatteryLab
+      coin-cell robot. The single, primary deliverable of this run is a recipe
+      file in BatteryLab's solvency JSON format (schema below). Do NOT attempt any
+      physical, electrochemical, or wet-lab experiment — you cannot run one, and
+      the robot/humans will do the measurements later.
+
+      Scientific context. The broader open question in the aqueous Zn battery
+      field is the relationship between WATER ACTIVITY and performance (ionic
+      conductivity and Coulombic efficiency): when does water activity serve as a
+      transferable descriptor, and when does it fail? Lowering water activity
+      (e.g. by adding a water-miscible co-solvent, or raising salt concentration)
+      tends to suppress parasitic water reactions at the Zn anode (hydrogen
+      evolution, corrosion) and widen the stability window, improving Zn
+      reversibility — but it also raises viscosity and tends to REDUCE ionic
+      conductivity and Zn-ion transport. The interesting science lives in this
+      trade-off.
+
+      This first, deliberately SIMPLE study turns one knob: the water-to-
+      co-solvent volume ratio, at a fixed Zn salt concentration. It produces the
+      first rung of a "water activity vs performance" map and exercises the whole
+      design -> build -> measure loop end to end. Ionic conductivity (measured by
+      EIS) is the target performance metric here; it is directly measurable on the
+      existing BatteryLab setup.
+
+      Assume all reactants are available — you may choose whatever Zn salt,
+      co-solvent(s), and additives you judge sensible; assume the lab can stock
+      them. Use any literature you gather to ground the choices (which co-solvent,
+      what salt concentration is reasonable, roughly how water activity is expected
+      to move with composition), but keep the chemistry defensible and simple.
+
+      ──────────────────────────────────────────────────────────────────────────
+      RECIPE OUTPUT FORMAT — BatteryLab solvency JSON (MANDATORY, EXACT SHAPE)
+
+      Write a single JSON file: BL-recipes/idx-0.json (relative to the workspace
+      root). It must be a JSON ARRAY of recipe objects. Each object:
+
+        {
+          "recipe_name": "wa_ladder_cell_01",        # unique, human-readable
+          "target_electrolyte": {
+            "name": "wa_ladder_target_01",            # name for the formulation
+            "volume": 0.05,                           # TOTAL volume in MILLILITRES (0.05 = 50 uL)
+            "v": {"water": 0.8, "propylene glycol": 0.2},  # solvent VOLUME FRACTIONS, MUST sum to 1.0
+            "s": {"ZnSO4": 1.0},                      # OPTIONAL: salt molarities (mol/L)
+            "a": {"additive_name": 0.1}               # OPTIONAL: additive molarities (mol/L)
+          }
+        }
+
+      Hard rules for every recipe:
+        - "volume" is in millilitres and > 0 (use 0.05 mL = 50 uL unless you have
+          a reason to vary it).
+        - "v" is REQUIRED, non-empty, with non-negative fractions that SUM TO 1.0.
+        - "s" and "a" are optional maps of substance name -> non-negative molarity.
+        - Hold the salt content FIXED across the ladder; vary only the water /
+          co-solvent split, so water activity is the single independent variable.
+        - Produce roughly 6-8 cells spanning a wide range of water activity (from
+          water-rich to co-solvent-rich), e.g. water volume fraction stepping from
+          ~0.9 down to ~0.2. Order them from highest to lowest water activity.
+      ──────────────────────────────────────────────────────────────────────────
+
+  methodology:
+    approach: |
+      Rational design of a single-variable composition ladder. Use brief
+      literature grounding, estimate how water activity changes with co-solvent
+      fraction, then emit a fixed-salt water/co-solvent series as BatteryLab
+      recipes. No physical experiments are run in this session.
+
+    steps:
+      - "Briefly review literature on water activity in aqueous Zn electrolytes and on water-miscible co-solvents that lower water activity while preserving Zn-ion transport."
+      - "Pick one Zn salt and a fixed salt concentration, and one primary water-miscible co-solvent. Justify the choices in one short paragraph."
+      - "Define a 6-8 point water/co-solvent volume-fraction ladder at the fixed salt content, spanning water-rich to co-solvent-rich, so water activity is the single independent variable."
+      - "For each composition, estimate (qualitatively or with a simple model) the relative water activity, so the cells can be ordered from highest to lowest water activity."
+      - "Write all recipes as a JSON array to BL-recipes/idx-0.json in the exact BatteryLab solvency format specified in the background. Validate that every recipe's 'v' fractions sum to 1.0 and volume is in mL."
+      - "Write a short recipes_rationale.md mapping each recipe_name to its intended water-activity level, the expected ionic-conductivity trend, and the design reasoning. Then stop — do not run experiments."
+
+    metrics:
+      - "Estimated relative water activity per composition (design-time)"
+      - "Ionic conductivity (to be measured later by EIS on BatteryLab — not in this session)"
+
+  constraints:
+    compute: cpu_only
+    time_limit: 1800
+    memory: "4GB"
+    dependencies:
+      - "numpy"
+
+  expected_outputs:
+    - type: dataset
+      format: json
+      description: |
+        BL-recipes/idx-0.json — the PRIMARY deliverable. A JSON array of 6-8
+        BatteryLab solvency-format electrolyte recipes forming a fixed-salt
+        water/co-solvent ladder that spans a wide range of water activity. Must
+        follow the exact schema in the background (recipe_name, target_electrolyte
+        with name, volume in mL, v fractions summing to 1.0, optional s/a
+        molarities). This file is what gets sent to the wet lab.
+
+    - type: report
+      format: markdown
+      description: |
+        recipes_rationale.md — a short note mapping each recipe to its intended
+        water-activity level, the expected ionic-conductivity trend, and the
+        design reasoning (salt and co-solvent choice). Keep it brief; the recipes
+        are the deliverable, not a full research report.
+
+  evaluation_criteria:
+    - "BL-recipes/idx-0.json exists and is a valid JSON array of recipe objects in the exact BatteryLab solvency format."
+    - "Every recipe has volume in mL (> 0) and solvent fractions 'v' that sum to 1.0."
+    - "Salt content is held fixed across the batch; only the water/co-solvent fraction varies, so water activity is the single independent variable."
+    - "The batch contains 6-8 cells spanning water-rich to co-solvent-rich, ordered by descending water activity."
+    - "No physical or electrochemical experiment was attempted; the run stops once recipes and the short rationale are written."
+
+  metadata:
+    author: "gujingxuan"
+    tags:
+      - "battery"
+      - "zinc"
+      - "water-activity"
+      - "electrolyte"
+      - "recipe-generation"
+    priority: high
+    estimated_duration: "15-30 minutes"

--- a/src/interactive/manager.py
+++ b/src/interactive/manager.py
@@ -119,16 +119,29 @@ def load_config() -> Dict[str, Any]:
     return {}
 
 
-def load_tool_definitions() -> List[Dict[str, Any]]:
-    """Load tool definitions from templates/manager/tools.yaml."""
+def load_tool_definitions(domain: str = "") -> List[Dict[str, Any]]:
+    """Load tool definitions from templates/manager/tools.yaml.
+
+    For the battery domain, merge in the extra BL-mode tools (e.g.
+    deliver_recipe) from tools_battery.yaml so normal interactive runs never see
+    them.
+    """
     tools_file = PROJECT_ROOT / "templates" / "manager" / "tools.yaml"
     if not tools_file.exists():
         raise FileNotFoundError(f"Tool definitions not found: {tools_file}")
 
     with open(tools_file) as f:
         data = yaml.safe_load(f)
+    tools = data.get("tools", [])
 
-    return data.get("tools", [])
+    if (domain or "").lower() == "battery":
+        battery_file = PROJECT_ROOT / "templates" / "manager" / "tools_battery.yaml"
+        if battery_file.exists():
+            with open(battery_file) as f:
+                battery_data = yaml.safe_load(f) or {}
+            tools = tools + battery_data.get("tools", [])
+
+    return tools
 
 
 def load_system_prompt(idea: Dict[str, Any], workspace: Path,
@@ -169,6 +182,14 @@ def load_system_prompt(idea: Dict[str, Any], workspace: Path,
     rendered = rendered.replace("{{ workspace_path }}", str(workspace))
     rendered = rendered.replace("{{ provider }}", provider)
     rendered = rendered.replace("{{ engagement_instructions }}", engagement_instructions)
+
+    # Battery-lab mode: append the BL workflow addendum so the manager knows the
+    # wet-lab step is a human running deliver_recipe, not an in-Docker agent.
+    if idea_content.get("domain", "").lower() == "battery":
+        addendum_file = (PROJECT_ROOT / "templates" / "manager"
+                         / "system_prompt_battery_addendum.txt")
+        if addendum_file.exists():
+            rendered = rendered + "\n" + addendum_file.read_text()
 
     return rendered
 
@@ -250,7 +271,7 @@ class InteractiveManager:
         self.tools = ToolExecutor(workspace, self.session, idea_file, provider,
                                   PROJECT_ROOT, channel=self.channel,
                                   research=self.research)
-        self.tool_definitions = load_tool_definitions()
+        self.tool_definitions = load_tool_definitions(idea_content.get("domain", ""))
         # Base system prompt; the live research-state digest is appended fresh
         # each turn (see _agent_step) so the manager always reasons over current
         # state without polluting the persisted conversation history.

--- a/src/interactive/tools.py
+++ b/src/interactive/tools.py
@@ -18,6 +18,116 @@ from datetime import datetime
 from interactive.session_state import SessionState
 
 
+# Solvent volume fractions are physical fractions of a mixture, so they must sum
+# to 1. Wet-lab pipetting and rounding make an exact 1.0 unrealistic, so we allow
+# a small tolerance rather than rejecting otherwise-fine recipes.
+_V_SUM_TOL = 0.02
+
+
+def _is_number(val: Any) -> bool:
+    """True for a real numeric value. Excludes bool, which is an int subclass in
+    Python and would otherwise sneak through as 0/1."""
+    return isinstance(val, (int, float)) and not isinstance(val, bool)
+
+
+def _validate_molarity_map(m: Any, label: str, name: str, field: str,
+                           errors: List[str]) -> Dict[str, float]:
+    """Validate an optional salt/additive molarity map (name -> molarity).
+    Returns the cleaned map; appends human-readable problems to `errors`."""
+    if m is None:
+        return {}
+    if not isinstance(m, dict):
+        errors.append(f"{label} ('{name}'): '{field}' must be an object mapping "
+                      "substance name -> molarity.")
+        return {}
+    clean: Dict[str, float] = {}
+    for k, val in m.items():
+        if not _is_number(val) or val < 0:
+            errors.append(f"{label} ('{name}'): '{field}' entry '{k}' must be a "
+                          "non-negative number.")
+        else:
+            clean[str(k)] = float(val)
+    return clean
+
+
+def validate_recipes(recipes: List[Any]) -> tuple:
+    """Validate a batch of BatteryLab solvency-style recipes.
+
+    Returns (cleaned_recipes, errors). When `errors` is non-empty the batch must
+    NOT be delivered — the caller should surface the errors so the recipe can be
+    fixed and re-submitted. The `volume` field is interpreted in MILLILITERS
+    (e.g. 0.05 == 50 µL), matching the BatteryLab robot's [B]atch loader.
+
+    A valid recipe looks like:
+        {"recipe_name": "round1_cell_01",
+         "target_electrolyte": {
+            "name": "round1_cell_01",
+            "volume": 0.05,                       # mL
+            "v": {"water": 0.5, "propylene glycol": 0.5},   # fractions, sum=1
+            "s": {"ZnSO4": 1.0},                  # optional salt molarities
+            "a": {"...": 0.1}}}                    # optional additive molarities
+    """
+    cleaned: List[Dict[str, Any]] = []
+    errors: List[str] = []
+    for i, rec in enumerate(recipes):
+        label = f"recipe[{i}]"
+        if not isinstance(rec, dict):
+            errors.append(f"{label}: must be a JSON object.")
+            continue
+
+        name = rec.get("recipe_name")
+        if not isinstance(name, str) or not name.strip():
+            errors.append(f"{label}: missing a non-empty 'recipe_name'.")
+            name = name.strip() if isinstance(name, str) else ""
+
+        te = rec.get("target_electrolyte")
+        if not isinstance(te, dict):
+            errors.append(f"{label} ('{name}'): missing the 'target_electrolyte' object.")
+            continue
+
+        te_name = te.get("name")
+        te_name = te_name.strip() if isinstance(te_name, str) and te_name.strip() else name
+
+        vol = te.get("volume")
+        if not _is_number(vol) or vol <= 0:
+            errors.append(f"{label} ('{name}'): 'volume' must be a positive number "
+                          "in millilitres (e.g. 0.05 for 50 µL).")
+
+        v = te.get("v")
+        clean_v: Dict[str, float] = {}
+        if not isinstance(v, dict) or not v:
+            errors.append(f"{label} ('{name}'): 'v' (solvent volume fractions) must "
+                          "be a non-empty object.")
+        else:
+            v_ok = True
+            for k, val in v.items():
+                if not _is_number(val) or val < 0:
+                    errors.append(f"{label} ('{name}'): solvent '{k}' fraction must "
+                                  "be a non-negative number.")
+                    v_ok = False
+                else:
+                    clean_v[str(k)] = float(val)
+            if v_ok:
+                total = sum(clean_v.values())
+                if abs(total - 1.0) > _V_SUM_TOL:
+                    errors.append(f"{label} ('{name}'): solvent fractions 'v' sum to "
+                                  f"{total:.3f}; they must sum to 1.0 (±{_V_SUM_TOL}).")
+
+        clean_s = _validate_molarity_map(te.get("s"), label, name, "s", errors)
+        clean_a = _validate_molarity_map(te.get("a"), label, name, "a", errors)
+
+        te_clean: Dict[str, Any] = {"name": te_name,
+                                    "volume": float(vol) if _is_number(vol) else vol,
+                                    "v": clean_v}
+        if clean_s:
+            te_clean["s"] = clean_s
+        if clean_a:
+            te_clean["a"] = clean_a
+        cleaned.append({"recipe_name": name, "target_electrolyte": te_clean})
+
+    return cleaned, errors
+
+
 class ToolExecutor:
     """
     Executes tools called by the manager LLM.
@@ -70,6 +180,7 @@ class ToolExecutor:
             "update_research_state": self._update_research_state,
             "assess": self._assess,
             "design_panel": self._design_panel,
+            "deliver_recipe": self._deliver_recipe,
         }
 
         handler = handlers.get(tool_name)
@@ -333,6 +444,84 @@ class ToolExecutor:
         if response is None:
             return "[User ended the session without responding.]"
         return response
+
+    def _deliver_recipe(self, args: Dict[str, Any]) -> str:
+        """Battery-lab mode: hand a validated electrolyte recipe batch to the
+        human for wet-lab execution, then pause.
+
+        This is the wet-lab analogue of run_agent: the experiment is run by a
+        *human* on the BatteryLab robot, not by an in-Docker agent. The recipe is
+        written in BatteryLab's solvency-style JSON (volume in mL) so it can be
+        fed straight to the robot's [B]atch loader. The batch is validated first;
+        an invalid batch is NOT delivered so the manager can fix and retry."""
+        recipes = args.get("recipes")
+        rationale = str(args.get("rationale", "")).strip()
+
+        # The CLI backend's tool-call shim can hand the array back as a
+        # JSON-encoded string — coerce it before validating.
+        if isinstance(recipes, str):
+            try:
+                recipes = json.loads(recipes)
+            except (json.JSONDecodeError, ValueError):
+                return ("Error: 'recipes' was a string that is not valid JSON. "
+                        "Pass a JSON array of recipe objects.")
+        if isinstance(recipes, dict):
+            recipes = [recipes]
+        if not isinstance(recipes, list) or not recipes:
+            return ("Error: 'recipes' must be a non-empty JSON array of recipe "
+                    "objects in BatteryLab solvency format.")
+
+        cleaned, errors = validate_recipes(recipes)
+        if errors:
+            # Do NOT write or pause — let the manager fix the recipe and retry.
+            return ("Recipe NOT delivered — validation failed. Fix these and call "
+                    "deliver_recipe again:\n- " + "\n- ".join(errors))
+
+        # Number the delivery from prior rounds so a long, repeated campaign keeps
+        # an ordered, append-only trail under the workspace.
+        recipe_root = self.work_dir / "BL-recipes"
+        recipe_root.mkdir(parents=True, exist_ok=True)
+        round_n = len([p for p in recipe_root.glob("round-*") if p.is_dir()]) + 1
+        round_dir = recipe_root / f"round-{round_n}"
+        round_dir.mkdir(parents=True, exist_ok=True)
+
+        recipe_file = round_dir / "recipes.json"
+        recipe_file.write_text(json.dumps(cleaned, indent=2) + "\n", encoding="utf-8")
+        if rationale:
+            (round_dir / "rationale.md").write_text(
+                f"# Recipe round {round_n} — rationale\n\n{rationale}\n",
+                encoding="utf-8")
+
+        names = ", ".join(r["recipe_name"] for r in cleaned)
+
+        # Record in the world model: a delivered recipe is a real (human-run)
+        # experiment and a decision worth grading later.
+        self.research.add_finding(
+            f"Delivered recipe round {round_n} ({len(cleaned)} cell(s)): {names}",
+            kind="note", insight=rationale)
+        self.research.set_fields(
+            current_best=f"Round {round_n} recipe delivered — awaiting wet-lab results")
+        self.session.update_findings(phase="wet_lab_pause")
+
+        pretty = json.dumps(cleaned, indent=2)
+        self.channel.send(
+            f"🧪 Recipe round {round_n} ready for the wet lab "
+            f"({len(cleaned)} cell(s)). Saved to {recipe_file}.\n\n"
+            f"```json\n{pretty}\n```",
+            kind="system")
+
+        prompt_msg = (
+            f"Recipe round {round_n} is ready ({len(cleaned)} cell(s): {names}). "
+            "Please run it on BatteryLab and drop the results into the "
+            "BL-results folder.\n\n"
+            "Reply when results are ready, or with any feedback / changes."
+        )
+        response = self.channel.prompt(message=prompt_msg)
+        if response is None:
+            return (f"Recipe round {round_n} delivered and saved to {recipe_file}, "
+                    "but the session ended before the human replied.")
+        return (f"Recipe round {round_n} delivered ({names}). "
+                f"Human replied: {response}")
 
     def _update_session(self, args: Dict[str, Any]) -> str:
         """Update session state."""

--- a/templates/manager/system_prompt_battery_addendum.txt
+++ b/templates/manager/system_prompt_battery_addendum.txt
@@ -1,0 +1,38 @@
+
+---
+
+## Battery Lab (BL) mode
+
+This is a BATTERY LAB run. The decisive experiments are physical coin cells built
+and measured by a HUMAN on the BatteryLab robot — not by any in-Docker agent. Your
+job is to drive the science (form hypotheses, design compositions, interpret data)
+and hand the human concrete recipes to make.
+
+The cycle for this run is:
+
+1. **Plan & design.** Use resource_finder and experiment_runner as usual for
+   literature and *computational* work (property estimates, candidate screening,
+   modelling). These inform the recipe — they never replace the wet-lab step.
+2. **Deliver a recipe.** When you are ready to test a real composition, call
+   `deliver_recipe` with a batch of cells in BatteryLab solvency format. This
+   writes the recipe and PAUSES for the human to run it. The recipe must be
+   physically makeable: real solvents/salts/additives, sensible molarities,
+   `volume` in millilitres, solvent fractions `v` summing to 1.0.
+3. **Wait for results.** The human runs the cells and drops raw results into the
+   BL-results folder. Results are unstructured (instrument screenshots, EIS/Nyquist
+   plots, CSVs, `.mpr` files, photos) — whatever the lab produces.
+4. **Interpret & iterate.** Read the returned results, update your world model
+   (findings, hypotheses, crux), and design the next recipe. Repeat.
+
+Critical rules for BL mode:
+
+- The physical experiment runner is a PERSON. NEVER call
+  `run_agent(experiment_runner)` for the cell build or electrochemical
+  measurement — only `deliver_recipe` triggers real synthesis.
+- One `deliver_recipe` call = one delivery to the lab. Do not deliver a new batch
+  until the human has reported back on the previous one.
+- A BL campaign is LONG and REPEATED — many design→deliver→wait→interpret loops
+  over a single idea. Keep the world model current so each new recipe is an
+  honest, evidence-grounded next step rather than a restatement of the last one.
+- Before each delivery, briefly state in chat what the batch tests and why; the
+  recipe's `rationale` should capture the same so the decision is gradeable.

--- a/templates/manager/tools_battery.yaml
+++ b/templates/manager/tools_battery.yaml
@@ -1,0 +1,55 @@
+# Battery-lab (BL) mode tool definitions.
+#
+# These are MERGED on top of templates/manager/tools.yaml only when the idea's
+# domain is "battery" (see load_tool_definitions in src/interactive/manager.py).
+# Normal interactive runs never see these tools.
+
+tools:
+  - name: deliver_recipe
+    description: |
+      Hand a batch of electrolyte recipes to the human for WET-LAB execution on
+      the BatteryLab robot, then PAUSE until they reply. This is the battery-lab
+      analogue of run_agent: the physical experiment is run by a human, not by an
+      in-Docker agent. NEVER use run_agent(experiment_runner) for the physical
+      cell build — that agent only does computation. Use deliver_recipe for the
+      real synthesis/measurement step.
+
+      The batch is validated before delivery (schema, solvent fractions sum to 1,
+      numeric molarities). If validation fails, nothing is delivered and you get
+      the list of problems to fix — correct the recipe and call deliver_recipe
+      again. On success the batch is written to BL-recipes/round-N/recipes.json in
+      the workspace and shown to the human, and the session waits for their reply
+      (e.g. "results are ready" or requested changes).
+    parameters:
+      recipes:
+        type: array
+        items:
+          type: object
+        description: |
+          A JSON array of recipe objects in BatteryLab solvency format. Each:
+            {
+              "recipe_name": "round1_cell_01",
+              "target_electrolyte": {
+                "name": "round1_cell_01",
+                "volume": 0.05,                                  # MILLILITRES (0.05 = 50 µL)
+                "v": {"water": 0.5, "propylene glycol": 0.5},    # solvent volume fractions, MUST sum to 1.0
+                "s": {"ZnSO4": 1.0},                             # OPTIONAL salt molarities (mol/L)
+                "a": {"additive_name": 0.1}                      # OPTIONAL additive molarities (mol/L)
+              }
+            }
+          Rules: volume is in mL and must be > 0; the "v" map is required, with
+          non-negative fractions summing to 1.0 (±0.02); "s" and "a" are optional
+          maps of substance -> non-negative molarity. Provide one object per coin
+          cell you want built.
+        required: true
+      rationale:
+        type: string
+        description: |
+          One short paragraph: which hypothesis this batch tests and why these
+          specific compositions were chosen now. Saved alongside the recipe and
+          recorded in the world model so the decision is gradeable later.
+        required: false
+    returns: |
+      On success: confirmation that round N was written and the human's reply
+      after they ran the wet-lab experiment. On validation failure: the list of
+      problems to fix (nothing is delivered).


### PR DESCRIPTION
BL mode specializes NeuriCo for a physical coin-cell lab: NeuriCo designs electrolyte recipes, a human builds/measures them on the BatteryLab robot, and results feed back for the next round (a long, repeated campaign).

- BL_MODE_README.md: what BL mode is, the recipe format (BatteryLab solvency JSON, v/s/a, mL), the water-activity research target, how to generate recipes in normal mode, and the closed-loop roadmap.
- deliver_recipe manager tool + validation (mL volume, v fractions sum to 1, numeric s/a molarities); writes BL-recipes/round-N/ and pauses for the human — the wet-lab analogue of run_agent.
- Battery-only tool + prompt: tools_battery.yaml and system_prompt_battery_addendum.txt, merged/appended when domain=battery.
- Domain routing in manager.py so normal interactive runs are untouched.
- ideas/examples/bl_water_activity_ladder.yaml: example idea whose deliverable is a recipe batch (water-activity ladder).