### PR TITLE
fix(hitl): strengthen phase completion handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 <hr>
 
-<!-- agent-summary: NeuriCo is an autonomous research framework. Input: YAML (title, domain, hypothesis). Output: code, results, plots, LaTeX paper, GitHub repo. Providers: Claude Code, Codex, Gemini. Install: curl one-liner or git+docker. Requirements: git + docker (or git + python 3.10+), plus an AI coding CLI (Claude Code, Codex, or Gemini). License: Apache 2.0. Repository: https://github.com/ChicagoHAI/neurico -->
+<!-- agent-summary: NeuriCo is an autonomous and human-in-the-loop research framework. Input: YAML (title, domain, hypothesis). Workflows: single-run research, scored AutoResearch, and manager-mediated HITL AutoResearch. Output: code, results, plots, LaTeX paper, GitHub repo. Providers: Claude Code, Codex, Gemini. Install: curl one-liner or git+docker. Requirements: git + docker (or git + python 3.10+), plus an AI coding CLI (Claude Code, Codex, or Gemini). License: Apache 2.0. Repository: https://github.com/ChicagoHAI/neurico -->
 
-**NeuriCo** (**Neur**al **Co**-Scientist, inspired by Enrico Fermi) is an autonomous research framework that takes structured research ideas and orchestrates AI agents to design, execute, analyze, and document experiments across diverse domains.
+**NeuriCo** (**Neur**al **Co**-Scientist, inspired by Enrico Fermi) takes structured research ideas and orchestrates AI agents to design, execute, analyze, and document experiments across diverse domains.
 
 <div align="center">
 <img src="assets/neurico-6x.gif" alt="NeuriCo Demo" width="700"/>
@@ -29,7 +29,7 @@
 | **Minimal Input** | Just provide title, domain, and hypothesis - agents handle the rest |
 | **Agent-Driven Research** | Literature review, dataset search, baseline identification |
 | **Multi-Provider Support** | Works with Claude, Codex, and Gemini (raw CLI by default, notebooks optional) |
-| **Pragmatic Execution** | Creates resources when they don't exist, always proceeds |
+| **AutoResearch** | Iteratively proposes, executes, scores, and checkpoints improvements |
 | **Domain-Agnostic** | ML, data science, AI, systems, theory, and more |
 | **Smart Documentation** | Auto-generates reports, code, and results |
 | **GitHub Integration** | Auto-creates repos and pushes results |
@@ -81,6 +81,8 @@ cd NeuriCo
 ```
 
 That's it! The agent fetches the idea, creates a GitHub repo, runs experiments, writes a paper, and pushes everything.
+
+For iterative and human-in-the-loop (HITL) AutoResearch workflows, see [Research Workflows](#research-workflows).
 
 <details>
 <summary>Manual setup (alternative to one-liner)</summary>
@@ -257,6 +259,17 @@ uv run python src/cli/submit.py ideas/examples/ml_regularization_test.yaml
 uv run python src/core/runner.py <idea_id> --provider claude --full-permissions
 ```
 
+### Research Workflows
+
+After submitting an idea, choose the workflow that matches the research task:
+
+| Workflow | Command | Use when |
+|----------|---------|----------|
+| **Standard run** | `./neurico run <idea_id>` | Run the research pipeline once |
+| **AutoResearch** | `./neurico run <idea_id> --autoresearch --autoresearch-iterations 3` | Build an initial scored experiment, then try iterative improvements |
+| **Continue AutoResearch** | `./neurico run <idea_id> --continue-autoresearch --autoresearch-iterations 3` | Continue improving an existing scored workspace |
+| **HITL AutoResearch** | `./neurico hitl-web <idea_id>` | Use the local manager interface to work closely with NeuriCo|
+
 ### Run Options
 
 | Option | Description |
@@ -270,6 +283,9 @@ uv run python src/core/runner.py <idea_id> --provider claude --full-permissions
 | `--no-hash` | Simpler repo names (skip random hash) |
 | `--write-paper` | Generate LaTeX paper after experiments |
 | `--paper-style neurips\|icml\|acl` | Paper format (default: neurips) |
+| `--autoresearch` | Run AutoResearch after creating the initial scored experiment |
+| `--continue-autoresearch` | Continue AutoResearch from an existing scored workspace |
+| `--autoresearch-iterations N` | Number of AutoResearch iterations (default: 1) |
 
 ### Other Commands
 
@@ -334,11 +350,11 @@ workspace/<repo-name>/
 
 **You can submit minimal ideas** - agents will research the details:
 
-- Just provide: title, domain, research question
+- Just provide: title, domain, and a testable hypothesis
 - Agent searches for: datasets, baselines, evaluation methods
 - Grounds in literature when resources exist
 - Creates synthetic data/baselines when they don't
-- Always proceeds to execution - doesn't get stuck
+- Executes without requiring a fully specified methodology upfront
 
 **Example minimal idea:**
 ```yaml

--- a/docs/HITL_AUTORESEARCH.md
+++ b/docs/HITL_AUTORESEARCH.md
@@ -1,0 +1,405 @@
+# HITL AutoResearch Design and Workflow
+
+This document describes the design and workflow of NeuriCo's human-in-the-loop
+(HITL) AutoResearch system: how the human, manager, workers, and runtime divide
+responsibility, how research decisions move through the system, and how the
+workflow preserves its state across feedback, worker exits, and process
+restarts.
+
+HITL AutoResearch is a separate execution path from ordinary AutoResearch. It
+reuses NeuriCo's research agents, scoring contract, and Git checkpoints, but
+adds a durable interactive manager, explicit human decision points, a retained
+research frontier, and runtime-mediated recovery.
+
+## Design Goals
+
+The HITL path is organized around five invariants:
+
+1. **One authoritative workflow state.** Runtime-held requests and durable
+   transitions, rather than worker processes or browser state, determine where
+   the workflow is.
+2. **Judgment is separate from mechanism.** The manager and human make research
+   decisions; runtime validates and applies those decisions without replacing
+   them with score-based policy.
+3. **A worker cannot advance its own phase.** Workers submit evidence, raised
+   ideas, proposals, and phase-finish requests through a narrow runtime command
+   surface.
+4. **Human involvement is manager-mediated.** The manager decides when human
+   intent is required, asks through the durable conversation, and translates
+   the response into a precise worker instruction.
+5. **Every consequential boundary is recoverable.** Checkpoints, private HITL
+   snapshots, held requests, and replayable transitions preserve the ordering
+   of the workflow across failures and restarts.
+
+## Workflow Overview
+
+```text
+idea
+  -> resource finding
+  -> scoring-rule construction
+  -> initial experiment
+  -> isolated scoring
+  -> automatic root frontier node
+  -> proposal
+  -> human admission
+  -> candidate experiment
+  -> isolated scoring
+  -> manager accept / reject / repair
+  -> frontier maintenance
+  -> next proposal
+```
+
+Each research stage has a living plan and an execution phase. A worker requests
+review through the runtime instead of declaring itself complete. The runtime
+keeps that command open while the manager inspects the work, asks the human when
+required, and returns either approval or actionable feedback.
+
+## Actors and Authority
+
+HITL depends on a strict separation between judgment and mechanism.
+
+| Actor | Owns | Does not own |
+| --- | --- | --- |
+| Human | Research intent, preferences, scope, risk tolerance, access, and explicit plan or proposal approval | Runtime state, scoring transport, or frontier mutation |
+| Manager | Semantic review, worker-facing feedback, scientific interpretation, candidate accept/reject/repair decisions, frontier pruning and selection | Direct workspace mutation or unchecked workflow transitions |
+| Worker | Research, implementation, experiments, public artifacts, and living stage plans | Official HITL records, scoring authority, or phase completion |
+| Runtime | Command validation, allowed tools, phase state, provenance, checkpoints, scoring isolation, durable transitions, and recovery | Scientific merit, interpretation of a score, or research strategy |
+
+This boundary is intentional. Runtime may reject an invalid command, a missing
+required artifact, a protected-path write, or a changed workspace fingerprint.
+It must not reject research because a score is low or decide that a candidate is
+scientifically uninteresting. Those judgments belong to the manager, informed
+by the human where the workflow requires human intent.
+
+## Stage Lifecycle
+
+### Planning
+
+The stage worker writes or updates a living plan under `plans/`. The plan must
+describe the current scope, execution steps, artifacts, decision boundaries,
+risks, and stop conditions. It remains a public workspace artifact and is
+updated rather than replaced by a parallel planning record.
+
+Before execution, the worker calls `hitl-finish-phase`. The runtime validates
+the plan boundary and gives the manager the plan and related artifacts. When
+human approval is required, the manager uses `ask_human` and translates the
+human's response into precise worker-facing feedback.
+
+### Execution
+
+After plan approval, the same worker session receives execution instructions.
+The worker performs the work, records material ideas as they arise, and calls
+`hitl-finish-phase` once when the phase is ready for review.
+
+`hitl-finish-phase` is intentionally blocking. It may remain open through
+manager review and scoring. A worker must not launch duplicate, background, or
+timed retries while the original command is still waiting.
+
+Runtime validation at this boundary is mechanical:
+
+- the phase was completed through the required runtime command;
+- required public artifacts exist at their prescribed paths;
+- structured artifacts are readable and valid where a schema exists;
+- protected paths and phase write boundaries were respected;
+- the reviewed workspace can be checkpointed safely.
+
+The manager decides whether the completed work is semantically adequate. If it
+is not, the manager returns targeted feedback and the worker revises the living
+plan or artifacts in the same workflow.
+
+## Initial Research and Root Creation
+
+A fresh HITL run performs the multi-agent research pipeline before beginning
+iterative AutoResearch:
+
+1. **Resource finder** discovers and verifies relevant papers, datasets,
+   repositories, baselines, licenses, and constraints.
+2. **Rule maker** defines the public scoring interface and creates the sealed
+   evaluator contract.
+3. **Experiment runner** plans and executes the first complete experiment.
+4. **Runtime** scores the exact manager-approved experiment checkpoint in an
+   isolated scoring workspace.
+5. **Manager** reviews the complete scorer result. It either approves an
+   error-free scored workspace or sends repair instructions to a replacement
+   experiment worker.
+6. **Runtime** automatically publishes an approved initial score as the root
+   frontier node.
+
+There is no accept/reject frontier decision for the initial experiment. The
+manager's initial scoring review answers whether the result is valid or needs
+repair; an approved result becomes the root automatically.
+
+Root publication is a durable transaction. Checkpoint creation, frontier
+initialization, continuation metadata, public mirroring, and temporary scoring
+reference cleanup are recorded as replayable steps so a restart can complete
+publication without repeating scientific judgment.
+
+## AutoResearch Iterations
+
+After the root exists, every iteration follows the selected frontier node.
+
+### 1. Proposal generation
+
+The proposal worker receives the current idea, selected direction, accepted
+experiment plan, and relevant attempt history. It submits one complete proposal
+through `hitl-submit-proposal` and labels it as:
+
+- **exploitation**: improve an existing retained direction;
+- **exploration**: test a structurally different direction or assumption.
+
+The proposal must make one concrete experiment-stage change while preserving
+the research question and scoring protocol.
+
+### 2. Proposal admission
+
+The manager first checks only whether the proposal is legal under the scoring
+and experiment boundaries. It does not rewrite the method or treat legality as
+a recommendation.
+
+- An illegal proposal is rejected with a precise boundary correction. The
+  proposer creates a new proposal; the rejected proposal is not revised in
+  place.
+- A legal proposal is presented to the human for approval or concrete
+  feedback.
+
+### 3. Candidate execution and scoring
+
+The experiment worker plans and executes the admitted proposal. After manager
+approval of the completed execution, runtime checkpoints the exact reviewed
+workspace and runs the sealed scorer against that checkpoint.
+
+The manager receives the complete objective result and decides one action:
+
+- **accept**: retain the candidate in the frontier;
+- **reject**: restore the parent direction without retaining the candidate as
+  active;
+- **repair**: preserve the work and return targeted instructions to a
+  replacement worker.
+
+Runtime records and applies the manager's decision; it does not reinterpret the
+score.
+
+### 4. Frontier maintenance
+
+Accepting an exploitation candidate replaces its parent in that active
+direction. Accepting an exploration candidate retains both the parent and child
+as active directions. Rejected attempts remain in the audit history but are not
+active frontier nodes.
+
+The active frontier may contain at most 10 nodes. After a scored iteration,
+runtime opens a manager-only pruning boundary when the limit is exceeded, then
+opens a separate selection boundary. The selected active node becomes the
+workspace basis for the next proposal and is also the final selected result
+when the requested run ends.
+
+## Runtime Commands
+
+Workers interact with HITL through a small stage-specific command surface.
+Runtime exposes only commands legal for the current worker invocation and
+validates them again when called.
+
+| Command | Purpose | Blocking |
+| --- | --- | --- |
+| `hitl-report-idea` | Record material autonomous evidence or a decision | No |
+| `hitl-raise-idea` | Request manager or human resolution before continuing | Yes |
+| `hitl-finish-phase` | Submit a completed plan, execution, or review phase | Yes |
+| `hitl-submit-proposal` | Submit one AutoResearch proposal for admission | Yes |
+| `hitl-view-ideas` | Read finalized HITL ideas and their premises | No |
+| `view_current_frontier` | Read the selected frontier context during proposal generation | No |
+
+A provider process ending is not a completion signal. If a worker exits before
+the active command is resolved, runtime either reconnects a replacement worker
+to that durable request or rolls back the failed attempt. The overall stage
+advances only after the required response and durable transition exist.
+
+## Ideas and Decision Levels
+
+The append-only HITL idea log records consequential evidence, decisions, and
+AutoResearch proposals. Each record has a runtime-assigned ID such as `I17` and
+may cite earlier finalized records as premises. Premises always point backward,
+so the idea graph remains acyclic.
+
+| Level | Final actor | Meaning |
+| --- | --- | --- |
+| C | Worker | Autonomous evidence or a decision the worker can record and continue from |
+| B | Manager | A manager resolution or strategic decision based on the plan and available evidence |
+| A | Human | A decision that depends on human intent, preference, access, scope, or risk tolerance |
+
+Evidence may begin a new lineage without a premise. Decisions require at least
+one finalized premise. Runtime validates identifiers, actor/level alignment,
+option structure, provenance, and artifact paths before appending a record.
+
+The idea log is the authority for the idea graph. The web page and manager world
+model are projections that can be rebuilt from it.
+
+## Manager and Human Conversation
+
+The HITL manager is long-running and workspace-specific. It maintains:
+
+- one chronological conversation for human messages, manager replies, tool
+  calls, and tool results;
+- a compact active context for the next provider turn;
+- a complete raw archive and bounded full-text recall index;
+- a structured research projection built from authoritative HITL sources.
+
+Ordinary manager replies are direct assistant text. They do not require a tool
+and do not release a runtime-held worker request.
+
+When a worker request requires human input, the manager calls `ask_human` with a
+question and options. The request is rendered once as a manager conversation
+item. Runtime records the explicit human reply, returns it to the manager, and
+requires the manager to preserve that raw reply while translating it into
+worker-facing instructions.
+
+Only the finalizer authorized for the current boundary can release a held
+request. For example, initial scoring uses `finalize_worker_request`, while a
+candidate frontier decision uses `finalize_frontier_decision`.
+
+### Manager tool isolation
+
+Codex and Claude use the same runtime-owned manager tool contract. Runtime
+derives the allowed tools for each turn, exposes that subset through a local
+authenticated MCP bridge, and validates each call before execution. The manager
+never receives unrestricted access to runtime state.
+
+The human may switch the manager provider between Codex and Claude. One manager
+turn has one provider; the two providers are not combined as simultaneous
+manager backbones.
+
+## Scoring and Integrity Boundary
+
+The rule maker establishes the evaluator authority once. Runtime seals:
+
+- `scoring/eval.py`;
+- `scoring/targets.json`;
+- `scoring/rule_maker_log.md`, when present;
+- declared private evaluator inputs under `data/.test/`.
+
+The sealed payload receives an integrity manifest. Experiment workers cannot
+replace it with candidate-authored scoring files.
+
+For each scoring attempt, runtime:
+
+1. verifies the reviewed public-workspace fingerprint;
+2. creates an immutable source checkpoint;
+3. creates a private detached Git worktree;
+4. restores only the sealed evaluator payload and the workspace's public
+   datasets;
+5. uses the candidate workspace's configured `.venv` so task dependencies are
+   available;
+6. runs the scorer and commits `scoring/results.json` in the private worktree;
+7. publishes an integrity-checked review copy to the public workspace;
+8. gives the manager the complete scorer result and checkpoint provenance.
+
+The public `scoring/results.json` is a review artifact, not the scoring
+authority. Runtime owns evaluator transport and integrity; the manager owns the
+meaning of the result.
+
+## Durable State and Recovery
+
+HITL control state lives under `.neurico/hitl/` and is separate from ordinary
+AutoResearch state.
+
+| Path | Purpose |
+| --- | --- |
+| `.neurico/hitl/runtime.json` | Current worker request, continuation, manager boundary, and replayable transitions |
+| `.neurico/hitl/idea/idea.jsonl` | Append-only finalized idea audit log |
+| `.neurico/hitl/autoresearch_state.json` | Selected node, active frontier, and continuation metadata |
+| `.neurico/hitl/nodes/` | Accepted nodes, saved plans, and immutable attempt records |
+| `.neurico/hitl/manager/context.jsonl` | Active chronological manager context |
+| `.neurico/hitl/manager/history.sqlite` | Complete manager archive and recall index |
+| `.neurico/hitl/manager/inbox.json` | Durable queued human conversation input |
+| `.neurico/hitl/whiteboard/whiteboard.json` | Cross-attempt research lessons |
+| `.neurico/research_state.json` | Rebuildable manager research projection and synthesis |
+
+Public workspace checkpoints intentionally represent research artifacts, not
+all hidden control state. Runtime therefore stores matching `.neurico/hitl`
+snapshots in private Git refs. A failed attempt can restore both the public
+workspace and the corresponding manager/runtime state; an intentionally
+rejected candidate restores the parent workspace while preserving the new audit
+record.
+
+Recovery distinguishes several cases:
+
+- an unresolved worker command is resumed by a replacement worker;
+- finalized feedback is replayed until the worker consumes it;
+- an interrupted scoring handoff resumes from its saved fingerprint and
+  checkpoint;
+- an initial-root or frontier publication resumes its recorded transaction;
+- a failed pre-scoring attempt restores the selected parent and its matching
+  HITL snapshot.
+
+Private refs are local durability mechanisms. They are not ordinary research
+branches and are not pushed as part of normal GitHub publication.
+
+## Web Interface and Security
+
+The dedicated HITL web page is an artifact-driven projection of durable
+workspace state. Reloading the page does not create a new conversation or
+request. Server-sent events provide refresh hints; the browser then reads a
+complete snapshot.
+
+The local server uses:
+
+- a random token in the printed bootstrap URL;
+- an HTTP-only, same-site session cookie after bootstrap;
+- same-origin validation for state-changing requests;
+- a content security policy;
+- bounded request bodies and bounded manager inbox entries;
+- a cross-process workspace run lock.
+
+The server binds to loopback by default. Container mode may bind to `0.0.0.0`
+only when explicitly configured behind a loopback Docker publish.
+
+## Failure Behavior
+
+HITL is designed to fail closed at workflow boundaries:
+
+- invalid worker commands return a correction and keep the current phase open;
+- manager prose cannot substitute for a required finalizer;
+- a scorer exception becomes manager-visible score evidence or a repair request,
+  rather than an automatic scientific rejection;
+- a disconnected HTTP client does not invalidate an already persisted command;
+- manager backend retries are bounded; exhausted provider failures cancel the
+  held request and roll back the affected attempt instead of relaunching workers
+  forever;
+- recoverable HITL attempt relaunches remain unbounded so a worker failure does
+  not impose an arbitrary research-attempt limit.
+
+HITL commands and file guards are application-level controls. Running workers
+with full local permissions is not an operating-system sandbox.
+
+## Relationship to Other NeuriCo Modes
+
+| Mode | Control model | Scored iteration model |
+| --- | --- | --- |
+| Standard research | Multi-agent pipeline with ordinary stage completion | No iterative frontier |
+| AutoResearch | Automated proposal, execution, scoring, and current-best comparison | Single current-best lineage |
+| HITL AutoResearch | Runtime-mediated workers, durable manager/human conversation, isolated scoring, and manager-owned frontier decisions | Multi-node active frontier |
+| Interactive mode | Human conversation with the ordinary interactive manager | Separate from the HITL runtime |
+
+HITL keeps a separate control path so its durability and authority rules do not
+change ordinary NeuriCo behavior.
+
+## Implementation Map
+
+The main implementation entry points are:
+
+| Area | Module |
+| --- | --- |
+| Web entry and automatic fresh/continue detection | `src/cli/hitl_web.py` |
+| Shared runner integration | `src/core/runner.py` |
+| Worker command runtime and idea log | `src/core/hitl.py` |
+| Initial root and iterative frontier workflow | `src/core/hitl_autoresearch.py` |
+| Long-running manager and MCP tool policy | `src/core/hitl_manager_react.py` |
+| Durable worker requests and transitions | `src/core/hitl_runtime_state.py` |
+| Frontier nodes, attempts, pruning, and selection | `src/core/hitl_frontier.py` |
+| Private HITL Git snapshots | `src/core/hitl_git_state.py` |
+| Isolated scorer worktrees | `src/core/hitl_scoring_workspace.py` |
+| Workspace validation and inspection | `src/core/hitl_workspace_guard.py`, `src/core/hitl_workspace_inspection.py` |
+| Manager conversation, history, and inbox | `src/core/hitl_manager_context.py`, `src/core/hitl_manager_history.py`, `src/core/hitl_manager_inbox.py` |
+| Dedicated web server and workspace projection | `src/interactive/hitl_web_server.py`, `src/core/hitl_workspace_view.py` |
+
+The behavioral contracts supplied to workers and the manager live under
+`templates/hitl/`. Those templates define how agents use the runtime protocol;
+the Python runtime remains authoritative for validation and state transitions.

--- a/src/agents/rule_maker.py
+++ b/src/agents/rule_maker.py
@@ -11,6 +11,7 @@ scoring/. The harness consists of:
 - scoring/interface.md: visible to the experiment_runner -- describes what
   files the runner must produce and how they will be invoked.
 - scoring/rule_maker_log.md: rationale for the chosen metrics.
+- data/.test/: optional evaluator-owned private inputs declared by targets.json.
 
 This agent runs between resource_finder and experiment_runner. Its outputs
 should be sealed (read-only) before experiment_runner starts so the runner
@@ -25,6 +26,7 @@ import sys
 import time
 import json
 import ast
+import stat
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -46,6 +48,101 @@ RULE_MAKER_OUTPUT_FILES = {
 _DISALLOWED_EVALUATOR_CLI_MODULES = {"argparse", "click", "docopt", "typer"}
 _EVALUATOR_RESULTS_PATH = f"scoring/{RESULTS_FILE_NAME}"
 _EVALUATOR_OWNED_INTERFACE_PREFIXES = ("scoring/", "data/.test/")
+_SEALED_INPUTS_FIELD = "sealed_inputs"
+
+
+def _validate_declared_sealed_inputs(
+    work_dir: Path,
+    targets: Dict[str, Any],
+) -> list[str]:
+    """Validate the rule-maker-owned private inputs before runtime seals them."""
+    declared = targets.get(_SEALED_INPUTS_FIELD)
+    if not isinstance(declared, list):
+        return [
+            "scoring/targets.json must declare `sealed_inputs` as a list; "
+            "use an empty list when the evaluator needs no private inputs."
+        ]
+
+    issues: list[str] = []
+    seen: set[str] = set()
+    root = Path(work_dir).resolve()
+    for index, raw_path in enumerate(declared):
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            issues.append(f"sealed_inputs[{index}] must be a non-empty workspace-relative path.")
+            continue
+        normalized = raw_path.strip().replace("\\", "/")
+        candidate = Path(normalized)
+        if (
+            candidate.is_absolute()
+            or ".." in candidate.parts
+            or len(candidate.parts) < 3
+            or candidate.parts[:2] != ("data", ".test")
+        ):
+            issues.append(
+                f"sealed input `{normalized}` must be a file under `data/.test/`."
+            )
+            continue
+        relative = candidate.as_posix()
+        if relative in seen:
+            issues.append(f"sealed input `{relative}` is declared more than once.")
+            continue
+        seen.add(relative)
+
+        current = root
+        missing = False
+        for part in candidate.parts:
+            current = current / part
+            try:
+                metadata = current.lstat()
+            except FileNotFoundError:
+                issues.append(f"declared sealed input is missing: {relative}")
+                missing = True
+                break
+            except OSError as exc:
+                issues.append(f"declared sealed input is unreadable: {relative}: {exc}")
+                missing = True
+                break
+            if stat.S_ISLNK(metadata.st_mode):
+                issues.append(f"declared sealed input cannot contain a symlink: {relative}")
+                missing = True
+                break
+        if missing:
+            continue
+        if not stat.S_ISREG(metadata.st_mode):
+            issues.append(f"declared sealed input must be a regular file: {relative}")
+        elif metadata.st_size == 0:
+            issues.append(f"declared sealed input must not be empty: {relative}")
+
+    private_root = root / "data" / ".test"
+    try:
+        private_metadata = private_root.lstat()
+    except FileNotFoundError:
+        return issues
+    except OSError as exc:
+        issues.append(f"private evaluator input directory is unreadable: {exc}")
+        return issues
+    if stat.S_ISLNK(private_metadata.st_mode):
+        issues.append("private evaluator input directory cannot be a symlink: data/.test")
+        return issues
+    if not stat.S_ISDIR(private_metadata.st_mode):
+        issues.append("private evaluator input root must be a directory: data/.test")
+        return issues
+
+    actual_files: set[str] = set()
+    for path in private_root.rglob("*"):
+        relative = path.relative_to(root).as_posix()
+        try:
+            metadata = path.lstat()
+        except OSError as exc:
+            issues.append(f"private evaluator input is unreadable: {relative}: {exc}")
+            continue
+        if stat.S_ISLNK(metadata.st_mode):
+            issues.append(f"private evaluator input cannot contain a symlink: {relative}")
+        elif stat.S_ISREG(metadata.st_mode):
+            actual_files.add(relative)
+    for relative in sorted(actual_files - seen):
+        issues.append(f"private evaluator input is not declared in sealed_inputs: {relative}")
+    return issues
 
 
 def _assigned_expressions(tree: ast.AST) -> dict[str, ast.AST]:
@@ -534,6 +631,7 @@ def validate_rule_maker_outputs(work_dir: Path) -> Dict[str, Any]:
     Checks:
       - scoring/eval.py exists and parses as valid Python
       - scoring/targets.json exists and parses as valid JSON
+      - targets.json declares every private evaluator input and each file exists
       - scoring/interface.md exists and is non-empty
       - scoring/rule_maker_log.md exists (informational; not required)
 
@@ -565,18 +663,22 @@ def validate_rule_maker_outputs(work_dir: Path) -> Dict[str, Any]:
     else:
         try:
             targets = json.loads(targets_path.read_text(encoding="utf-8"))
-            declared_result = (
-                str(targets.get("result_file", "")).strip().replace("\\", "/")
-                if isinstance(targets, dict)
-                else ""
-            )
-            if declared_result and declared_result != _EVALUATOR_RESULTS_PATH:
-                issues.append(
-                    "scoring/targets.json declares a conflicting result_file; "
-                    f"the evaluator ABI requires `{_EVALUATOR_RESULTS_PATH}`."
-                )
+            if not isinstance(targets, dict):
+                issues.append("scoring/targets.json must contain a JSON object.")
             else:
-                found["targets"] = str(targets_path)
+                target_issues = _validate_declared_sealed_inputs(work_dir, targets)
+                declared_result = (
+                    str(targets.get("result_file", "")).strip().replace("\\", "/")
+                )
+                if declared_result and declared_result != _EVALUATOR_RESULTS_PATH:
+                    target_issues.append(
+                        "scoring/targets.json declares a conflicting result_file; "
+                        f"the evaluator ABI requires `{_EVALUATOR_RESULTS_PATH}`."
+                    )
+                if target_issues:
+                    issues.extend(target_issues)
+                else:
+                    found["targets"] = str(targets_path)
         except json.JSONDecodeError as e:
             issues.append(f"targets.json is not valid JSON: {e}")
 

--- a/src/agents/rule_maker.py
+++ b/src/agents/rule_maker.py
@@ -48,6 +48,7 @@ RULE_MAKER_OUTPUT_FILES = {
 _DISALLOWED_EVALUATOR_CLI_MODULES = {"argparse", "click", "docopt", "typer"}
 _EVALUATOR_RESULTS_PATH = f"scoring/{RESULTS_FILE_NAME}"
 _EVALUATOR_OWNED_INTERFACE_PREFIXES = ("scoring/", "data/.test/")
+_POST_RESEARCH_ARTIFACT_PREFIXES = ("paper/", "paper_draft/")
 _SEALED_INPUTS_FIELD = "sealed_inputs"
 
 
@@ -631,7 +632,6 @@ def validate_rule_maker_outputs(work_dir: Path) -> Dict[str, Any]:
     Checks:
       - scoring/eval.py exists and parses as valid Python
       - scoring/targets.json exists and parses as valid JSON
-      - targets.json declares every private evaluator input and each file exists
       - scoring/interface.md exists and is non-empty
       - scoring/rule_maker_log.md exists (informational; not required)
 
@@ -663,22 +663,18 @@ def validate_rule_maker_outputs(work_dir: Path) -> Dict[str, Any]:
     else:
         try:
             targets = json.loads(targets_path.read_text(encoding="utf-8"))
-            if not isinstance(targets, dict):
-                issues.append("scoring/targets.json must contain a JSON object.")
-            else:
-                target_issues = _validate_declared_sealed_inputs(work_dir, targets)
-                declared_result = (
-                    str(targets.get("result_file", "")).strip().replace("\\", "/")
+            declared_result = (
+                str(targets.get("result_file", "")).strip().replace("\\", "/")
+                if isinstance(targets, dict)
+                else ""
+            )
+            if declared_result and declared_result != _EVALUATOR_RESULTS_PATH:
+                issues.append(
+                    "scoring/targets.json declares a conflicting result_file; "
+                    f"the evaluator ABI requires `{_EVALUATOR_RESULTS_PATH}`."
                 )
-                if declared_result and declared_result != _EVALUATOR_RESULTS_PATH:
-                    target_issues.append(
-                        "scoring/targets.json declares a conflicting result_file; "
-                        f"the evaluator ABI requires `{_EVALUATOR_RESULTS_PATH}`."
-                    )
-                if target_issues:
-                    issues.extend(target_issues)
-                else:
-                    found["targets"] = str(targets_path)
+            else:
+                found["targets"] = str(targets_path)
         except json.JSONDecodeError as e:
             issues.append(f"targets.json is not valid JSON: {e}")
 
@@ -699,13 +695,26 @@ def validate_rule_maker_outputs(work_dir: Path) -> Dict[str, Any]:
                 for artifact in artifacts
                 if artifact.path.startswith(_EVALUATOR_OWNED_INTERFACE_PREFIXES)
             ]
+            post_research = [
+                artifact.path
+                for artifact in artifacts
+                if artifact.path.startswith(_POST_RESEARCH_ARTIFACT_PREFIXES)
+            ]
             if evaluator_owned:
                 issues.append(
                     "scoring/interface.md assigns evaluator-owned paths to the "
                     "experiment runner: "
                     + ", ".join(evaluator_owned)
                 )
-            else:
+            if post_research:
+                issues.append(
+                    "scoring/interface.md assigns post-research paper outputs to "
+                    "the experiment runner: "
+                    + ", ".join(post_research)
+                    + ". Paper artifacts belong to the later paper_writer stage "
+                    "and cannot be scoring inputs."
+                )
+            if not evaluator_owned and not post_research:
                 found["interface"] = str(interface_path)
         except (OSError, HitlValidationError) as exc:
             issues.append(f"invalid artifact contract in {interface_path}: {exc}")
@@ -719,6 +728,29 @@ def validate_rule_maker_outputs(work_dir: Path) -> Dict[str, Any]:
         "found": found,
         "issues": issues,
     }
+
+
+def validate_hitl_rule_maker_outputs(work_dir: Path) -> Dict[str, Any]:
+    """Apply the HITL-only private evaluator input contract."""
+    validation = validate_rule_maker_outputs(work_dir)
+    found = dict(validation["found"])
+    issues = list(validation["issues"])
+    targets_path = Path(work_dir) / "scoring" / RULE_MAKER_OUTPUT_FILES["targets"]
+
+    try:
+        targets = json.loads(targets_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"valid": False, "found": found, "issues": issues}
+
+    target_issues = (
+        ["scoring/targets.json must contain a JSON object."]
+        if not isinstance(targets, dict)
+        else _validate_declared_sealed_inputs(Path(work_dir), targets)
+    )
+    issues.extend(target_issues)
+    if target_issues:
+        found.pop("targets", None)
+    return {"valid": len(issues) == 0, "found": found, "issues": issues}
 
 
 def load_interface_for_runner(work_dir: Path) -> str:

--- a/src/core/hitl.py
+++ b/src/core/hitl.py
@@ -1459,6 +1459,14 @@ class HitlRuntime:
             return self.log.append(record)
 
     def submit_proposal_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._worker_request_lock.acquire(blocking=False):
+            raise HitlActiveWorkerRequestError(self._pending_worker_command())
+        try:
+            return self._submit_proposal_payload_locked(payload)
+        finally:
+            self._worker_request_lock.release()
+
+    def _submit_proposal_payload_locked(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         with self._tool_lock:
             validator = self._tool_context.get("proposal_submission_validator")
             if callable(validator):
@@ -2180,11 +2188,22 @@ class HitlRuntime:
             "Runtime scoring repair response",
         )
         pending = self._pending_worker_command()
-        request_key = str((pending or {}).get("request_key", "")).strip()
-        if not request_key:
+        manager_request_key = str((pending or {}).get("request_key", "")).strip()
+        if not manager_request_key:
             raise HitlValidationError(
                 "Runtime scoring repair has no pending phase-finish request to resume."
             )
+        request_key = self._phase_finish_request_key_for(
+            hitl_stage=str((pending or {}).get("hitl_stage", "")).strip(),
+            plan_fingerprint=str((pending or {}).get("plan_fingerprint", "")).strip(),
+            workspace_fingerprint=str(
+                (pending or {}).get("workspace_fingerprint", "")
+            ).strip(),
+            summary=str((pending or {}).get("finish_summary", "")).strip(),
+            related_artifacts=_as_related_artifacts(
+                (pending or {}).get("related_artifacts")
+            ),
+        )
         prompt_block = self.compose_worker_prompt(
             hitl_stage="review",
             phase_prompt=self.review_prompt_block(feedback),
@@ -2403,15 +2422,24 @@ class HitlRuntime:
         try:
             handler(approval)
         except Exception as exc:
-            self.manager.resume_worker_request(
-                prompt=_load_hitl_template(
-                    "manager_runtime_scoring_failure.txt",
-                    error=str(exc),
-                ),
-                validate=self._validate_runtime_scoring_failure,
-                finalize=finalize_failure,
-                manager_review_kind="scoring_failure",
-            )
+            pending = self._pending_worker_command()
+            if isinstance(pending, dict) and pending.get("status") == "cancelled":
+                return
+            try:
+                self.manager.resume_worker_request(
+                    prompt=_load_hitl_template(
+                        "manager_runtime_scoring_failure.txt",
+                        error=str(exc),
+                    ),
+                    validate=self._validate_runtime_scoring_failure,
+                    finalize=finalize_failure,
+                    manager_review_kind="scoring_failure",
+                )
+            except Exception:
+                pending = self._pending_worker_command()
+                if isinstance(pending, dict) and pending.get("status") == "cancelled":
+                    return
+                raise
 
     def _finalize_resumed_scoring_failure(
         self,
@@ -2648,6 +2676,19 @@ class HitlRuntime:
 
     def _finish_tool_phase_locked(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         with self._tool_lock:
+            pending = self._pending_worker_command()
+            if (
+                isinstance(pending, dict)
+                and pending.get("kind") == "phase_finish"
+                and pending.get("status") == "cancelled"
+            ):
+                from core.hitl_runtime_state import HitlRuntimeStateError
+
+                reason = str(pending.get("cancellation_reason", "")).strip()
+                raise HitlRuntimeStateError(
+                    "Runtime cancelled the held worker command while rolling back its failed attempt."
+                    + (f" {reason}" if reason else "")
+                )
             terminal_response = self._terminal_phase_finish_response()
             if terminal_response is not None:
                 return terminal_response
@@ -2852,6 +2893,11 @@ class HitlRuntime:
                 on_finalize=persist_phase_review,
                 on_scoring_approval=persist_scoring_approval,
             )
+            if (
+                self._phase_finish_request_key == request_key
+                and isinstance(self._phase_finish_response, dict)
+            ):
+                return dict(self._phase_finish_response)
             status = str(review.get("status", "")).strip()
             if status == "feedback":
                 logged = finalized.get("record")

--- a/src/core/hitl.py
+++ b/src/core/hitl.py
@@ -1345,6 +1345,63 @@ class HitlRuntime:
         response = pending.get("response")
         return dict(response) if isinstance(response, dict) else None
 
+    def _pending_worker_request_replacement(
+        self,
+        *,
+        phase: str,
+        worker_name: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Reconnect a replacement worker to one durable held command."""
+        from core.hitl_runtime_state import HitlRuntimeState, worker_command_requires_resume
+
+        state = HitlRuntimeState(self.work_dir)
+        pending = state.pending_worker_command()
+        continuation = state.worker_continuation()
+        if not worker_command_requires_resume(pending) or not isinstance(continuation, dict):
+            return None
+        if not str(continuation.get("prompt_block", "")).strip():
+            return None
+
+        prompt_block = _load_hitl_template("worker_resume_pending_request.txt")
+        self._update_worker_continuation(
+            prompt_block=prompt_block,
+            hitl_stage=str(continuation.get("hitl_stage", "")).strip() or None,
+            status="replacement_pending",
+        )
+        state.mark_worker_replacement()
+        self._enable_worker_command("hitl-resume-worker-request")
+        return {
+            "status": "replacement",
+            "approved": False,
+            "replacement": True,
+            "prompt_block": prompt_block,
+            "phase": phase,
+            "worker_exit_warning": (
+                f"{worker_name} exited while a runtime-held request still required replay. "
+                "Runtime terminated its remaining processes and will reconnect a "
+                "replacement worker to the preserved request."
+            ),
+        }
+
+    def _join_live_worker_request_handler(self, *, expected_kind: str) -> bool:
+        """Wait for the in-process owner of a durable worker request."""
+        from core.hitl_runtime_state import HitlRuntimeState
+
+        pending = HitlRuntimeState(self.work_dir).pending_worker_command()
+        if (
+            not isinstance(pending, dict)
+            or str(pending.get("kind", "")).strip() != expected_kind
+            or not self._worker_request_lock.locked()
+        ):
+            return False
+
+        # The HTTP handler owns this lock across manager/human review and all
+        # runtime transition work. Joining it preserves the single ordered
+        # completion path when the provider exits before its command child.
+        self._worker_request_lock.acquire()
+        self._worker_request_lock.release()
+        return True
+
     def idea_tool_env(self, base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
         env = dict(base_env or os.environ)
         env["PYTHONUNBUFFERED"] = "1"
@@ -1665,6 +1722,7 @@ class HitlRuntime:
         *,
         worker_name: str,
     ) -> Dict[str, Any]:
+        self._join_live_worker_request_handler(expected_kind="proposal")
         cancelled = self._cancelled_worker_command_result(
             result,
             phase="proposal",
@@ -1674,16 +1732,6 @@ class HitlRuntime:
             return cancelled
         submitted = self._proposal_submit_result
         if submitted and submitted.get("status") == "approved":
-            if result.get("background_processes_terminated"):
-                return {
-                    "success": False,
-                    "hitl": True,
-                    "phase": "proposal",
-                    "error": (
-                        f"{worker_name} left background processes after proposal admission. "
-                        "Runtime terminated them and discarded the proposal admission."
-                    ),
-                }
             validator = self._tool_context.get("proposal_submission_validator")
             if callable(validator):
                 validation = validator()
@@ -1738,6 +1786,24 @@ class HitlRuntime:
                 "error": (
                     f"{worker_name} exited after proposal feedback, but runtime has no "
                     "continuation prompt to launch safely."
+                ),
+            }
+        pending_replacement = self._pending_worker_request_replacement(
+            phase="proposal",
+            worker_name=worker_name,
+        )
+        if pending_replacement is not None:
+            return pending_replacement
+        if result.get("background_processes_terminated"):
+            return {
+                **result,
+                "success": False,
+                "hitl": True,
+                "phase": "proposal",
+                "error": (
+                    f"{worker_name} left background processes without a durable "
+                    "proposal decision or resumable request. Runtime terminated them "
+                    "and will not advance proposal admission."
                 ),
             }
         continuation = HitlRuntime.worker_continuation(self)
@@ -2453,12 +2519,35 @@ class HitlRuntime:
         request_key = str(pending.get("request_key", "")).strip()
         if not request_key:
             raise HitlValidationError("Pending HITL worker request has no request key.")
+        kind = str(pending.get("kind", "")).strip()
         if pending.get("status") == "resolved":
             response = pending.get("response")
             if not isinstance(response, dict):
                 raise HitlValidationError("Resolved HITL worker request has no runtime response.")
+            if (
+                kind == "phase_finish"
+                and str(response.get("status", "")).strip() == "feedback"
+                and not str(response.get("feedback", "")).strip()
+            ):
+                return self._normalize_phase_finish_feedback(
+                    request_key=request_key,
+                    hitl_stage=_require_text(
+                        pending.get("hitl_stage"),
+                        "hitl_stage",
+                        "Resolved HITL phase-finish request",
+                    ),
+                    plan_fingerprint=str(pending.get("plan_fingerprint", "")).strip(),
+                    workspace_fingerprint=str(
+                        pending.get("workspace_fingerprint", "")
+                    ).strip(),
+                    summary=str(pending.get("finish_summary", "")).strip(),
+                    related_artifacts=_as_related_artifacts(
+                        pending.get("related_artifacts")
+                    ),
+                    review=response,
+                    record=response.get("record"),
+                )
             return dict(response)
-        kind = str(pending.get("kind", "")).strip()
         if kind == "phase_finish":
             from core.hitl_runtime_state import MANAGER_REVIEW_FINALIZERS
 
@@ -2765,101 +2854,18 @@ class HitlRuntime:
             )
             status = str(review.get("status", "")).strip()
             if status == "feedback":
-                human_resolved_plan = bool(
-                    hitl_stage == "plan"
-                    and self._tool_context.get("requires_human_approval")
-                    and str(review.get("human_feedback", "")).strip()
-                )
-                if human_resolved_plan:
-                    feedback = _require_text(
-                        review.get("manager_feedback"),
-                        "manager_feedback",
-                        "Manager translation of human plan feedback",
-                    )
-                    logged = finalized.get("record")
-                    if not logged:
-                        raise RuntimeError(
-                            "Human plan feedback was finalized without an audit record."
-                        )
-                    self._phase_finish_result = {
-                        "called": True,
-                        "status": "feedback",
-                        "hitl_stage": hitl_stage,
-                        "plan_fingerprint": plan_fingerprint,
-                        "workspace_fingerprint": workspace_fingerprint,
-                        "summary": summary,
-                        "related_artifacts": related_artifacts,
-                        "manager_feedback": feedback,
-                        "context": str(review.get("context", "")),
-                        "record": logged,
-                        "next_phase": "plan",
-                        "final": False,
-                    }
-                    return self._remember_phase_finish_response(
-                        request_key,
-                        {
-                            "status": "feedback",
-                            "feedback": feedback,
-                            "next_phase": "plan",
-                            "instruction": (
-                                "Apply this plan feedback, update the living plan, then "
-                                "call hitl-finish-phase again."
-                            ),
-                            "prompt_block": self.compose_worker_prompt(
-                                hitl_stage="plan",
-                                phase_prompt=self.plan_revision_prompt_block(feedback),
-                            ),
-                            "record": logged,
-                        },
-                    )
-                feedback = _require_text(
-                    review.get("manager_feedback"),
-                    "manager_feedback",
-                    "Manager phase finish review with status='feedback'",
-                )
-                next_phase = "review" if hitl_stage == "execution" else hitl_stage
-                prompt_block = self._finish_feedback_prompt_block(
-                    hitl_stage=next_phase,
-                    feedback=feedback,
-                )
-                if next_phase != hitl_stage:
-                    self.transition_worker_stage(next_phase, prompt_block=prompt_block)
-                else:
-                    self._update_worker_continuation(
-                        prompt_block=prompt_block,
-                        hitl_stage=next_phase,
-                        status="running",
-                    )
                 logged = finalized.get("record")
                 if not logged:
                     raise RuntimeError("Manager feedback was finalized without an audit record.")
-                self._phase_finish_result = {
-                    "called": True,
-                    "status": "feedback",
-                    "hitl_stage": next_phase,
-                    "plan_fingerprint": plan_fingerprint,
-                    "workspace_fingerprint": workspace_fingerprint,
-                    "summary": summary,
-                    "related_artifacts": related_artifacts,
-                    "manager_feedback": feedback,
-                    "context": str(review.get("context", "")),
-                    "record": logged,
-                    "next_phase": next_phase,
-                    "final": False,
-                }
-                return self._remember_phase_finish_response(
-                    request_key,
-                    {
-                        "status": "feedback",
-                        "feedback": feedback,
-                        "next_phase": next_phase,
-                        "instruction": (
-                            "Apply this feedback in the current phase, update the living "
-                            "plan/current artifacts, then call hitl-finish-phase again."
-                        ),
-                        "prompt_block": prompt_block,
-                        "record": logged,
-                    },
+                return self._normalize_phase_finish_feedback(
+                    request_key=request_key,
+                    hitl_stage=hitl_stage,
+                    plan_fingerprint=plan_fingerprint,
+                    workspace_fingerprint=workspace_fingerprint,
+                    summary=summary,
+                    related_artifacts=related_artifacts,
+                    review=review,
+                    record=logged,
                 )
 
             if status != "approved":
@@ -2964,6 +2970,7 @@ class HitlRuntime:
         live tool-server and request state and gives a continuation worker the runtime
         prompt that the lost worker should have continued from.
         """
+        self._join_live_worker_request_handler(expected_kind="phase_finish")
         cancelled = self._cancelled_worker_command_result(
             result,
             phase=phase,
@@ -2971,14 +2978,6 @@ class HitlRuntime:
         )
         if cancelled is not None:
             return cancelled
-        if result.get("background_processes_terminated"):
-            return {
-                "approved": False,
-                "error": (
-                    f"{worker_name} left background processes after its provider exited. "
-                    "Runtime terminated them and will not accept or score this workspace."
-                ),
-            }
         finish = self.phase_finish_result()
         resolved = self.resolved_worker_response()
         if resolved and (
@@ -3010,22 +3009,32 @@ class HitlRuntime:
                 ),
             }
 
+        pending_replacement = self._pending_worker_request_replacement(
+            phase=phase,
+            worker_name=worker_name,
+        )
+        if pending_replacement is not None:
+            return pending_replacement
+        if result.get("background_processes_terminated") and finish is None and resolved is None:
+            return {
+                **result,
+                "approved": False,
+                "success": False,
+                "hitl": True,
+                "phase": phase,
+                "error": (
+                    f"{worker_name} left background processes without a durable "
+                    "HITL result or resumable request. Runtime terminated them and "
+                    "will not accept or score this workspace."
+                ),
+            }
+
         continuation = self.worker_continuation()
         if continuation is not None:
             prompt_block = str(
                 (finish or {}).get("prompt_block") or continuation.get("prompt_block", "")
             ).strip()
             if prompt_block:
-                pending = self._pending_worker_command()
-                needs_resume = isinstance(pending, dict) and pending.get("status") in {
-                    "pending",
-                    "scoring_approval_pending",
-                    "scoring",
-                }
-                if needs_resume:
-                    # A held command is runtime state, not continuation text.
-                    # The replacement must reconnect before changing the workspace.
-                    prompt_block = _load_hitl_template("worker_resume_pending_request.txt")
                 self._update_worker_continuation(
                     prompt_block=prompt_block,
                     hitl_stage=str(
@@ -3037,11 +3046,6 @@ class HitlRuntime:
                 from core.hitl_runtime_state import HitlRuntimeState
 
                 HitlRuntimeState(self.work_dir).mark_worker_replacement()
-                if needs_resume:
-                    # A replacement is the only worker that may reconnect to
-                    # a runtime-held command. Expose it immediately before the
-                    # replacement launch, never to the original invocation.
-                    self._enable_worker_command("hitl-resume-worker-request")
                 return {
                     "approved": False,
                     "replacement": True,
@@ -3083,6 +3087,81 @@ class HitlRuntime:
         else:
             phase_prompt = self.review_prompt_block(feedback)
         return self.compose_worker_prompt(hitl_stage=hitl_stage, phase_prompt=phase_prompt)
+
+    def _normalize_phase_finish_feedback(
+        self,
+        *,
+        request_key: str,
+        hitl_stage: str,
+        plan_fingerprint: str,
+        workspace_fingerprint: str,
+        summary: str,
+        related_artifacts: List[Dict[str, str]],
+        review: Dict[str, Any],
+        record: Any = None,
+    ) -> Dict[str, Any]:
+        """Convert a manager phase review into the worker-facing continuation."""
+        feedback = _require_text(
+            review.get("manager_feedback"),
+            "manager_feedback",
+            "Manager phase finish review with status='feedback'",
+        )
+        human_resolved_plan = bool(
+            hitl_stage == "plan" and str(review.get("human_feedback", "")).strip()
+        )
+        next_phase = "plan" if human_resolved_plan else (
+            "review" if hitl_stage == "execution" else hitl_stage
+        )
+        prompt_block = self._finish_feedback_prompt_block(
+            hitl_stage=next_phase,
+            feedback=feedback,
+        )
+        current_stage = str(
+            self._tool_context.get("hitl_stage", self.current_hitl_stage)
+        ).strip()
+        if next_phase != current_stage:
+            self.transition_worker_stage(next_phase, prompt_block=prompt_block)
+        else:
+            self._update_worker_continuation(
+                prompt_block=prompt_block,
+                hitl_stage=next_phase,
+                status="running",
+            )
+
+        normalized_record = dict(record) if isinstance(record, dict) else None
+        self._phase_finish_result = {
+            "called": True,
+            "status": "feedback",
+            "hitl_stage": next_phase,
+            "plan_fingerprint": plan_fingerprint,
+            "workspace_fingerprint": workspace_fingerprint,
+            "summary": summary,
+            "related_artifacts": related_artifacts,
+            "manager_feedback": feedback,
+            "context": str(review.get("context", "")),
+            "next_phase": next_phase,
+            "final": False,
+            **({"record": normalized_record} if normalized_record is not None else {}),
+        }
+        instruction = (
+            "Apply this plan feedback, update the living plan, then "
+            "call hitl-finish-phase again."
+            if human_resolved_plan
+            else (
+                "Apply this feedback in the current phase, update the living "
+                "plan/current artifacts, then call hitl-finish-phase again."
+            )
+        )
+        response = {
+            "status": "feedback",
+            "feedback": feedback,
+            "next_phase": next_phase,
+            "instruction": instruction,
+            "prompt_block": prompt_block,
+            "final": False,
+            **({"record": normalized_record} if normalized_record is not None else {}),
+        }
+        return self._remember_phase_finish_response(request_key, response)
 
     def _record_from_tool_payload(
         self,
@@ -3579,11 +3658,21 @@ class HitlRuntime:
 
             def _send_json(self, status: int, payload: Dict[str, Any]) -> None:
                 encoded = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-                self.send_response(status)
-                self.send_header("Content-Type", "application/json")
-                self.send_header("Content-Length", str(len(encoded)))
-                self.end_headers()
-                self.wfile.write(encoded)
+                try:
+                    self.send_response(status)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(encoded)))
+                    self.end_headers()
+                    self.wfile.write(encoded)
+                except (BrokenPipeError, ConnectionAbortedError, ConnectionResetError):
+                    # Runtime processing is already complete. A provider that
+                    # exits before its blocking command only loses delivery of
+                    # this response; durable state remains authoritative.
+                    self.close_connection = True
+                    LOGGER.info(
+                        "HITL runtime response client disconnected for %s",
+                        self.path,
+                    )
 
         server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), ToolHandler)
         thread = threading.Thread(target=server.serve_forever, daemon=True)

--- a/src/core/hitl_manager_react.py
+++ b/src/core/hitl_manager_react.py
@@ -424,6 +424,55 @@ class HitlManager:
         allowed = self._available_tool_names()
         return [tool for tool in self.tool_definitions if tool["name"] in allowed]
 
+    @classmethod
+    def _runtime_completion_tool_name(cls, tools: List[Dict[str, Any]]) -> str:
+        for tool in tools:
+            name = str(tool.get("name", "")).strip()
+            if name in cls._REQUEST_FINALIZER_TOOL_NAMES or name in {
+                "prune_frontier",
+                "select_frontier",
+            }:
+                return name
+        return ""
+
+    @classmethod
+    def _runtime_tool_boundary_instruction(cls, tools: List[Dict[str, Any]]) -> str:
+        """Describe the exact runtime-authorized MCP surface for one turn."""
+        names = [str(tool.get("name", "")).strip() for tool in tools]
+        names = [name for name in names if name]
+        rendered = ", ".join(f"`{name}`" for name in names) or "(none)"
+        lines = [
+            "Runtime-authorized MCP tool surface for this turn:",
+            rendered,
+            "This list is authoritative and these tools are supplied through MCP. "
+            "Do not claim that a listed tool is unavailable, and do not call tools "
+            "outside this list.",
+        ]
+        completion_name = cls._runtime_completion_tool_name(tools)
+        if completion_name:
+            lines.append(
+                "The current runtime-held action remains unresolved until "
+                f"`{completion_name}` succeeds. Direct assistant text does not "
+                "complete the action."
+            )
+        return "\n".join(lines)
+
+    def _unresolved_request_reminder(self) -> str:
+        """Return a boundary-specific reminder for a text-only manager turn."""
+        tools = self._tools_for_current_runtime_boundary()
+        completion_name = self._runtime_completion_tool_name(tools)
+        if completion_name:
+            return (
+                "The worker request remains unresolved. Continue reviewing or consult "
+                "the human as permitted, then call "
+                f"`{completion_name}`. Direct assistant text cannot complete it."
+            )
+        return (
+            "The worker request remains unresolved. Follow the exact "
+            "runtime-authorized MCP tool surface in the system instruction; direct "
+            "assistant text cannot complete it."
+        )
+
     def listed_workspace_artifacts(self) -> set[str]:
         """Return declared sealed evaluator files visible as metadata for review."""
         from core.scoring_seal import SEALED_PATHS
@@ -1733,7 +1782,7 @@ class HitlManager:
                     # abandoning the request after a text-only response.
                     reminder = _Turn(
                         "runtime",
-                        "The worker request remains unresolved. Use the available tools to inspect it, ask the human if needed, or finalize it with a valid runtime result.",
+                        self._unresolved_request_reminder(),
                         requires_worker_resolution=True,
                         generation=turn.generation,
                         request_key=turn.request_key,
@@ -1832,10 +1881,10 @@ class HitlManager:
                 if not self._generation_is_current(generation):
                     return ""
                 try:
-                    messages = self._messages(generation)
+                    tools = self._tools_for_current_runtime_boundary()
+                    messages = self._messages(generation, tools)
                 except _StaleManagerTurn:
                     return ""
-            tools = self._tools_for_current_runtime_boundary()
             response = self._send(messages, tools)
             with self._turn_lock:
                 if not self._generation_is_current(generation):
@@ -1868,7 +1917,11 @@ class HitlManager:
                         return ""
         return ""
 
-    def _messages(self, generation: int) -> List[Dict[str, Any]]:
+    def _messages(
+        self,
+        generation: int,
+        tools: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
         from core.hitl import _load_hitl_template
 
         self.world_model.reconcile(self.research)
@@ -1881,6 +1934,10 @@ class HitlManager:
             {
                 "role": "system",
                 "content": _load_hitl_template("interactive_manager_system.txt"),
+            },
+            {
+                "role": "system",
+                "content": self._runtime_tool_boundary_instruction(tools),
             },
             {
                 "role": "user",

--- a/src/core/hitl_manager_react.py
+++ b/src/core/hitl_manager_react.py
@@ -287,14 +287,6 @@ class HitlManager:
         self.max_backend_retries = max(
             1, int(config.get("manager", {}).get("hitl_manager_backend_retries", 3))
         )
-        self.backend_timeout_seconds = max(
-            0.01,
-            float(
-                config.get("manager", {}).get(
-                    "hitl_manager_backend_timeout_seconds", 120.0
-                )
-            ),
-        )
         self.backend_retry_delay_seconds = max(
             0.1,
             float(config.get("manager", {}).get("hitl_manager_retry_delay_seconds", 1.0)),
@@ -437,6 +429,17 @@ class HitlManager:
                 return name
         return ""
 
+    @staticmethod
+    def _scoring_handoff_instruction(tools: List[Dict[str, Any]]) -> str:
+        names = {str(tool.get("name", "")).strip() for tool in tools}
+        if {"approve_for_scoring", "finalize_worker_request"} <= names:
+            return (
+                "If the completed work is acceptable, call `approve_for_scoring`; "
+                "if revision is required, call `finalize_worker_request` with a "
+                "`feedback` result."
+            )
+        return ""
+
     @classmethod
     def _runtime_tool_boundary_instruction(cls, tools: List[Dict[str, Any]]) -> str:
         """Describe the exact runtime-authorized MCP surface for one turn."""
@@ -450,8 +453,16 @@ class HitlManager:
             "Do not claim that a listed tool is unavailable, and do not call tools "
             "outside this list.",
         ]
-        completion_name = cls._runtime_completion_tool_name(tools)
-        if completion_name:
+        scoring_handoff = cls._scoring_handoff_instruction(tools)
+        if scoring_handoff:
+            lines.append(
+                "The current runtime-held action remains unresolved. "
+                f"{scoring_handoff} Direct assistant text does not advance the action."
+            )
+        else:
+            completion_name = cls._runtime_completion_tool_name(tools)
+            if not completion_name:
+                return "\n".join(lines)
             lines.append(
                 "The current runtime-held action remains unresolved until "
                 f"`{completion_name}` succeeds. Direct assistant text does not "
@@ -462,6 +473,12 @@ class HitlManager:
     def _unresolved_request_reminder(self) -> str:
         """Return a boundary-specific reminder for a text-only manager turn."""
         tools = self._tools_for_current_runtime_boundary()
+        scoring_handoff = self._scoring_handoff_instruction(tools)
+        if scoring_handoff:
+            return (
+                "The worker request remains unresolved. "
+                f"{scoring_handoff} Direct assistant text cannot advance it."
+            )
         completion_name = self._runtime_completion_tool_name(tools)
         if completion_name:
             return (
@@ -646,6 +663,14 @@ class HitlManager:
                     f"Error: {tool_name} is unavailable for the current worker request. "
                     f"Use {expected}."
                 )
+            scoring_handoff = self._scoring_handoff_instruction(
+                self._tools_for_current_runtime_boundary()
+            )
+            if scoring_handoff:
+                return (
+                    f"Error: {tool_name} is unavailable for the current worker request. "
+                    f"{scoring_handoff}"
+                )
             return (
                 f"Error: {tool_name} is unavailable for the current worker request. "
                 "Use finalize_worker_request, or ask_human if human intent is required."
@@ -697,6 +722,9 @@ class HitlManager:
     def stop(self) -> None:
         self._stop.set()
         self._turns.put(_Turn("runtime", ""))
+        cancel_active = getattr(self.backend, "cancel_active", None)
+        if callable(cancel_active):
+            cancel_active()
         if self._thread is not None:
             self._thread.join(timeout=1)
         self._stop_cli_mcp_bridge()
@@ -1269,6 +1297,12 @@ class HitlManager:
         request_key = str(pending.get("request_key", "")).strip()
         if not request_key:
             raise HitlRuntimeStateError("Pending worker command is missing request_key.")
+        if pending.get("status") == "cancelled":
+            reason = str(pending.get("cancellation_reason", "")).strip()
+            raise HitlRuntimeStateError(
+                "Runtime cancelled the held worker command while rolling back its failed attempt."
+                + (f" {reason}" if reason else "")
+            )
         manager_finalizer = str(manager_finalizer).strip()
         if manager_finalizer not in self._REQUEST_FINALIZER_TOOL_NAMES:
             raise HitlRuntimeStateError(
@@ -1992,18 +2026,17 @@ class HitlManager:
                 return self._send_once(messages, tools, backend=backend)
             except Exception as exc:
                 last = exc
+                if self._stop.is_set():
+                    raise RuntimeError("HITL manager stopped during its provider turn.") from exc
                 if attempt + 1 < self.max_backend_retries:
-                    threading.Event().wait(self.backend_retry_delay_seconds)
+                    if self._stop.wait(self.backend_retry_delay_seconds):
+                        raise RuntimeError(
+                            "HITL manager stopped during its provider turn."
+                        ) from exc
         raise RuntimeError("Manager backend was unavailable") from last
 
     def _send_once(self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]], *, backend: Any = None) -> Any:
-        """Run one bounded manager provider turn.
-
-        ``LLMBackend`` receives the deadline directly and cancels its own CLI
-        process group or HTTP request. The short daemon wrapper remains only
-        for injected third-party/test backends that do not implement this
-        adapter contract.
-        """
+        """Run one manager provider turn without a wall-clock deadline."""
         result: "queue.Queue[tuple[bool, Any]]" = queue.Queue(maxsize=1)
 
         parameters: Dict[str, inspect.Parameter] = {}
@@ -2033,7 +2066,7 @@ class HitlManager:
             try:
                 if supports_adapter_contract:
                     kwargs: Dict[str, Any] = {
-                        "timeout_seconds": self.backend_timeout_seconds,
+                        "timeout_seconds": None,
                         "disable_native_tools": True,
                     }
                     if (
@@ -2060,13 +2093,7 @@ class HitlManager:
 
         thread = threading.Thread(target=call_backend, daemon=True)
         thread.start()
-        try:
-            succeeded, value = result.get(timeout=self.backend_timeout_seconds)
-        except queue.Empty as exc:
-            raise TimeoutError(
-                "HITL manager backend call timed out after "
-                f"{self.backend_timeout_seconds:g} seconds"
-            ) from exc
+        succeeded, value = result.get()
         if not succeeded:
             raise value
         return value

--- a/src/core/hitl_manager_react.py
+++ b/src/core/hitl_manager_react.py
@@ -249,6 +249,8 @@ class HitlManagerToolExecutor:
 class HitlManager:
     """One long-running, queued ReAct manager for an HITL workspace."""
 
+    _CLI_MCP_SERVER_NAME = "neurico_hitl_manager"
+
     def __init__(
         self,
         config: Dict[str, Any],
@@ -496,10 +498,10 @@ class HitlManager:
             if path.startswith("scoring/") and path in declared
         }
 
-    @staticmethod
-    def _mcp_allowed_tool_name(tool_name: str) -> str:
+    @classmethod
+    def _mcp_allowed_tool_name(cls, tool_name: str) -> str:
         """Return Claude Code's global name for one server-local MCP tool."""
-        return f"mcp__neurico_hitl_manager__{tool_name}"
+        return f"mcp__{cls._CLI_MCP_SERVER_NAME}__{tool_name}"
 
     def _uses_cli_mcp_bridge(self) -> bool:
         return getattr(self.backend, "backend", None) in {"cli", "codex_cli", "codex"}
@@ -560,7 +562,7 @@ class HitlManager:
         adapter = Path(__file__).with_name("hitl_manager_mcp.py")
         config = {
             "mcpServers": {
-                "neurico_hitl_manager": {
+                self._CLI_MCP_SERVER_NAME: {
                     "command": sys.executable,
                     "args": [str(adapter)],
                     "env": {

--- a/src/core/hitl_runtime_state.py
+++ b/src/core/hitl_runtime_state.py
@@ -218,6 +218,15 @@ class HitlRuntimeState:
             command = self._state.get("pending_worker_command")
             if not isinstance(command, dict) or command.get("request_key") != request_key:
                 raise HitlRuntimeStateError("No matching pending HITL worker command")
+            next_status = updates.get("status")
+            if (
+                command.get("status") == "cancelled"
+                and next_status is not None
+                and next_status != "cancelled"
+            ):
+                raise HitlRuntimeStateError(
+                    "A cancelled HITL worker command cannot return to an active state."
+                )
             command.update(self._copy(updates))
             command["updated_at"] = _now()
             self._save_unlocked()
@@ -229,6 +238,10 @@ class HitlRuntimeState:
             command = self._state.get("pending_worker_command")
             if not isinstance(command, dict) or command.get("request_key") != request_key:
                 raise HitlRuntimeStateError("No matching pending HITL worker command")
+            if command.get("status") == "cancelled":
+                raise HitlRuntimeStateError(
+                    "A cancelled HITL worker command cannot be completed."
+                )
             command["status"] = "resolved"
             command["response"] = self._copy(response)
             command["resolved_at"] = _now()

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -32,6 +32,7 @@ from agents.resource_finder import generate_resource_finder_prompt, run_resource
 from agents.rule_maker import (
     generate_rule_maker_prompt,
     run_rule_maker,
+    validate_hitl_rule_maker_outputs,
     validate_rule_maker_outputs,
 )
 from agents.rule_maker_bootstrap import run_bootstrap_rule_maker
@@ -1507,7 +1508,7 @@ class ResearchPipelineOrchestrator:
         )
 
         def rule_maker_artifact_validator() -> Dict[str, Any]:
-            validation = validate_rule_maker_outputs(self.work_dir)
+            validation = validate_hitl_rule_maker_outputs(self.work_dir)
             if not validation.get("valid"):
                 return validation
             try:

--- a/src/interactive/llm_backend.py
+++ b/src/interactive/llm_backend.py
@@ -13,6 +13,7 @@ import os
 from pathlib import Path
 import signal
 import subprocess
+import threading
 
 
 @dataclass
@@ -45,6 +46,24 @@ class LLMBackend:
         """
         self.backend = backend
         self.model = model
+        self._process_lock = threading.Lock()
+        self._active_process: Optional[subprocess.Popen[str]] = None
+
+    def cancel_active(self) -> None:
+        """Terminate the active CLI call owned by this backend, if any."""
+        with self._process_lock:
+            process = self._active_process
+        if process is not None:
+            self._terminate_process_group(process)
+
+    def _set_active_process(self, process: subprocess.Popen[str]) -> None:
+        with self._process_lock:
+            self._active_process = process
+
+    def _clear_active_process(self, process: subprocess.Popen[str]) -> None:
+        with self._process_lock:
+            if self._active_process is process:
+                self._active_process = None
 
     def send(
         self,
@@ -135,14 +154,18 @@ class LLMBackend:
             bufsize=1,
             start_new_session=(os.name == "posix"),
         )
+        self._set_active_process(process)
         try:
-            stdout, stderr = process.communicate(input=prompt, timeout=timeout_seconds)
-        except subprocess.TimeoutExpired as exc:
-            self._terminate_process_group(process)
-            raise TimeoutError(
-                "Codex CLI backend timed out after "
-                f"{timeout_seconds:g} seconds"
-            ) from exc
+            try:
+                stdout, stderr = process.communicate(input=prompt, timeout=timeout_seconds)
+            except subprocess.TimeoutExpired as exc:
+                self._terminate_process_group(process)
+                raise TimeoutError(
+                    "Codex CLI backend timed out after "
+                    f"{timeout_seconds:g} seconds"
+                ) from exc
+        finally:
+            self._clear_active_process(process)
         if process.returncode != 0:
             error_msg = stderr.strip() if stderr else f"codex exec exited with code {process.returncode}"
             raise RuntimeError(f"Codex CLI backend error: {error_msg}")
@@ -263,15 +286,19 @@ class LLMBackend:
             # ordinary interactive-manager launch behavior unchanged.
             start_new_session=(disable_native_tools and os.name == "posix"),
         )
+        self._set_active_process(process)
 
         try:
-            stdout, stderr = process.communicate(input=prompt, timeout=timeout_seconds)
-        except subprocess.TimeoutExpired as exc:
-            self._terminate_process_group(process)
-            raise TimeoutError(
-                "CLI backend timed out after "
-                f"{timeout_seconds:g} seconds"
-            ) from exc
+            try:
+                stdout, stderr = process.communicate(input=prompt, timeout=timeout_seconds)
+            except subprocess.TimeoutExpired as exc:
+                self._terminate_process_group(process)
+                raise TimeoutError(
+                    "CLI backend timed out after "
+                    f"{timeout_seconds:g} seconds"
+                ) from exc
+        finally:
+            self._clear_active_process(process)
 
         if process.returncode != 0:
             # Try to extract useful error info
@@ -288,7 +315,7 @@ class LLMBackend:
 
     @staticmethod
     def _terminate_process_group(process: subprocess.Popen[str]) -> None:
-        """Terminate a timed-out CLI turn and any child processes it spawned."""
+        """Terminate one CLI turn and any child processes it spawned."""
         if process.poll() is not None:
             return
         if os.name == "posix":

--- a/src/interactive/llm_backend.py
+++ b/src/interactive/llm_backend.py
@@ -88,6 +88,7 @@ class LLMBackend:
                 tools,
                 timeout_seconds=timeout_seconds,
                 mcp_config_path=mcp_config_path,
+                allowed_mcp_tools=allowed_mcp_tools,
             )
         elif self.backend == "anthropic_api":
             return self._send_anthropic_api(messages, tools, timeout_seconds=timeout_seconds)
@@ -103,6 +104,7 @@ class LLMBackend:
         *,
         timeout_seconds: Optional[float] = None,
         mcp_config_path: Optional[str] = None,
+        allowed_mcp_tools: Optional[List[str]] = None,
     ) -> LLMResponse:
         """Send a manager turn through `codex exec`."""
         prompt = self._messages_to_prompt(messages, None if mcp_config_path else tools)
@@ -120,7 +122,10 @@ class LLMBackend:
         if self.model:
             cmd[2:2] = ["--model", self.model]
         if mcp_config_path:
-            cmd[2:2] = self._codex_mcp_config_args(mcp_config_path)
+            cmd[2:2] = self._codex_mcp_config_args(
+                mcp_config_path,
+                allowed_mcp_tools=allowed_mcp_tools,
+            )
         process = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
@@ -150,15 +155,20 @@ class LLMBackend:
         return json.dumps(value, ensure_ascii=False)
 
     @classmethod
-    def _codex_mcp_config_args(cls, mcp_config_path: str) -> List[str]:
+    def _codex_mcp_config_args(
+        cls,
+        mcp_config_path: str,
+        *,
+        allowed_mcp_tools: Optional[List[str]] = None,
+    ) -> List[str]:
         payload = json.loads(Path(mcp_config_path).read_text(encoding="utf-8"))
         servers = payload.get("mcpServers") or payload.get("mcp_servers") or {}
         if not isinstance(servers, dict) or not servers:
-            return []
+            raise ValueError("Codex MCP configuration must define at least one server")
         args: List[str] = []
         for name, server in servers.items():
             if not isinstance(server, dict):
-                continue
+                raise ValueError(f"Codex MCP server {name!r} must be an object")
             prefix = f"mcp_servers.{name}"
             for key in ("command", "args", "cwd", "url", "enabled"):
                 if key in server:
@@ -179,6 +189,18 @@ class LLMBackend:
                     ])
             if "enabled" not in server:
                 args.extend(["-c", f"{prefix}.enabled=true"])
+            allowed_prefix = f"mcp__{name}__"
+            enabled_tools = [
+                tool_name[len(allowed_prefix):]
+                for raw_name in allowed_mcp_tools or []
+                if (tool_name := str(raw_name).strip()).startswith(allowed_prefix)
+            ]
+            if allowed_mcp_tools is not None:
+                args.extend([
+                    "-c",
+                    f"{prefix}.enabled_tools={cls._codex_config_value(enabled_tools)}",
+                ])
+            args.extend(["-c", f"{prefix}.required=true"])
         return args
 
     def _send_cli(

--- a/templates/agents/rule_maker.txt
+++ b/templates/agents/rule_maker.txt
@@ -78,8 +78,10 @@ WHAT YOU MUST NOT DO:
 ✗ Do NOT run experiments. You are not the experiment_runner.
 ✗ Do NOT execute scoring/eval.py. The runner's artifact does not exist
   yet — running eval.py would fail and pollute scoring/.
-✗ Do NOT read or reference files under data/.test/. Their contents are
-  sealed; only scoring/eval.py touches them at scorer-execution time.
+✗ Do NOT defer creation of private evaluator inputs until scorer execution.
+  If the evaluator needs fixed private inputs, create them deterministically
+  under data/.test/ during this rule-maker stage, declare each file in
+  scoring/targets.json, and treat them as evaluator-owned sealed data.
 ✗ Do NOT mention targets, test inputs, or the baseline in
   scoring/interface.md. That file is visible to the runner; leaking
   these defeats the evaluation.
@@ -110,8 +112,8 @@ Skim (do not deep-read):
 - literature_review.md — what metrics do prior works use?
 - resources.md — which datasets / baselines are available locally?
 - code/ — is there a baseline implementation you can call from eval.py?
-- datasets/ — is there a held-out split you can use? (look for a
-  data/.test/ subdir; if absent, plan to create one in Phase 3)
+- datasets/ — is there a held-out split you can use? If the evaluator needs a
+  private fixed subset, plan to materialize it under data/.test/ in Phase 3.
 
 STEP 3: Decide the property set
 ─────────────────────────────────────────────────────────────────────────────
@@ -280,6 +282,8 @@ neurico pipeline) AFTER the runner produces its artifact. It must:
   paths inside the evaluator.
 ✓ Load the runner's artifact via importlib (NOT subprocess).
 ✓ Load any test inputs from `data/.test/` (sealed; only eval.py reads).
+✓ Require every private input to exist before this rule-maker stage finishes.
+  eval.py may read declared sealed inputs but must never create or modify them.
 ✓ Compute one scalar per declared property.
 ✓ Load targets from `scoring/targets.json`.
 ✓ Write structured results to `scoring/results.json`.
@@ -454,6 +458,7 @@ FORMAT (mirror exactly):
 {
   "<property_name>": {"target": <number>, "direction": "max" | "min"},
   "<property_name>": {"target": <number>, "direction": "max" | "min"},
+  "sealed_inputs": ["data/.test/<private-evaluator-input>"],
   "success_rule": "ALL_PROPERTIES_SATISFIED",
   "meta": {
     "generated_by": "rule_maker",
@@ -486,6 +491,7 @@ CONCRETE EXAMPLE (LCS speedup):
 {
   "correctness": {"target": 1.0, "direction": "max"},
   "speedup":     {"target": 3.0, "direction": "max"},
+  "sealed_inputs": [],
   "success_rule": "ALL_PROPERTIES_SATISFIED",
   "meta": {
     "generated_by": "rule_maker",
@@ -556,13 +562,17 @@ CHECKS (run each from the workspace root):
    python -c "import json; json.load(open('scoring/targets.json')); print('targets.json: OK')"
    ```
 
-4. interface.md is non-empty and references at least one file the runner
+4. Every path in targets.json `sealed_inputs` already exists as a non-empty
+   regular file under data/.test/. Use an empty list when no private input is
+   required. Do not rely on runtime or eval.py to create these files later.
+
+5. interface.md is non-empty and references at least one file the runner
    must produce:
    ```bash
    grep -q "Files to produce" scoring/interface.md && echo "interface.md: OK"
    ```
 
-5. eval.py does NOT contain `import neurico` or `from neurico`:
+6. eval.py does NOT contain `import neurico` or `from neurico`:
    ```bash
    grep -q "neurico" scoring/eval.py && echo "FAIL: eval.py must not import neurico" || echo "eval.py: no neurico imports"
    ```
@@ -612,10 +622,12 @@ THEN:
 
 IF: the resource_finder did not produce a `data/.test/` split
 THEN:
-  1. Create one in eval.py (NOT in interface.md). Hold out a fixed
-     fraction of any available data using a deterministic seed; write
-     the held-out subset to data/.test/ at scorer-execution time.
-  2. Document the split strategy in rule_maker_log.md.
+  1. If private evaluation data is required, create it during this rule-maker
+     stage (NOT in interface.md or at scorer-execution time). Hold out a fixed
+     fraction of available data using a deterministic seed and write the
+     resulting evaluator-owned file under data/.test/.
+  2. Declare every created file in scoring/targets.json `sealed_inputs`.
+  3. Document the split strategy in rule_maker_log.md.
 
 IF: a property is hard to measure deterministically (timing,
     random initialization)

--- a/templates/agents/rule_maker.txt
+++ b/templates/agents/rule_maker.txt
@@ -78,10 +78,11 @@ WHAT YOU MUST NOT DO:
 ✗ Do NOT run experiments. You are not the experiment_runner.
 ✗ Do NOT execute scoring/eval.py. The runner's artifact does not exist
   yet — running eval.py would fail and pollute scoring/.
-✗ Do NOT defer creation of private evaluator inputs until scorer execution.
-  If the evaluator needs fixed private inputs, create them deterministically
-  under data/.test/ during this rule-maker stage, declare each file in
-  scoring/targets.json, and treat them as evaluator-owned sealed data.
+✗ Do NOT read or reference files under data/.test/. Their contents are
+  sealed; only scoring/eval.py touches them at scorer-execution time.
+✗ Do NOT require, inspect, or score `paper/` or `paper_draft/`. Paper
+  generation belongs to the later paper_writer stage, even when the research
+  idea requests a paper as a final output.
 ✗ Do NOT mention targets, test inputs, or the baseline in
   scoring/interface.md. That file is visible to the runner; leaking
   these defeats the evaluation.
@@ -112,8 +113,8 @@ Skim (do not deep-read):
 - literature_review.md — what metrics do prior works use?
 - resources.md — which datasets / baselines are available locally?
 - code/ — is there a baseline implementation you can call from eval.py?
-- datasets/ — is there a held-out split you can use? If the evaluator needs a
-  private fixed subset, plan to materialize it under data/.test/ in Phase 3.
+- datasets/ — is there a held-out split you can use? (look for a
+  data/.test/ subdir; if absent, plan to create one in Phase 3)
 
 STEP 3: Decide the property set
 ─────────────────────────────────────────────────────────────────────────────
@@ -282,8 +283,6 @@ neurico pipeline) AFTER the runner produces its artifact. It must:
   paths inside the evaluator.
 ✓ Load the runner's artifact via importlib (NOT subprocess).
 ✓ Load any test inputs from `data/.test/` (sealed; only eval.py reads).
-✓ Require every private input to exist before this rule-maker stage finishes.
-  eval.py may read declared sealed inputs but must never create or modify them.
 ✓ Compute one scalar per declared property.
 ✓ Load targets from `scoring/targets.json`.
 ✓ Write structured results to `scoring/results.json`.
@@ -458,7 +457,6 @@ FORMAT (mirror exactly):
 {
   "<property_name>": {"target": <number>, "direction": "max" | "min"},
   "<property_name>": {"target": <number>, "direction": "max" | "min"},
-  "sealed_inputs": ["data/.test/<private-evaluator-input>"],
   "success_rule": "ALL_PROPERTIES_SATISFIED",
   "meta": {
     "generated_by": "rule_maker",
@@ -491,7 +489,6 @@ CONCRETE EXAMPLE (LCS speedup):
 {
   "correctness": {"target": 1.0, "direction": "max"},
   "speedup":     {"target": 3.0, "direction": "max"},
-  "sealed_inputs": [],
   "success_rule": "ALL_PROPERTIES_SATISFIED",
   "meta": {
     "generated_by": "rule_maker",
@@ -562,17 +559,13 @@ CHECKS (run each from the workspace root):
    python -c "import json; json.load(open('scoring/targets.json')); print('targets.json: OK')"
    ```
 
-4. Every path in targets.json `sealed_inputs` already exists as a non-empty
-   regular file under data/.test/. Use an empty list when no private input is
-   required. Do not rely on runtime or eval.py to create these files later.
-
-5. interface.md is non-empty and references at least one file the runner
+4. interface.md is non-empty and references at least one file the runner
    must produce:
    ```bash
    grep -q "Files to produce" scoring/interface.md && echo "interface.md: OK"
    ```
 
-6. eval.py does NOT contain `import neurico` or `from neurico`:
+5. eval.py does NOT contain `import neurico` or `from neurico`:
    ```bash
    grep -q "neurico" scoring/eval.py && echo "FAIL: eval.py must not import neurico" || echo "eval.py: no neurico imports"
    ```
@@ -622,12 +615,10 @@ THEN:
 
 IF: the resource_finder did not produce a `data/.test/` split
 THEN:
-  1. If private evaluation data is required, create it during this rule-maker
-     stage (NOT in interface.md or at scorer-execution time). Hold out a fixed
-     fraction of available data using a deterministic seed and write the
-     resulting evaluator-owned file under data/.test/.
-  2. Declare every created file in scoring/targets.json `sealed_inputs`.
-  3. Document the split strategy in rule_maker_log.md.
+  1. Create one in eval.py (NOT in interface.md). Hold out a fixed
+     fraction of any available data using a deterministic seed; write
+     the held-out subset to data/.test/ at scorer-execution time.
+  2. Document the split strategy in rule_maker_log.md.
 
 IF: a property is hard to measure deterministically (timing,
     random initialization)

--- a/templates/hitl/manager_review_phase_finish.txt
+++ b/templates/hitl/manager_review_phase_finish.txt
@@ -33,15 +33,20 @@ For this rule-maker review, verify that the proposed scorer preserves the
 fixed NeuriCo evaluator ABI: runtime invokes exactly `python scoring/eval.py`
 with no command-line arguments, and the evaluator writes its authoritative
 structured result to exactly `scoring/results.json`. The evaluator must resolve
-its approved workspace-relative inputs itself. Verify that
+its approved workspace-relative inputs itself. Any private evaluator inputs
+must already exist under `data/.test/` and be declared by
+`scoring/targets.json`; runtime validates and seals them but does not create
+scientific inputs on the rule maker's behalf. Verify that
 `scoring/interface.md` describes only prerequisites the experiment runner must
 produce; it must not assign `scoring/eval.py`, `scoring/targets.json`, another
 evaluator-owned file, or an evaluator result to that runner. If the plan,
 finish summary, or inspected artifacts use another authoritative result path,
 require runtime-supplied CLI arguments, or cross that ownership boundary,
-finalize `feedback` with a precise correction. Runtime separately validates
-the evaluator source and interface mechanically before sealing; do not infer
-source-level compliance without evidence.
+finalize `feedback` with a precise correction. Also reject any unresolved plan
+that delegates future evaluator-input creation to runtime or scorer execution.
+Runtime separately validates the evaluator source, declared inputs, and
+interface mechanically before sealing; do not infer source-level compliance
+without evidence.
 {% endif %}
 
 When ready, finalize this request with a result object following this contract.

--- a/templates/hitl/manager_review_phase_finish.txt
+++ b/templates/hitl/manager_review_phase_finish.txt
@@ -28,25 +28,32 @@ frontier accept/reject decision. If the work needs revision, finalize
 `feedback` with precise worker-facing manager_feedback.
 {% endif %}
 
+{% if pipeline_stage == "resource_finder" %}
+`literature_review.md` and `resources.md` are mandatory pipeline artifacts.
+They may not be omitted, renamed, relocated, or replaced by a worker plan or
+manager decision. If the plan does not preserve both files, finalize `feedback`
+with precise correction instructions. Do not ask the human to choose an
+alternative artifact boundary.
+{% endif %}
+
 {% if is_rule_maker %}
-For this rule-maker review, verify that the proposed scorer preserves the
-fixed NeuriCo evaluator ABI: runtime invokes exactly `python scoring/eval.py`
-with no command-line arguments, and the evaluator writes its authoritative
-structured result to exactly `scoring/results.json`. The evaluator must resolve
-its approved workspace-relative inputs itself. Any private evaluator inputs
-must already exist under `data/.test/` and be declared by
-`scoring/targets.json`; runtime validates and seals them but does not create
-scientific inputs on the rule maker's behalf. Verify that
-`scoring/interface.md` describes only prerequisites the experiment runner must
-produce; it must not assign `scoring/eval.py`, `scoring/targets.json`, another
-evaluator-owned file, or an evaluator result to that runner. If the plan,
-finish summary, or inspected artifacts use another authoritative result path,
-require runtime-supplied CLI arguments, or cross that ownership boundary,
-finalize `feedback` with a precise correction. Also reject any unresolved plan
-that delegates future evaluator-input creation to runtime or scorer execution.
-Runtime separately validates the evaluator source, declared inputs, and
-interface mechanically before sealing; do not infer source-level compliance
-without evidence.
+For this rule-maker review, judge the evaluator's semantic and scientific
+design from the public plan, finish summary, `scoring/interface.md`, and
+finalized HITL evidence. Assess whether the metrics and targets match the
+research objective, the documented evaluation split is scientifically
+defensible, the design avoids leakage and trivial gaming, and the requested
+experiment-runner artifacts are sufficient for the stated measurements.
+`scoring/interface.md` must describe only experiment-runner prerequisites and
+must not require, inspect, or score `paper/` or `paper_draft/`; those outputs
+belong to the later paper_writer stage.
+
+Runtime has already validated the hidden evaluator files, private-input
+declarations and existence, symlink and integrity constraints, evaluator ABI,
+result path, and interface structure before opening this manager review. Do not
+attempt to inspect `data/.test/`, infer hidden source contents, or re-decide
+those mechanical facts. If the public design or documented split is
+scientifically unsound or inconsistent, finalize `feedback` with a precise
+semantic correction.
 {% endif %}
 
 When ready, finalize this request with a result object following this contract.

--- a/templates/hitl/worker_execution.txt
+++ b/templates/hitl/worker_execution.txt
@@ -23,12 +23,17 @@ when needed, then continue from the current workspace state.
 
 The base rule-maker prompt permits a baseline implementation under `baselines/`
 when the approved evaluation design needs one. That explicit baseline exception
-is permitted in this HITL execution phase; all other evaluator-owned outputs
-remain under `scoring/`.
+is permitted in this HITL execution phase. Private evaluator inputs may also be
+created under `data/.test/`; all other evaluator-owned outputs remain under
+`scoring/`.
 
 Rule-maker execution requirements:
 - create or update only the approved evaluation contract: `scoring/eval.py`,
-  `scoring/targets.json`, `scoring/interface.md`, and `scoring/rule_maker_log.md`
+  `scoring/targets.json`, `scoring/interface.md`, `scoring/rule_maker_log.md`,
+  and any required evaluator-owned private input files under `data/.test/`
+- declare every private evaluator input in `scoring/targets.json` under
+  `sealed_inputs`; use an empty list when none is required, and materialize every
+  declared file before requesting phase completion
 - preserve the fixed evaluator ABI: runtime invokes exactly
   `python scoring/eval.py` with no command-line arguments, and the evaluator
   must write its authoritative structured result to `scoring/results.json`
@@ -38,6 +43,8 @@ Rule-maker execution requirements:
 - keep metric direction, targets, interface requirements, and rationale aligned
   with the approved plan
 - do not run `scoring/eval.py` before runner artifacts exist
+- do not defer creation of private evaluator inputs to scorer execution and do
+  not delegate their creation to runtime
 - do not seal scoring artifacts; runtime performs sealing only after this stage
   receives final HITL approval
 {% endif %}

--- a/templates/hitl/worker_execution.txt
+++ b/templates/hitl/worker_execution.txt
@@ -28,6 +28,8 @@ created under `data/.test/`; all other evaluator-owned outputs remain under
 `scoring/`.
 
 Rule-maker execution requirements:
+- these HITL private-input requirements supersede ordinary rule-maker guidance
+  that permits evaluator inputs to be created at scorer-execution time
 - create or update only the approved evaluation contract: `scoring/eval.py`,
   `scoring/targets.json`, `scoring/interface.md`, `scoring/rule_maker_log.md`,
   and any required evaluator-owned private input files under `data/.test/`

--- a/templates/hitl/worker_plan.txt
+++ b/templates/hitl/worker_plan.txt
@@ -43,9 +43,10 @@ Rule-maker plan requirements:
   `scoring/interface.md`'s `Files to produce` table; evaluator-owned files and
   evaluator results are not runner artifacts
 - keep rule-maker execution artifacts within `scoring/eval.py`,
-  `scoring/targets.json`, `scoring/interface.md`, and
-  `scoring/rule_maker_log.md`; do not assign those sealed files to the
-  experiment runner
+  `scoring/targets.json`, `scoring/interface.md`,
+  `scoring/rule_maker_log.md`, and any evaluator-owned private input files
+  required under `data/.test/`; declare each private input in
+  `scoring/targets.json` and do not assign sealed files to the experiment runner
 - describe split, aggregation, determinism, and failure behavior where relevant
 - identify reward-hacking risks and how `scoring/eval.py` prevents trivial
   outputs from satisfying the rule

--- a/templates/hitl/worker_review_revision.txt
+++ b/templates/hitl/worker_review_revision.txt
@@ -21,8 +21,9 @@ location is `baselines/`; all other evaluator-owned outputs remain under
 
 Revalidate the approved rule-maker deliverables after the revision:
 `scoring/eval.py`, `scoring/targets.json`, `scoring/interface.md`, and
-`scoring/rule_maker_log.md`. Do not seal them; runtime handles sealing only
-after final approval.
+`scoring/rule_maker_log.md`, plus every private evaluator input declared by
+`scoring/targets.json` under `data/.test/`. Do not seal them; runtime handles
+sealing only after final approval.
 {% endif %}
 
 If another idea requires manager/human feedback, update `{{ plan_path }}`, call


### PR DESCRIPTION
## Summary

This follow-up to [#146](https://github.com/ChicagoHAI/NeuriCo/pull/146) addresses reliability issues identified during post-merge HITL AutoResearch testing.

- Preserve ordered phase completion when a provider exits before its blocking runtime command returns.
- Reconnect replacement workers only when a durable held request genuinely requires replay.
- Treat the durable manager response as authoritative instead of using worker-process exit as a workflow-completion signal.
- Prevent client disconnects from turning an already-completed `/phase/finish` operation into a runtime error.
- Provide managers with the exact runtime-authorized MCP tool surface and required finalizer for each turn.
- Restrict Codex MCP access to the explicitly enabled tools and fail clearly when the required MCP server is unavailable.
- Require private evaluator inputs to be materialized under `data/.test/` and declared through `scoring/targets.json`.
- Validate declared evaluator inputs before sealing, including path containment, existence, regular-file type, non-empty content, symlink rejection, and undeclared-file detection.
- Align rule-maker, worker, revision, and manager-review instructions with the sealed-input contract.