### PR TITLE
fix: stabilize HITL manager context compaction across providers

### DIFF
--- a/src/core/hitl_manager_context.py
+++ b/src/core/hitl_manager_context.py
@@ -23,6 +23,8 @@ MICROCOMPACT_MEDIUM_OUTPUT_CHARS = 300
 MICROCOMPACT_LARGE_OUTPUT_CHARS = 1_200
 COMPACTION_MIN_RECENT_MESSAGES = 2
 COMPACTION_MIN_MIDDLE_MESSAGES = 1
+COMPACTION_SUMMARY_MIN_INPUT_TOKENS = 2_500
+COMPACTION_SUMMARY_MAX_INPUT_TOKENS = 64_000
 MAX_ACTIVE_TOOL_RESULT_CHARS = 64_000
 
 
@@ -321,7 +323,11 @@ class HitlManagerContext:
             records[recent_start:],
         )
         summaries: List[Dict[str, Any]] = []
-        for chunk in self._chunks(oldest, limit=10_000):
+        chunk_token_budget = min(
+            COMPACTION_SUMMARY_MAX_INPUT_TOKENS,
+            max(COMPACTION_SUMMARY_MIN_INPUT_TOKENS, self.context_tokens // 4),
+        )
+        for chunk in self._chunks(oldest, limit=chunk_token_budget * 4):
             rendered = self._render(chunk)
             summary = str(summarize(rendered, research_state)).strip()
             if not summary:

--- a/src/core/hitl_manager_react.py
+++ b/src/core/hitl_manager_react.py
@@ -2008,7 +2008,7 @@ class HitlManager:
     def _summarize(self, prior: str, research_state: str, generation: int) -> str:
         from core.hitl import _load_hitl_template
 
-        prompt = _load_hitl_template("manager_conversation_compaction.txt", max_tokens=6000)
+        prompt = _load_hitl_template("manager_conversation_compaction.txt", max_tokens=1600)
         response = self._send(
             [
                 {"role": "system", "content": prompt},

--- a/src/interactive/llm_backend.py
+++ b/src/interactive/llm_backend.py
@@ -283,7 +283,9 @@ class LLMBackend:
         elif disable_native_tools:
             # HITL manager tools are parsed and executed by the runtime. Do
             # not let the CLI agent gain a second, unmanaged tool surface.
-            cmd.extend(["--bare", "--tools", ""])
+            # Safe mode also suppresses local hooks and project instructions,
+            # while preserving OAuth/keychain authentication for Claude Code.
+            cmd.extend(["--safe-mode", "--tools", ""])
 
         process = subprocess.Popen(
             cmd,
@@ -311,8 +313,11 @@ class LLMBackend:
             self._clear_active_process(process)
 
         if process.returncode != 0:
-            # Try to extract useful error info
-            error_msg = stderr.strip() if stderr else f"claude -p exited with code {process.returncode}"
+            error_msg = self._claude_cli_error_message(
+                stdout=stdout,
+                stderr=stderr,
+                returncode=process.returncode,
+            )
             raise RuntimeError(f"CLI backend error: {error_msg}")
 
         response = self._parse_cli_response(stdout)
@@ -322,6 +327,33 @@ class LLMBackend:
             # ReAct loop must not replay them as legacy XML tool calls.
             response.tool_calls = []
         return response
+
+    @staticmethod
+    def _claude_cli_error_message(*, stdout: str, stderr: str, returncode: int) -> str:
+        """Recover Claude's structured error before falling back to process output."""
+        error_code = ""
+        error_text = ""
+        terminal_reason = ""
+        for raw_line in str(stdout).splitlines():
+            try:
+                event = json.loads(raw_line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            if event.get("error"):
+                error_code = str(event["error"]).strip()
+            if event.get("type") == "result" and event.get("is_error"):
+                error_text = str(event.get("result", "")).strip()
+                terminal_reason = str(event.get("terminal_reason", "")).strip()
+        if error_text:
+            label = error_code or terminal_reason
+            return f"{label}: {error_text}" if label else error_text
+        if error_code:
+            return error_code
+        if str(stderr).strip():
+            return str(stderr).strip()
+        return f"claude -p exited with code {returncode}"
 
     @staticmethod
     def _terminate_process_group(process: subprocess.Popen[str]) -> None:


### PR DESCRIPTION
## Summary

This update fixes a HITL manager context-compaction failure that could incorrectly report an available provider as unavailable after several successful AutoResearch iterations.

## Root cause

The captured manager context remained usable through the normal MCP-backed manager path. The failure began only when a new review pushed the active context above its compaction threshold.

At that boundary:

- context compaction divided the retained history into 67 small summarization requests;
- Claude summaries were launched with `--bare --tools ""`;
- Claude’s `--bare` mode does not read OAuth or keychain credentials;
- each summary therefore failed authentication;
- after three retries, NeuriCo replaced the underlying error with `Manager backend was unavailable` and entered normal failure recovery.

This was not context-window exhaustion or genuine provider unavailability.

## Changes

- Use Claude `--safe-mode --tools ""` for tool-free context summarization.
  - OAuth and keychain authentication remain available.
  - Local hooks, project instructions, plugins, and tools remain disabled.
- Derive summary chunk size from the configured manager context window.
  - The captured context now requires four summarization calls instead of 67.
- Reduce the requested summary size from approximately 6,000 to 1,600 tokens.
- Extract structured Claude errors from stream output before falling back to stderr or a generic exit-code message.

The HITL workflow, manager authority, runtime recovery rules, retry budget, and authorized MCP tool surface are unchanged.