### PR TITLE
fix(hitl): exclude runtime-owned STATE.md from the write-boundary guard

### DIFF
--- a/src/core/hitl_workspace_guard.py
+++ b/src/core/hitl_workspace_guard.py
@@ -20,6 +20,9 @@ _EXCLUDED_PUBLIC_PREFIXES = {
     ".venv",
     "__pycache__",
     "logs",
+    # Runtime-owned: PipelineState._save() rewrites it during guarded phases,
+    # so snapshotting it turns the runtime's own write into a worker violation.
+    "STATE.md",
 }
 
 

--- a/tests/test_hitl_workspace_guard.py
+++ b/tests/test_hitl_workspace_guard.py
@@ -1,0 +1,60 @@
+"""Unit tests for the HITL workspace write-boundary guard.
+
+Pins the fix for the endless resource_finder recovery loop: the runtime's own
+pipeline-state document (STATE.md) is rewritten by PipelineState._save() during
+guarded phases, so it must be outside the public write boundary. Before the
+fix, the guard flagged that runtime write as a worker violation at phase
+finish, and each rejection-triggered recovery rewrote STATE.md again, so the
+phase could never pass.
+
+Run: python -m pytest tests/test_hitl_workspace_guard.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from core.hitl_workspace_guard import HitlWorkspaceWriteGuard  # noqa: E402
+
+
+def _workspace(tmp_path):
+    work_dir = tmp_path / "ws"
+    (work_dir / "plans").mkdir(parents=True)
+    (work_dir / "plans" / "resource_finder_plan.md").write_text("plan v1\n")
+    (work_dir / "STATE.md").write_text("# state v1\n")
+    (work_dir / "README.md").write_text("readme\n")
+    return work_dir
+
+
+def test_runtime_state_document_is_outside_the_boundary(tmp_path):
+    work_dir = _workspace(tmp_path)
+    guard = HitlWorkspaceWriteGuard.capture_public(work_dir)
+
+    # The runtime rewrites STATE.md mid-phase (new content AND new mtime).
+    (work_dir / "STATE.md").write_text("# state v2 (recovery recorded)\n")
+    (work_dir / "plans" / "resource_finder_plan.md").write_text("plan v2\n")
+
+    result = guard.allow_only(["plans/resource_finder_plan.md"])
+    assert result["valid"], result["issues"]
+
+
+def test_worker_writes_outside_boundary_still_caught(tmp_path):
+    work_dir = _workspace(tmp_path)
+    guard = HitlWorkspaceWriteGuard.capture_public(work_dir)
+
+    (work_dir / "README.md").write_text("tampered\n")
+
+    result = guard.allow_only(["plans/resource_finder_plan.md"])
+    assert not result["valid"]
+    assert "README.md" in result["issues"][0]
+
+
+def test_allowed_plan_write_passes(tmp_path):
+    work_dir = _workspace(tmp_path)
+    guard = HitlWorkspaceWriteGuard.capture_public(work_dir)
+
+    (work_dir / "plans" / "resource_finder_plan.md").write_text("plan v2\n")
+
+    result = guard.allow_only(["plans/resource_finder_plan.md"])
+    assert result["valid"], result["issues"]


### PR DESCRIPTION
The runtime rewrites STATE.md (via `PipelineState._save()`) during guarded phases, but the public write-boundary guard snapshots it, so at phase finish the runtime's own write is flagged as a worker violation: `writes outside this HITL boundary: STATE.md`. Each rejection triggers a recovery, each recovery updates pipeline state and rewrites STATE.md again, so the phase can never pass. Observed live as 16 consecutive resource_finder recovery loops on a web-HITL run.

Fix: add `STATE.md` to the guard's excluded prefixes, like the other runtime-owned paths (`.neurico`, `logs`). Three unit tests pin the behavior: a mid-phase STATE.md rewrite no longer fails the plan gate, and genuine out-of-boundary writes are still caught.