### PR TITLE
AutoResearch continuation: --continue-recover and NEURICO_IDEAS override

### DIFF
--- a/src/cli/submit.py
+++ b/src/cli/submit.py
@@ -23,7 +23,7 @@ if env_local.exists():
 elif env_file.exists():
     load_dotenv(env_file)
     
-from core.idea_manager import IdeaManager
+from core.idea_manager import IdeaManager, resolve_ideas_dir
 
 # Check if GitHub integration is available
 try:
@@ -94,7 +94,7 @@ def main():
         sys.exit(1)
 
     # Initialize manager
-    manager = IdeaManager()
+    manager = IdeaManager(resolve_ideas_dir())
 
     # Validate
     if not args.no_validate:

--- a/src/core/autoresearch.py
+++ b/src/core/autoresearch.py
@@ -1313,6 +1313,7 @@ def continue_from_current_best(
     autoresearch_history_dir: Optional[Path],
     proposer_timeout: int,
     comment_timeout: int,
+    continue_recover: bool = False,
 ) -> Dict[str, Any]:
     """Validate the current scored node and run Phase 2 AutoResearch search."""
     print()
@@ -1321,7 +1322,9 @@ def continue_from_current_best(
     print("=" * 80)
     print()
 
-    current_sha = validate_continue_autoresearch_workspace(work_dir)
+    current_sha = validate_continue_autoresearch_workspace(
+        work_dir, auto_restore=continue_recover
+    )
     state = read_autoresearch_state(work_dir)
     lineage_source_sha = autoresearch_state_lineage_source_sha(state) or current_sha
     previous_last_iteration = autoresearch_state_last_iteration(state)
@@ -1393,8 +1396,16 @@ def continue_from_current_best(
     }
 
 
-def validate_continue_autoresearch_workspace(work_dir: Path) -> str:
-    """Validate the workspace is positioned at its saved AutoResearch current best."""
+def validate_continue_autoresearch_workspace(
+    work_dir: Path, auto_restore: bool = False
+) -> str:
+    """Validate the workspace is positioned at its saved AutoResearch current best.
+
+    With auto_restore, a workspace left dirty or ahead of current_best_sha by an
+    interrupted attempt (for example a job killed at the Slurm wall clock) is
+    restored to current_best_sha and treated as if that attempt were rejected,
+    instead of refusing to continue.
+    """
     work_dir = Path(work_dir)
     if not work_dir.exists():
         raise ValueError(f"Workspace does not exist: {work_dir}")
@@ -1430,15 +1441,33 @@ def validate_continue_autoresearch_workspace(work_dir: Path) -> str:
             + ", ".join(missing)
         )
 
-    status_lines = [
-        line
-        for line in checkpoints.repo.git.status("--porcelain").splitlines()
-        if line.strip() and not _is_allowed_continue_dirty_status(line)
-    ]
+    def _disallowed_dirty():
+        return [
+            line
+            for line in checkpoints.repo.git.status("--porcelain").splitlines()
+            if line.strip() and not _is_allowed_continue_dirty_status(line)
+        ]
+
+    status_lines = _disallowed_dirty()
+    if auto_restore and (status_lines or checkpoints.current_sha() != current_best_sha):
+        # An interrupted attempt can leave the working tree dirty or HEAD ahead
+        # of the saved current best. Restore to current_best_sha and treat the
+        # interrupted attempt as rejected. restore_checkpoint resets only tracked
+        # files and preserves ignored datasets and logs.
+        print(
+            "⚠️  Interrupted-attempt workspace detected; restoring to the "
+            f"current best checkpoint {current_best_sha[:12]} before continuing."
+        )
+        checkpoints.restore_checkpoint(current_best_sha)
+        status_lines = _disallowed_dirty()
+
     if status_lines:
         raise ValueError(
             "Cannot continue AutoResearch with a dirty workspace. "
-            "Commit, stash, or remove pending changes first. Status:\n"
+            "Commit, stash, or remove pending changes first"
+            + (" (--continue-recover left untracked changes it will not delete)"
+               if auto_restore else "")
+            + ". Status:\n"
             + "\n".join(status_lines[:20])
         )
 

--- a/src/core/idea_manager.py
+++ b/src/core/idea_manager.py
@@ -15,11 +15,28 @@ import yaml
 import json
 import hashlib
 import sys
+import os
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.config_loader import ConfigLoader
+
+
+def resolve_ideas_dir(project_root: Optional[Path] = None) -> Path:
+    """Resolve the ideas directory, honoring the NEURICO_IDEAS override.
+
+    Mirrors NEURICO_WORKSPACE: if NEURICO_IDEAS is set, use it, so a shared
+    read-only install can point each user at their own ideas directory.
+    Otherwise fall back to <project_root>/ideas (project_root defaults to the
+    repo root), which is the historical behavior.
+    """
+    env_ideas = os.getenv("NEURICO_IDEAS")
+    if env_ideas:
+        return Path(env_ideas)
+    if project_root is None:
+        project_root = Path(__file__).parent.parent.parent
+    return Path(project_root) / "ideas"
 
 
 class IdeaManager:

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -199,6 +199,7 @@ class ResearchRunner:
         autoresearch_iterations: int = 1,
         autoresearch_history_dir: Optional[Path] = None,
         continue_autoresearch: bool = False,
+        continue_recover: bool = False,
         bootstrap_autoresearch_baseline: bool = False,
         proposer_timeout: int = 900,
         compute_backend: str = "local",
@@ -260,6 +261,10 @@ class ResearchRunner:
         if len(selected_hitl_modes) > 1:
             raise ValueError("Choose one HITL entry mode: " + ", ".join(selected_hitl_modes))
         hitl = hitl_autoresearch or hitl_continue_autoresearch
+        if continue_recover and not continue_autoresearch:
+            raise ValueError(
+                "--continue-recover only applies with --continue-autoresearch."
+            )
         if hitl_autoresearch:
             if autoresearch or continue_autoresearch:
                 raise ValueError(
@@ -522,6 +527,7 @@ class ResearchRunner:
                         autoresearch_history_dir=autoresearch_history_dir,
                         proposer_timeout=proposer_timeout,
                         comment_timeout=timeout,
+                        continue_recover=continue_recover,
                     )
                 success = pipeline_result.get("success", False)
 
@@ -1417,6 +1423,13 @@ def main():
         help="Continue AutoResearch from the existing scored workspace and skip upstream pipeline stages",
     )
     parser.add_argument(
+        "--continue-recover",
+        action="store_true",
+        help="With --continue-autoresearch: if the workspace is dirty from an interrupted "
+             "attempt (e.g. a job killed at the Slurm wall clock), restore it to the current "
+             "best checkpoint and continue, instead of refusing.",
+    )
+    parser.add_argument(
         "--autoresearch-iterations",
         type=int,
         default=1,
@@ -1554,6 +1567,7 @@ def main():
             autoresearch_iterations=args.autoresearch_iterations,
             autoresearch_history_dir=args.autoresearch_history_dir,
             continue_autoresearch=args.continue_autoresearch,
+            continue_recover=args.continue_recover,
             bootstrap_autoresearch_baseline=args.bootstrap_autoresearch_baseline,
             proposer_timeout=args.proposer_timeout,
             compute_backend=args.compute_backend,

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -33,7 +33,7 @@ _PROJECT_ROOT = _SRC_ROOT.parent
 sys.path.insert(0, str(_SRC_ROOT))
 sys.path.insert(0, str(_PROJECT_ROOT))
 
-from core.idea_manager import IdeaManager
+from core.idea_manager import IdeaManager, resolve_ideas_dir
 from core.config_loader import ConfigLoader
 from core.agent_cli import (
     build_agent_command,
@@ -123,7 +123,7 @@ class ResearchRunner:
         if config_loader.should_auto_create_workspace():
             self.runs_dir.mkdir(parents=True, exist_ok=True)
 
-        self.idea_manager = IdeaManager(self.project_root / "ideas")
+        self.idea_manager = IdeaManager(resolve_ideas_dir(self.project_root))
         self.prompt_generator = PromptGenerator(self.project_root / "templates")
 
         # GitHub integration

--- a/tests/test_ideas_dir_override.py
+++ b/tests/test_ideas_dir_override.py
@@ -1,0 +1,46 @@
+"""Unit tests for the NEURICO_IDEAS ideas-directory override.
+
+The override lets a shared read-only NeuriCo install point each user at their
+own ideas directory. It mirrors NEURICO_WORKSPACE: honored when set, otherwise
+the historical <project_root>/ideas path. The submit and run entry points must
+resolve the same directory so a submitted idea is found at run time.
+
+Run: python -m pytest tests/test_ideas_dir_override.py
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from core.idea_manager import resolve_ideas_dir  # noqa: E402
+
+
+def test_falls_back_to_project_root_when_unset(monkeypatch, tmp_path):
+    monkeypatch.delenv("NEURICO_IDEAS", raising=False)
+    assert resolve_ideas_dir(tmp_path) == tmp_path / "ideas"
+
+
+def test_default_project_root_is_repo_root_when_unset(monkeypatch):
+    monkeypatch.delenv("NEURICO_IDEAS", raising=False)
+    repo_root = Path(__file__).resolve().parents[1]
+    assert resolve_ideas_dir() == repo_root / "ideas"
+
+
+def test_env_override_wins_and_ignores_project_root(monkeypatch, tmp_path):
+    override = tmp_path / "shared_ideas"
+    monkeypatch.setenv("NEURICO_IDEAS", str(override))
+    assert resolve_ideas_dir(tmp_path / "some" / "other" / "root") == override
+    assert resolve_ideas_dir() == override
+
+
+def test_submit_and_run_resolve_the_same_dir(monkeypatch, tmp_path):
+    """Submit passes no project_root, run passes its install root. Under the
+    override both must land on the same ideas directory."""
+    override = tmp_path / "user_ideas"
+    monkeypatch.setenv("NEURICO_IDEAS", str(override))
+    submit_side = resolve_ideas_dir()                      # cli/submit.py
+    run_side = resolve_ideas_dir(tmp_path / "install")     # core/runner.py
+    assert submit_side == run_side == override


### PR DESCRIPTION
Two small, independent enablers for running AutoResearch on a cluster.

## 1. `--continue-recover`
Opt-in flag used with `--continue-autoresearch`. A job killed at the Slurm wall clock leaves the in-progress attempt uncommitted, or HEAD ahead of the saved current best, so a plain continuation cannot resume. `--continue-recover` restores the workspace to `current_best_sha` (discarding the attempt as if rejected, via the existing `restore_checkpoint`) and continues. Passing it without `--continue-autoresearch` errors. Without it, the refuse-on-dirty behavior is unchanged.

Files: `src/core/autoresearch.py` (the `auto_restore` branch in `validate_continue_autoresearch_workspace`), `src/core/runner.py` (flag, guard, plumbing).

## 2. `NEURICO_IDEAS` override
Lets a shared read-only install point submit and run at a per-user ideas directory. `resolve_ideas_dir` honors `NEURICO_IDEAS` when set, else falls back to `<project_root>/ideas`, mirroring `NEURICO_WORKSPACE`. Scoped to the submit and run entry points so they resolve the same directory. The `IdeaManager` default and the interactive/HITL/fetch paths are unchanged. Inert when the variable is unset.

Files: `src/core/idea_manager.py` (`resolve_ideas_dir`), `src/cli/submit.py`, `src/core/runner.py`, plus `tests/test_ideas_dir_override.py`.

Both changes are backward compatible: with neither the flag nor the env var, behavior is identical to today.