### PR TITLE
fix(hitl): scope the manager's --bare compaction key so it does not override your login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@
 # ─── OPTIONAL: Additional API keys (passed through to agent environment) ───
 # Agents may use these during experiments (e.g., for model access, routing)
 # ANTHROPIC_API_KEY=
+# NEURICO_HITL_MANAGER_API_KEY=      # HITL only: Anthropic key for the manager's `claude --bare`
+#                                    # compaction step (it ignores login/OAuth); scoped to just that
+#                                    # call, so the rest of the run keeps using your login/OAuth.
 # GOOGLE_API_KEY=
 # OPENROUTER_KEY=
 # HF_TOKEN=                          # Hugging Face (private models/datasets)

--- a/src/interactive/llm_backend.py
+++ b/src/interactive/llm_backend.py
@@ -260,6 +260,7 @@ class LLMBackend:
         )
 
         # Build command
+        used_bare = False
         cmd = ["claude", "-p", "--verbose", "--output-format", "stream-json"]
         if self.model:
             cmd.extend(["--model", self.model])
@@ -274,6 +275,17 @@ class LLMBackend:
             # HITL manager tools are parsed and executed by the runtime. Do
             # not let the CLI agent gain a second, unmanaged tool surface.
             cmd.extend(["--bare", "--tools", ""])
+            used_bare = True
+
+        # `--bare` authenticates strictly via ANTHROPIC_API_KEY (it skips
+        # keychain/OAuth by design). If NEURICO_HITL_MANAGER_API_KEY is set,
+        # hand it to THIS subprocess only, so the rest of the run keeps using
+        # the user's login/OAuth instead of being forced onto a metered key.
+        child_env = None
+        if used_bare:
+            manager_key = os.environ.get("NEURICO_HITL_MANAGER_API_KEY")
+            if manager_key:
+                child_env = {**os.environ, "ANTHROPIC_API_KEY": manager_key}
 
         process = subprocess.Popen(
             cmd,
@@ -285,6 +297,7 @@ class LLMBackend:
             # Only HITL manager calls request cancellation semantics. Keep
             # ordinary interactive-manager launch behavior unchanged.
             start_new_session=(disable_native_tools and os.name == "posix"),
+            env=child_env,
         )
         self._set_active_process(process)
 
@@ -303,6 +316,15 @@ class LLMBackend:
         if process.returncode != 0:
             # Try to extract useful error info
             error_msg = stderr.strip() if stderr else f"claude -p exited with code {process.returncode}"
+            if used_bare and child_env is None and not os.environ.get("ANTHROPIC_API_KEY"):
+                # `--bare` skips keychain/OAuth, so a logged-in user still hits
+                # "Not logged in" here. Point at the real fix.
+                error_msg += (
+                    " (the HITL manager's conversation-compaction step runs "
+                    "`claude --bare`, which ignores your login/OAuth and needs an "
+                    "API key; set NEURICO_HITL_MANAGER_API_KEY to supply one scoped "
+                    "to just this call)"
+                )
             raise RuntimeError(f"CLI backend error: {error_msg}")
 
         response = self._parse_cli_response(stdout)

--- a/tests/test_llm_backend_bare_auth.py
+++ b/tests/test_llm_backend_bare_auth.py
@@ -1,0 +1,107 @@
+"""Unit tests for HITL manager `--bare` auth handling in the CLI backend.
+
+The HITL manager's conversation-compaction step runs `claude --bare`, which
+authenticates strictly via ANTHROPIC_API_KEY (it skips keychain/OAuth by
+design). These tests pin the fix that lets a subscription/login user supply a
+key scoped to just that subprocess via NEURICO_HITL_MANAGER_API_KEY, without
+overriding the OAuth/login auth used by every other call.
+
+Run: python -m pytest tests/test_llm_backend_bare_auth.py
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from interactive.llm_backend import LLMBackend, LLMResponse  # noqa: E402
+
+MESSAGES = [{"role": "user", "content": "hi"}]
+
+
+class _FakeProc:
+    def __init__(self, env, *, returncode=0, stderr=""):
+        self.captured_env = env
+        self.returncode = returncode
+        self._stderr = stderr
+
+    def communicate(self, input=None, timeout=None):
+        return ("{}", self._stderr)
+
+
+def _patch_popen(monkeypatch, *, returncode=0, stderr=""):
+    """Capture the Popen call and return a dict with its cmd/env."""
+    cap = {}
+
+    def fake_popen(cmd, **kwargs):
+        cap["cmd"] = cmd
+        cap["env"] = kwargs.get("env")
+        return _FakeProc(kwargs.get("env"), returncode=returncode, stderr=stderr)
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    return cap
+
+
+def _cli_backend(monkeypatch):
+    backend = LLMBackend(backend="cli")
+    # Decouple from the stream-json parser; we only assert on the Popen call.
+    monkeypatch.setattr(backend, "_parse_cli_response", lambda stdout: LLMResponse(text="ok"))
+    return backend
+
+
+def test_bare_injects_scoped_key_only(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("NEURICO_HITL_MANAGER_API_KEY", "sk-ant-manager-xyz")
+    cap = _patch_popen(monkeypatch)
+    backend = _cli_backend(monkeypatch)
+
+    backend.send(MESSAGES, [], disable_native_tools=True)
+
+    assert "--bare" in cap["cmd"]
+    assert cap["env"] is not None
+    assert cap["env"]["ANTHROPIC_API_KEY"] == "sk-ant-manager-xyz"
+    # The parent environment is never mutated.
+    assert "ANTHROPIC_API_KEY" not in os.environ
+
+
+def test_bare_without_var_inherits_env(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("NEURICO_HITL_MANAGER_API_KEY", raising=False)
+    cap = _patch_popen(monkeypatch)
+    backend = _cli_backend(monkeypatch)
+
+    backend.send(MESSAGES, [], disable_native_tools=True)
+
+    assert "--bare" in cap["cmd"]
+    # No scoped key -> inherit the parent env unchanged (today's behavior).
+    assert cap["env"] is None
+
+
+def test_non_bare_never_injects(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("NEURICO_HITL_MANAGER_API_KEY", "sk-ant-manager-xyz")
+    cap = _patch_popen(monkeypatch)
+    backend = _cli_backend(monkeypatch)
+
+    # Main-loop style call: not the bare path, so the key must not leak in.
+    backend.send(MESSAGES, [], disable_native_tools=False)
+
+    assert "--bare" not in cap["cmd"]
+    assert cap["env"] is None
+
+
+def test_bare_auth_failure_hint(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("NEURICO_HITL_MANAGER_API_KEY", raising=False)
+    _patch_popen(monkeypatch, returncode=1, stderr="Not logged in · Please run /login")
+    backend = _cli_backend(monkeypatch)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        backend.send(MESSAGES, [], disable_native_tools=True)
+
+    # The misleading "Not logged in" is annotated with the real fix.
+    assert "NEURICO_HITL_MANAGER_API_KEY" in str(excinfo.value)


### PR DESCRIPTION
The HITL manager's conversation-compaction step runs `claude --bare`, which by design skips keychain/OAuth and authenticates only via `ANTHROPIC_API_KEY`. For anyone signed in with `/login` or an OAuth token there is no way to satisfy it except a global `ANTHROPIC_API_KEY`, which then overrides that login for every call in the run and meters the whole session. Compaction only fires once the manager conversation grows past ~70% of its token budget, so the run works on the login up to that point and then a long HITL session dies partway through with a misleading `Not logged in · Please run /login`.

## What this adds

`NEURICO_HITL_MANAGER_API_KEY`: when set, the key is injected into only the `--bare` subprocess's environment. The main ReAct loop and the worker agents keep inheriting the parent environment, so they stay on your login/OAuth, and only the compaction call uses the scoped key. The global environment is never mutated, so nothing else switches to metered billing.

## Changes

- `src/interactive/llm_backend.py`: on the `--bare` path, pass `env={**os.environ, "ANTHROPIC_API_KEY": <manager key>}` to the subprocess when `NEURICO_HITL_MANAGER_API_KEY` is set, otherwise `env=None` (unchanged). When no key is resolvable, the existing `RuntimeError` is annotated with the real cause instead of the bare `Not logged in`.
- `tests/test_llm_backend_bare_auth.py`: the scoped key reaches only the `--bare` child, never the parent env or non-bare calls, and the failure hint is emitted.
- `.env.example`: documents the new optional variable.

With the variable unset, behavior is identical to today.
