### PR TITLE
feat: long-run skill so agents cannot exit prematurely during long training runs and downloads

### DIFF
--- a/templates/agents/comment_handler.txt
+++ b/templates/agents/comment_handler.txt
@@ -78,4 +78,23 @@ Current active tips (empty if none):
 
 If a virtual environment exists (.venv/), activate it. If you need new packages, use `uv add`.
 
+═══════════════════════════════════════════════════════════════════════════════════════════════
+                       LONG-RUNNING COMMANDS (TRAINING, SWEEPS, LARGE EVALS)
+═══════════════════════════════════════════════════════════════════════════════════════════════
+
+Commands that take more than ~10 minutes MUST go through the long-run skill
+(.claude/skills/long-run/):
+
+  python .claude/skills/long-run/scripts/long_run.py start --name retrain_v1 -- <command>
+  python .claude/skills/long-run/scripts/long_run.py wait --name retrain_v1 --timeout 240
+    (exit 0 = succeeded, 1 = failed, 124 = still running: run `wait` AGAIN)
+  python .claude/skills/long-run/scripts/long_run.py status
+    (run before ending the session; a running job means you are NOT done)
+
+Never background a long command with `nohup`, `&`, or your harness's
+background-execution feature and move on. Background tasks are killed when
+the session ends, even if the harness says it will notify you on completion.
+Never end the session while a job is still running: nothing resumes it, and
+the scorer will run against incomplete artifacts.
+
 Start by exploring the workspace, then proceed with the user's directions.

--- a/templates/agents/resource_finder.txt
+++ b/templates/agents/resource_finder.txt
@@ -45,6 +45,28 @@ For example:
 - Create literature_review.md → saves in workspace/literature_review.md
 
 ═══════════════════════════════════════════════════════════════════════════════
+                    CRITICAL: LONG-RUNNING COMMANDS
+═══════════════════════════════════════════════════════════════════════════════
+
+Commands that take more than ~10 minutes (large dataset downloads, big git
+clones) MUST go through the long-run skill (.claude/skills/long-run/):
+
+✓ Launch:  python .claude/skills/long-run/scripts/long_run.py start --name get_data -- <command>
+✓ Wait:    python .claude/skills/long-run/scripts/long_run.py wait --name get_data --timeout 240
+  - Exit 0 = succeeded, 1 = failed, 124 = still running: run `wait` AGAIN
+✓ Verify:  python .claude/skills/long-run/scripts/long_run.py status
+  - Run this before writing the completion marker
+
+✗ NEVER background a long command with `nohup` or `&` and move on
+✗ NEVER use your harness's background-execution feature (run_in_background)
+  for downloads you still need. Background tasks are KILLED when the session
+  ends, even if the harness says it will notify you on completion.
+✗ NEVER end the session while `status` shows a running job
+✗ NEVER write "I will resume when the download finishes" and stop working.
+  Nothing resumes. The download dies with the session and the pipeline
+  advances with incomplete resources.
+
+═══════════════════════════════════════════════════════════════════════════════
                     CRITICAL: ENVIRONMENT SETUP
 ═══════════════════════════════════════════════════════════════════════════════
 

--- a/templates/agents/session_instructions.txt
+++ b/templates/agents/session_instructions.txt
@@ -244,6 +244,8 @@ Phase 3: Implementation (60-90 min)
 Phase 4: Experimentation (60-90 min)
   ✓ Run baseline experiments
   ✓ Run proposed method experiments
+  ✓ Run any command expected to take >10 minutes through the long-run skill
+    (see LONG-RUNNING COMMANDS below) - never plain `nohup` or `&`
   ✓ Collect results systematically (save to results/ directory)
   ✓ Generate visualizations
   ✓ Monitor for issues
@@ -275,6 +277,33 @@ CRITICAL REMINDERS:
 - If you encounter issues, document them and continue
 - Even if experiments fail, complete Phase 6 documenting what happened
 - REPORT.md is mandatory - it's the primary deliverable
+
+LONG-RUNNING COMMANDS (TRAINING, SWEEPS, LARGE EVALS):
+────────────────────────────────────────────────────────────────────────────────
+Commands that take more than ~10 minutes MUST go through the long-run skill
+(.claude/skills/long-run/). It launches the command as a detached, registered
+job and gives you a bounded wait you can repeat until the job finishes.
+
+✓ Launch:  python .claude/skills/long-run/scripts/long_run.py start --name train_v1 -- <command>
+✓ Wait:    python .claude/skills/long-run/scripts/long_run.py wait --name train_v1 --timeout 240
+  - Exit 0 = succeeded, 1 = failed, 124 = still running: run `wait` AGAIN
+  - Between wait calls you may do other useful work, then return to the loop
+✓ Verify:  python .claude/skills/long-run/scripts/long_run.py status
+  - Run this before declaring ANY phase complete
+
+✗ NEVER background a long command with `nohup` or `&` and move on
+✗ NEVER use your harness's background-execution feature (run_in_background /
+  "run in background" tool options) for experiment commands. Background tasks
+  are KILLED when the session ends, even if the harness says it will notify
+  you on completion. Use the long-run skill: its jobs survive session end.
+✗ NEVER end the session while `status` shows a running job
+✗ NEVER write "I will check back when training finishes" and exit
+  - Nothing checks back. The run's results will be lost and the pipeline
+    will treat the incomplete session as a success.
+
+If the training genuinely cannot finish in this session, that is a design
+problem: reduce epochs, subsample data, or use a smaller model so the full
+experiment fits. An incomplete run documented honestly beats an orphaned job.
 
 WORKSPACE DIRECTORY AND DIRECTORY SAFETY:
 ────────────────────────────────────────────────────────────────────────────────

--- a/templates/skills/long-run/SKILL.md
+++ b/templates/skills/long-run/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: long-run
+description: Run any long command (training, sweeps, large downloads, big evals) as a named, registry-tracked job that survives tool timeouts and session interruptions. Use whenever a command is expected to take more than 10 minutes. Never end a phase or session while a registered job is still running.
+tags:
+  - execution
+  - training
+  - reliability
+  - background-jobs
+---
+
+# long-run
+
+Registry-backed execution for commands that outlive a single tool call.
+
+## When to use
+
+Use this skill when a command is expected to take more than ~10 minutes:
+
+- Model training runs and hyperparameter sweeps
+- Large dataset downloads or preparation
+- Long eval passes over big test sets
+- Big git clones or archive extractions
+
+Do **not** use this skill if:
+
+- The command finishes in a couple of minutes (just run it in the foreground)
+- The job runs on a remote backend with its own submit-and-monitor pattern
+  (dsi-slurm and modal-training document their own; use this skill only for
+  the local side of the wait when their patterns do not already cover it)
+
+Why this exists: long commands tempt agents into launching the process in
+the background, writing "I will check back when it finishes", and ending the
+session. Nothing ever checks back. The pipeline reads the clean exit as
+success and advances on results that do not exist.
+
+## Contract (read first)
+
+1. **Any command expected to take more than ~10 minutes goes through
+   `long_run.py start`.** Do not hand-roll `nohup` or `&`, and do not use
+   your harness's background-execution feature: harness background tasks are
+   killed when the session ends, and its completion notification never
+   arrives if you exit first. Jobs started here are independent processes
+   that survive both.
+
+2. **A phase is not done while the registry lists a running job.** Before
+   you declare any phase complete or end the session, run
+   `long_run.py status`. If anything is running, keep waiting with
+   `long_run.py wait`. "The job will finish on its own" is not a valid
+   reason to move on: nothing resumes the session when it does.
+
+3. **Waiting is a loop of bounded `wait` calls, not one giant sleep.**
+   `wait --timeout 240` returns exit code 124 if the job is still running.
+   Re-run it as many times as needed. Between calls you may do other useful
+   work (analyze earlier results, prepare eval code), but always come back
+   to the loop.
+
+## Quickstart
+
+```bash
+SKILL=.claude/skills/long-run/scripts/long_run.py
+
+# 1. Launch. Returns immediately; the job runs detached.
+python $SKILL start --name train_lora -- python train.py --epochs 3
+
+# 2. Wait in bounded slices. 0 = done and succeeded, 1 = failed, 124 = still going.
+python $SKILL wait --name train_lora --timeout 240
+# ...returned 124? Run it again. Repeat until it returns 0 or 1.
+
+# 3. Confirm nothing is still running before ending the phase.
+python $SKILL status
+```
+
+## Subcommands
+
+| Command | What it does | Exit code |
+|---------|--------------|-----------|
+| `start --name N -- CMD` | Launch CMD detached (own session, survives timeouts), register it | 0 on launch |
+| `wait --name N [--timeout S]` | Block until the job ends or S seconds pass (default 240, 0 = forever) | 0 succeeded, 1 failed or killed, 124 still running |
+| `status [--name N]` | One line per job: status, pid, start time, exit code | 0 |
+| `stop --name N` | SIGTERM the job's process group, record it as killed | 0 |
+
+## Workspace layout
+
+Everything is under `.neurico/long_run/` in the workspace:
+
+- `jobs.json` is the registry: one entry per job with status
+  (`running` / `succeeded` / `failed` / `killed`), pid, timestamps, exit code.
+- `<name>/run.log` is the job's combined stdout and stderr.
+- `<name>/exit_code` is written by the wrapper when the command finishes.
+  Its presence is how `wait` distinguishes a finished job from a killed one.
+- `<name>/job.json` is the final record, written once the job resolves.
+
+## The wait loop, spelled out
+
+```bash
+python $SKILL start --name big_sweep -- python sweep.py --grid full
+while true; do
+  python $SKILL wait --name big_sweep --timeout 240
+  code=$?
+  if [ "$code" -ne 124 ]; then break; fi
+  # still running: optionally check intermediate output, then loop
+done
+tail -50 .neurico/long_run/big_sweep/run.log
+```
+
+`wait` prints a heartbeat once a minute (elapsed time plus the last log
+line) so progress is visible without tailing the log yourself.
+
+## Resuming after an interruption
+
+If your session was interrupted (rate limit, token exhaustion, session
+restart), the job kept running: it is detached from the session. On resume:
+
+```bash
+python $SKILL status               # what happened while you were gone?
+python $SKILL wait --name train_lora --timeout 240   # re-attach if still running
+```
+
+Record the job name in your STATE.md attempt entry when you start it
+(alongside the `Status: RUNNING` line the researcher protocol requires) so
+a resumed session knows which jobs to check first.
+
+## Anti-patterns
+
+| Don't | Why |
+|---|---|
+| `nohup python train.py &` and move on | Nothing tracks the process; the phase ends with the work unfinished |
+| Harness background execution (run_in_background) for experiment commands | Background tasks are killed at session end; the promised notification never arrives if you exit first |
+| End the session while `status` shows a running job | Nothing resumes it; the scorer runs against incomplete artifacts |
+| Write "I will check back when training finishes" and stop | Nothing checks back; the pipeline reads the clean exit as success |
+| One giant `wait --timeout 0` as your only interaction | A tool timeout mid-wait tells you nothing; bounded slices keep progress visible |
+| Restart a failed job under the same name without reading `run.log` | The failure cause is in the log; a blind retry usually reproduces it |
+
+## What this skill does not do
+
+- It does not restart failed jobs. Read `run.log`, fix the cause, `start`
+  a new attempt under a new name.
+- It does not survive a machine or container restart: pids die with the
+  host. Check `status` after any restart; jobs whose process vanished are
+  recorded as `killed`.
+- It does not replace compute-backend skills. Modal and Slurm jobs already
+  detach on the remote side; use this skill for the local wait when their
+  documented patterns do not already provide one.
+
+## Troubleshooting
+
+- **`wait` says killed but I did not kill it.** The process died without
+  writing an exit code: OOM killer, docker restart, or an external kill.
+  Check `run.log` and system memory before retrying.
+- **`start` refuses: job already running.** Attach with `wait` instead, or
+  pick a new name. One name maps to one attempt.
+- **I need the job's output mid-run.** `tail .neurico/long_run/<name>/run.log`
+  any time; the log streams continuously.

--- a/templates/skills/long-run/scripts/long_run.py
+++ b/templates/skills/long-run/scripts/long_run.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Registry-backed launcher for long-running experiment commands.
+
+Every long command (training, sweeps, large evals) runs detached under a
+named job so it survives tool timeouts and session interruptions. The
+registry at .neurico/long_run/jobs.json is the single source of truth for
+what is still running; a phase must not end while it lists a live job.
+
+Subcommands:
+    start  --name NAME -- CMD...   Launch CMD detached, register the job, return immediately
+    wait   --name NAME [--timeout N]  Block until the job finishes (exit 0/1) or N seconds pass (exit 124)
+    status [--name NAME]           Show one job or the whole registry
+    stop   --name NAME             Kill a running job and record it as killed
+
+Exit codes for `wait`: 0 job succeeded, 1 job failed or was killed,
+124 still running when --timeout expired (re-run `wait` to keep waiting).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+REGISTRY_DIR = Path(".neurico") / "long_run"
+POLL_SECONDS = 5
+HEARTBEAT_SECONDS = 60
+EXIT_STILL_RUNNING = 124
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def registry_path() -> Path:
+    return REGISTRY_DIR / "jobs.json"
+
+
+def job_dir(name: str) -> Path:
+    return REGISTRY_DIR / name
+
+
+def load_registry() -> dict:
+    try:
+        return json.loads(registry_path().read_text())
+    except (OSError, ValueError):
+        return {"jobs": {}}
+
+
+def save_registry(reg: dict) -> None:
+    REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = registry_path().with_suffix(".tmp")
+    tmp.write_text(json.dumps(reg, indent=2) + "\n")
+    tmp.replace(registry_path())
+
+
+def pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def last_log_line(log_file: Path, max_chars: int = 120) -> str:
+    try:
+        with log_file.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - 4096))
+            lines = [ln for ln in fh.read().decode(errors="replace").splitlines() if ln.strip()]
+        return lines[-1][:max_chars] if lines else "(no output yet)"
+    except OSError:
+        return "(log unavailable)"
+
+
+def sanitize_name(name: str) -> str:
+    cleaned = "".join(c if c.isalnum() or c in "-_" else "-" for c in name)
+    if not cleaned:
+        sys.exit("error: --name must contain alphanumeric characters")
+    return cleaned
+
+
+def finalize(reg: dict, name: str) -> dict:
+    """Resolve a job's final status from its exit_code file. Idempotent."""
+    job = reg["jobs"][name]
+    if job["status"] != "running":
+        return job
+    exit_file = job_dir(name) / "exit_code"
+    if exit_file.exists():
+        try:
+            code = int(exit_file.read_text().strip())
+        except ValueError:
+            code = -1
+        job["exit_code"] = code
+        job["status"] = "succeeded" if code == 0 else "failed"
+    elif not pid_alive(job["pid"]):
+        # Process gone without writing an exit code: killed externally
+        # (OOM, docker restart, manual kill)
+        job["exit_code"] = None
+        job["status"] = "killed"
+    if job["status"] != "running":
+        job["finished_at"] = now_utc()
+        save_registry(reg)
+        (job_dir(name) / "job.json").write_text(json.dumps(job, indent=2) + "\n")
+    return job
+
+
+def cmd_start(args: argparse.Namespace) -> int:
+    name = sanitize_name(args.name)
+    command = " ".join(args.command)
+    if not command:
+        sys.exit("error: no command given after --")
+
+    reg = load_registry()
+    existing = reg["jobs"].get(name)
+    if existing and finalize(reg, name)["status"] == "running":
+        sys.exit(f"error: job '{name}' is already running (pid {existing['pid']}). "
+                 f"Use `wait --name {name}` to attach or pick another name.")
+
+    jdir = job_dir(name)
+    jdir.mkdir(parents=True, exist_ok=True)
+    log_file = jdir / "run.log"
+    exit_file = jdir / "exit_code"
+    exit_file.unlink(missing_ok=True)
+
+    # start_new_session detaches the job from this process group, so it
+    # survives tool timeouts and the end of the agent session. The command
+    # runs in a subshell so an `exit N` inside it cannot skip the exit_code
+    # write that `wait` relies on.
+    wrapped = f"( {command} ); echo $? > '{exit_file}'"
+    with log_file.open("w") as log_fh:
+        proc = subprocess.Popen(
+            ["/bin/sh", "-c", wrapped],
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            cwd=os.getcwd(),
+        )
+
+    reg["jobs"][name] = {
+        "name": name,
+        "command": command,
+        "pid": proc.pid,
+        "status": "running",
+        "exit_code": None,
+        "log": str(log_file),
+        "started_at": now_utc(),
+        "finished_at": None,
+    }
+    save_registry(reg)
+    print(f"[long-run] started '{name}' (pid {proc.pid})")
+    print(f"[long-run] log: {log_file}")
+    print(f"[long-run] next: python {sys.argv[0]} wait --name {name} --timeout 240")
+    return 0
+
+
+def cmd_wait(args: argparse.Namespace) -> int:
+    name = sanitize_name(args.name)
+    reg = load_registry()
+    if name not in reg["jobs"]:
+        sys.exit(f"error: no job named '{name}' in the registry")
+
+    deadline = time.time() + args.timeout if args.timeout > 0 else None
+    last_beat = 0.0
+    started = time.time()
+    while True:
+        job = finalize(reg, name)
+        if job["status"] != "running":
+            line = last_log_line(Path(job["log"]))
+            print(f"[long-run] '{name}' {job['status']} (exit {job['exit_code']}) | last: {line}")
+            print(f"[long-run] full log: {job['log']}")
+            return 0 if job["status"] == "succeeded" else 1
+        if deadline and time.time() >= deadline:
+            print(f"[long-run] '{name}' still running after {int(time.time() - started)}s. "
+                  f"Re-run `wait --name {name}` to keep waiting. Do NOT end the session.")
+            return EXIT_STILL_RUNNING
+        if time.time() - last_beat >= HEARTBEAT_SECONDS:
+            elapsed = int(time.time() - started)
+            print(f"[long-run] '{name}' running {elapsed // 60}m{elapsed % 60:02d}s "
+                  f"| last: {last_log_line(Path(job['log']))}", flush=True)
+            last_beat = time.time()
+        time.sleep(POLL_SECONDS)
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    reg = load_registry()
+    if not reg["jobs"]:
+        print("[long-run] registry empty: no jobs recorded")
+        return 0
+    names = [sanitize_name(args.name)] if args.name else list(reg["jobs"])
+    live = 0
+    for name in names:
+        if name not in reg["jobs"]:
+            sys.exit(f"error: no job named '{name}' in the registry")
+        job = finalize(reg, name)
+        live += job["status"] == "running"
+        print(f"{job['status']:>9}  {name}  pid={job['pid']}  started={job['started_at']}"
+              f"  exit={job['exit_code']}")
+    if live:
+        print(f"[long-run] {live} job(s) still running. The phase is NOT done.")
+    return 0
+
+
+def cmd_stop(args: argparse.Namespace) -> int:
+    name = sanitize_name(args.name)
+    reg = load_registry()
+    if name not in reg["jobs"]:
+        sys.exit(f"error: no job named '{name}' in the registry")
+    job = finalize(reg, name)
+    if job["status"] != "running":
+        print(f"[long-run] '{name}' already {job['status']}")
+        return 0
+    try:
+        os.killpg(os.getpgid(job["pid"]), signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        pass
+    time.sleep(1)
+    job = finalize(reg, name)
+    if job["status"] == "running":
+        job["status"] = "killed"
+        job["finished_at"] = now_utc()
+        save_registry(reg)
+    print(f"[long-run] '{name}' stopped")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="subcommand", required=True)
+
+    p_start = sub.add_parser("start", help="launch a command detached and register it")
+    p_start.add_argument("--name", required=True, help="short job name, e.g. train_lora")
+    p_start.add_argument("command", nargs=argparse.REMAINDER,
+                         help="the command to run, after --")
+
+    p_wait = sub.add_parser("wait", help="block until a job finishes or --timeout expires")
+    p_wait.add_argument("--name", required=True)
+    p_wait.add_argument("--timeout", type=int, default=240,
+                        help="seconds to wait before returning 124 (0 = wait forever)")
+
+    p_status = sub.add_parser("status", help="show job status")
+    p_status.add_argument("--name", default=None)
+
+    p_stop = sub.add_parser("stop", help="kill a running job")
+    p_stop.add_argument("--name", required=True)
+
+    args = parser.parse_args()
+    if args.subcommand == "start" and args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    handlers = {"start": cmd_start, "wait": cmd_wait, "status": cmd_status, "stop": cmd_stop}
+    return handlers[args.subcommand](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Experiment sessions terminate with training still running. The agent backgrounds a long command, writes "I will check back when it finishes", and ends the session. The harness kills background tasks at session end, so the work is lost and the pipeline advances on incomplete artifacts. The autoresearch prompts already forbid this ("experiment execution must be synchronous") and the rule gets violated anyway: blocking calls die at tool timeouts, so backgrounding is the only option that appears to work. This PR adds a skill that lets agents wait out long commands within tool-timeout limits, plus instruction blocks that route agents to it.

## What this adds

A `long-run` skill, copied to every workspace like the other non-compute skills. No orchestrator changes. It runs a long command as a named job tracked in a registry:

1. **Detached launch.** `start --name train_v1 -- <cmd>` runs the command in its own process session, so tool timeouts and session death do not kill it. A wrapper writes the command's exit code to a file when it finishes. A later `wait`, from any process, can then tell a failed job (nonzero exit) from a killed one (process died without writing the file).
2. **Bounded waiting.** `wait --name train_v1 --timeout 240` blocks for at most 240 seconds: exit 0 succeeded, 1 failed or killed, 124 still running (run `wait` again). It prints a heartbeat once a minute with the last log line. Waiting in slices fits inside tool timeouts, which removes the reason agents background commands.
3. **Pre-exit check.** `status` prints one line per job and warns when jobs are still running. The registry at `.neurico/long_run/jobs.json` is also an audit trail, and can back a future orchestrator gate that refuses to complete a stage while jobs are live.

## Instruction surface

Three templates gain a LONG-RUNNING COMMANDS block in their existing format: launch/wait/verify commands and the prohibitions, each with its reason. The block names the harness background-execution feature explicitly. The failure transcripts show agents use `run_in_background` rather than `nohup`: the harness promises a completion notification, so exiting looks safe, but the notification cannot arrive after the session exits.

## Files

| File | Purpose |
|---|---|
| `templates/skills/long-run/SKILL.md` (new) | Contract, quickstart, wait-loop pattern, resume after interruption, anti-patterns |
| `templates/skills/long-run/scripts/long_run.py` (new) | `start` / `wait` / `status` / `stop`; stdlib only; atomic registry writes |
| `templates/agents/session_instructions.txt` | LONG-RUNNING COMMANDS block, one Phase 4 checklist line |
| `templates/agents/resource_finder.txt` | Same block, adapted to downloads and clones |
| `templates/agents/comment_handler.txt` | Condensed block for AutoResearch retraining |

## What's been live-tested

Ran the failure and the fix on the `cifar10_fixed_protocol` idea, taken from a workspace where this failure was observed. Full pipeline (`--enable-scoring --autoresearch`), claude provider, native, control and fix back to back.

| | Control (main) | This branch |
|---|---|---|
| Resource finder | Backgrounded the CIFAR download via run_in_background. Final message: "I'll resume when the download notification arrives." Both download tasks killed at session end. No completion marker. Stage failed. | 17 skill invocations. The download server sent a corrupt file, then stalled all connections. The agent ran `stop`, restarted under new names five times, switched to the Internet Archive mirror, verified the MD5, wrote the marker. |
| Experiment runner | Not reached (stage 1 failed) | Ran the 5-iteration training loop as one registered job, waited in 240s slices, registry clean at exit. 91.5% test accuracy, all scorer targets met. |
| Comment handler | n/a | Before its template had the block: trained synchronously, no violations but no protection. After: registered its retrain as a job (`iter6_wrn16_8`) and produced an accepted AutoResearch iteration (val 0.9146 -> 0.9200). |

Observed:

- The control agent violated the existing synchronous-execution rule under the same conditions as the cluster failures.
- The comment handler gives a before/after comparison on the same workspace: adding the template block changed its execution from unprotected to registered.
- Script tests cover success, nonzero exit, external kill, timeout 124, duplicate-name guard, `stop`, and survival across separate shells.

## Notes

- This is prevention only. An agent can still ignore the skill. Enforcement (an orchestrator gate on the registry, or a waiter that relaunches the session for jobs longer than a session) is future work on top of this registry format.
