### PR TITLE
Default LLM usage to OpenRouter

### DIFF
--- a/config/paper_finder.md
+++ b/config/paper_finder.md
@@ -19,11 +19,11 @@ Paper-finder is built into the neurico Docker image. Just add the required API k
 ```bash
 # In your .env file:
 S2_API_KEY=your-semantic-scholar-key    # Required for paper-finder
-OPENAI_API_KEY=your-openai-key          # Required (used for GPT-4.1)
+OPENROUTER_KEY=your-openrouter-key      # Required (relevance ranking, GPT-4.1 via OpenRouter)
 COHERE_API_KEY=your-cohere-key          # Optional: improves ranking by ~7%
 ```
 
-When you run `./neurico build` and start the container, paper-finder automatically starts if `S2_API_KEY` and `OPENAI_API_KEY` are configured.
+When you run `./neurico build` and start the container, paper-finder automatically starts if `S2_API_KEY` and an LLM key (`OPENROUTER_KEY`, or `OPENAI_API_KEY` as a fallback) are configured.
 
 **That's it!** The container handles everything else.
 
@@ -57,13 +57,15 @@ python .claude/skills/paper-finder/scripts/find_papers.py "hypothesis generation
 | Tier | Keys Needed | Features |
 |------|-------------|----------|
 | **Basic** | 1 AI key (Anthropic/OpenAI/Google) | Full neurico, manual paper search |
-| **Standard** | + S2_API_KEY + OPENAI_API_KEY | Paper-finder with 92.5% quality |
+| **Standard** | + S2_API_KEY + OPENROUTER_KEY | Paper-finder with 92.5% quality |
 | **Full** | + COHERE_API_KEY | Paper-finder with full reranking |
+
+`OPENAI_API_KEY` still works as a fallback if you do not use OpenRouter.
 
 ## Getting API Keys
 
 - **S2_API_KEY**: [Semantic Scholar API](https://www.semanticscholar.org/product/api)
-- **OPENAI_API_KEY**: [OpenAI Platform](https://platform.openai.com/api-keys)
+- **OPENROUTER_KEY**: [OpenRouter Dashboard](https://openrouter.ai/keys)
 - **COHERE_API_KEY**: [Cohere Dashboard](https://dashboard.cohere.com/api-keys)
 
 ## Troubleshooting
@@ -73,8 +75,9 @@ python .claude/skills/paper-finder/scripts/find_papers.py "hypothesis generation
 - **Native**: Ensure paper-finder is running: `curl http://localhost:8000/health`
 
 ### API Key Errors
-- Verify environment variables: `echo $S2_API_KEY` and `echo $OPENAI_API_KEY`
-- OpenAI API key is required since paper-finder uses GPT-4.1 for relevance judgment
+- Verify environment variables: `echo $S2_API_KEY` and `echo $OPENROUTER_KEY`
+- An LLM key is required since paper-finder uses GPT-4.1 for relevance judgment.
+  OpenRouter is the default route; a direct `OPENAI_API_KEY` also works.
 
 ### Timeout Errors
 - "diligent" mode can take up to 3 minutes
@@ -86,7 +89,7 @@ If paper-finder cannot be set up, agents will fall back to manual search using a
 
 ## LLM Configuration
 
-Paper-finder uses OpenAI GPT-4.1 by default. Configuration is in:
+Paper-finder uses GPT-4.1 by default. Configuration is in:
 `services/paper-finder/agents/mabool/api/conf/config.toml`
 
 ```toml
@@ -98,3 +101,10 @@ relevance_model_name = "openai:gpt-4.1-2025-04-14"
 ```
 
 To use a different model, change the model name. Format: `provider:model-id`.
+
+When `OPENROUTER_KEY` (or `OPENROUTER_API_KEY`) is set, all `openai:` models
+are routed through OpenRouter automatically: the base URL switches to
+`https://openrouter.ai/api/v1` and the model ID is rewritten to the
+provider-prefixed, undated form (e.g. `gpt-4.1-2025-04-14` becomes
+`openai/gpt-4.1`). Unset the OpenRouter keys to call OpenAI directly with
+`OPENAI_API_KEY`.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -163,7 +163,9 @@ start_paper_finder() {
     echo -e "${BLUE}Paper-finder Service:${NC}"
 
     if [ -n "$S2_API_KEY" ]; then
-        if [ -n "$OPENAI_API_KEY" ]; then
+        # Paper-finder needs one LLM key for relevance ranking:
+        # OpenRouter (default) or a direct OpenAI key
+        if [ -n "$OPENROUTER_KEY" ] || [ -n "$OPENROUTER_API_KEY" ] || [ -n "$OPENAI_API_KEY" ]; then
             echo -e "  ${GREEN}[OK]${NC} S2_API_KEY configured"
 
             # Check if paper-finder is installed
@@ -197,7 +199,7 @@ start_paper_finder() {
                 echo -e "  ${YELLOW}[WARN]${NC} Paper-finder not installed"
             fi
         else
-            echo -e "  ${YELLOW}[WARN]${NC} OPENAI_API_KEY required for paper-finder"
+            echo -e "  ${YELLOW}[WARN]${NC} OPENROUTER_KEY (or OPENAI_API_KEY) required for paper-finder"
         fi
     else
         echo -e "  ${YELLOW}[INFO]${NC} S2_API_KEY not set - paper-finder disabled"

--- a/services/paper-finder/libs/chain/ai2i/chain/endpoints.py
+++ b/services/paper-finder/libs/chain/ai2i/chain/endpoints.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import re
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -128,8 +130,36 @@ class LangChainModelFactory(Protocol):
     def __call__(self, model: LLMModel, timeout: MaboolTimeout, api_key: SecretStr | None = None) -> BaseChatModel: ...
 
 
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def _openrouter_key_from_env() -> str | None:
+    return os.environ.get("OPENROUTER_KEY") or os.environ.get("OPENROUTER_API_KEY")
+
+
+def _openrouter_model_name(name: str) -> str:
+    # OpenRouter model IDs are provider-prefixed and generally undated,
+    # e.g. "gpt-4.1-2025-04-14" becomes "openai/gpt-4.1".
+    if "/" in name:
+        return name
+    return f"openai/{re.sub(r'-\d{4}-\d{2}-\d{2}$', '', name)}"
+
+
 def _openai_chat_factory(model: LLMModel, timeout: MaboolTimeout, api_key: SecretStr | None = None) -> BaseChatModel:
     params = openai_model_params(model.params)
+
+    # Route "openai" family models through OpenRouter when its key is
+    # configured, so paper-finder works without a direct OpenAI key.
+    openrouter_key = _openrouter_key_from_env()
+    if openrouter_key is not None:
+        return ChatOpenAI(
+            api_key=SecretStr(openrouter_key),
+            base_url=OPENROUTER_BASE_URL,
+            model=_openrouter_model_name(model.name),
+            model_kwargs={"response_format": {"type": "json_object"}},
+            timeout=timeout.httpx_timeout,
+            **params,
+        )
 
     return ChatOpenAI(
         api_key=api_key,

--- a/src/core/github_manager.py
+++ b/src/core/github_manager.py
@@ -474,6 +474,9 @@ class GitHubManager:
         """
         Generate a concise repository name using GPT-4o-mini.
 
+        Uses OpenRouter when OPENROUTER_KEY is set (the default key for
+        experiments), otherwise falls back to a direct OpenAI call.
+
         Args:
             title: Research title
             domain: Research domain (optional)
@@ -496,12 +499,20 @@ class GitHubManager:
             import openai
             import os
 
-            api_key = os.getenv('OPENAI_API_KEY')
-            if not api_key:
-                print("   ⚠️  OPENAI_API_KEY not set, using fallback naming")
+            # Prefer OpenRouter (OpenAI-compatible API, same SDK) over a direct
+            # OpenAI call, matching the default key setup for experiments
+            openrouter_key = os.getenv('OPENROUTER_KEY') or os.getenv('OPENROUTER_API_KEY')
+            openai_key = os.getenv('OPENAI_API_KEY')
+            if openrouter_key:
+                client = openai.OpenAI(api_key=openrouter_key,
+                                       base_url="https://openrouter.ai/api/v1")
+                model_name = "openai/gpt-4o-mini"
+            elif openai_key:
+                client = openai.OpenAI(api_key=openai_key)
+                model_name = "gpt-4o-mini"
+            else:
+                print("   ⚠️  Neither OPENROUTER_KEY nor OPENAI_API_KEY set, using fallback naming")
                 return self._sanitize_repo_name(idea_id)
-
-            client = openai.OpenAI(api_key=api_key)
 
             # Build prompt - ask for shorter names
             prompt = f"""Generate a very concise GitHub repository name for this research project.
@@ -530,7 +541,7 @@ Examples:
 Output ONLY the repository name, nothing else."""
 
             response = client.chat.completions.create(
-                model="gpt-4o-mini",
+                model=model_name,
                 messages=[{"role": "user", "content": prompt}],
                 temperature=0.3,
                 max_tokens=30

--- a/templates/agents/session_instructions.txt
+++ b/templates/agents/session_instructions.txt
@@ -153,8 +153,11 @@ CRITICAL: For LLM/AI Research - Use Real Models, Not Simulations
 IF your research involves LLM behavior, agents, prompting, or AI capabilities:
 
 ✓ YOU MUST use REAL LLM APIs:
-  - GPT-4.1 or GPT-5, or other real models
-  - You can also use openrouter, there is openrouter key in environment variable.
+  - Use OpenRouter by DEFAULT: the key is in the OPENROUTER_KEY environment variable.
+    It serves GPT, Claude, Gemini, and open models through one OpenAI-compatible
+    endpoint (base_url https://openrouter.ai/api/v1, model IDs like "openai/gpt-4.1").
+  - Only call a provider directly (e.g. OPENAI_API_KEY) if OpenRouter cannot serve
+    the model you need.
   - Use actual API calls to test behavior
   - Measure real model outputs, not simulated behavior
   - If you are not sure how to prompt and send API calls, search online.

--- a/templates/domains/artificial_intelligence/core.txt
+++ b/templates/domains/artificial_intelligence/core.txt
@@ -139,17 +139,19 @@ When automated metrics insufficient:
 **Setup**
 ```python
 import openai
-import anthropic
 import os
 from tenacity import retry, wait_exponential, stop_after_attempt
 
-# Load API keys from environment
-openai.api_key = os.getenv("OPENAI_API_KEY")
-anthropic_client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+# Default: OpenRouter serves GPT, Claude, Gemini, and open models through
+# one OpenAI-compatible endpoint. The key is provided as OPENROUTER_KEY.
+client = openai.OpenAI(
+    api_key=os.getenv("OPENROUTER_KEY"),
+    base_url="https://openrouter.ai/api/v1",
+)
 
 # Rate limiting and retry logic
 @retry(wait=wait_exponential(min=1, max=60), stop=stop_after_attempt(5))
-def call_api_with_retry(prompt, model="gpt-4"):
+def call_api_with_retry(prompt, model="openai/gpt-4.1"):
     """Robust API calling with exponential backoff."""
     # Implementation here
     pass
@@ -323,22 +325,26 @@ IMPORTANT: Use state-of-the-art models for credible research results.
 CRITICAL: For LLM research, use REAL models (APIs or downloads) and run them with experiments, do not simulate fake models!
 
 **Recommended Models (as of 2025):**
+
+Access all of these through OpenRouter by DEFAULT (key in OPENROUTER_KEY,
+base_url https://openrouter.ai/api/v1). You can search the full catalog at
+https://openrouter.ai/models.
+
 - **GPT-4.1 or GPT-5** (OpenAI, August 2025) - Best for everyday reasoning, coding, reliability
-  - API: `gpt-4.1`, `gpt-5`, `gpt-5-codex` (for coding tasks)
+  - OpenRouter IDs: `openai/gpt-4.1`, `openai/gpt-5`, `openai/gpt-5-codex` (for coding tasks)
   - Pricing: ~$1.25/M input tokens, ~$10/M output tokens
   - Context: Standard context window
 
 - **Claude Sonnet 4.5** (Anthropic, September 2025) - Best for coding, agents, polished writing
-  - API: `claude-sonnet-4-5`
+  - OpenRouter ID: `anthropic/claude-sonnet-4.5`
   - Context: 1,000,000 tokens
   - Excels at: Complex B2B workflows, multi-file reasoning, autonomous agents
 
 - **Gemini 2.5 Pro** (Google, June 2025) - Best for long context, visual reasoning
-  - API: `gemini-2-5-pro`
+  - OpenRouter ID: `google/gemini-2.5-pro`
   - Context: 1,000,000 tokens
   - Features: Computer Use for browser control, excellent multimodal
 
-You may also search models on openrouter. You can assume that we have the api keys available as environment variables
 **When to use older/smaller models:**
 - Historical baselines: Compare new methods against prior SOTA
 - Ablation studies: Test how model size affects phenomenon


### PR DESCRIPTION
Addresses #138.

## What this changes

- **Repo naming** (`src/core/github_manager.py`): `_generate_repo_name` prefers `OPENROUTER_KEY` (or `OPENROUTER_API_KEY`) and calls `openai/gpt-4o-mini` through OpenRouter. Falls back to a direct OpenAI call, then to sanitized-id naming.
- **Session instructions** (`templates/agents/session_instructions.txt`, `templates/domains/artificial_intelligence/core.txt`): agents are now told to use OpenRouter by default, with the key name, base URL, and provider-prefixed model IDs spelled out. The API setup snippet constructs an OpenRouter client instead of setting `openai.api_key`.
- **Paper-finder** (`services/paper-finder/libs/chain/ai2i/chain/endpoints.py`): when an OpenRouter key is in the environment, `_openai_chat_factory` switches the base URL and rewrites dated model names (`gpt-4.1-2025-04-14` becomes `openai/gpt-4.1`). All six `openai:` agents in config.toml route through this one factory, so no config changes needed. `docker/entrypoint.sh` accepts an OpenRouter key to start the service, and `config/paper_finder.md` documents the new default.

Direct `OPENAI_API_KEY` behavior is unchanged when no OpenRouter key is set.

## Testing

Live calls through the edited code paths, all passing:
- Repo naming generated a valid `{slug}-{hash}-{provider}` name via OpenRouter with only the OpenRouter key set.
- Paper-finder factory resolved `openai:gpt-4.1-2025-04-14` to `openai/gpt-4.1`, and a live completion with the JSON response format returned valid JSON.
- With both keys set (real OpenRouter key, deliberately invalid OpenAI key), both paths still succeed, confirming OpenRouter is preferred.
- With only `OPENAI_API_KEY` set, the factory builds the original client (default base URL, dated model name), so existing setups are unaffected.
- All referenced model IDs verified against the live OpenRouter catalog.