### PR TITLE
Continue-research mode: two-stage adopt-and-optimize an existing repo

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1061,8 +1061,29 @@ cmd_run() {
         docker "${prep_args[@]}" || { echo -e "${RED}Prepare stage failed${NC}"; exit 1; }
 
         echo -e "${BLUE}continue-research: Stage 2 (research) with NO source materials mounted${NC}"
-        docker_args+=( -w /app "$IMAGE_NAME" python /app/src/core/runner.py "$@" )
-        docker "${docker_args[@]}"
+        # --force-fresh belongs to the prepare stage only: it already moved any
+        # stale workspace aside and Stage 1 re-adopted. Passing it to the
+        # research container would move the freshly prepared workspace aside too,
+        # and Stage 2 cannot re-prepare (the source is deliberately not mounted
+        # here). Strip it from the research invocation.
+        local research_args=()
+        for a in "$@"; do
+            [ "$a" = "--force-fresh" ] && continue
+            research_args+=( "$a" )
+        done
+        # Drop the host ideas/ mount from the research container: the submitted
+        # YAML there retains the source repo URL, which the optimizing agent
+        # must not be able to read. Stage 2 loads the redacted contract from the
+        # workspace's .neurico/idea.yaml instead.
+        local research_docker_args=() _i=0 _arr=( "${docker_args[@]}" )
+        while [ $_i -lt ${#_arr[@]} ]; do
+            if [ "${_arr[$_i]}" = "-v" ] && [[ "${_arr[$((_i+1))]}" == *":/app/ideas" ]]; then
+                _i=$((_i+2)); continue
+            fi
+            research_docker_args+=( "${_arr[$_i]}" ); _i=$((_i+1))
+        done
+        research_docker_args+=( -w /app "$IMAGE_NAME" python /app/src/core/runner.py "${research_args[@]}" )
+        docker "${research_docker_args[@]}"
         return
     fi
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1084,7 +1084,21 @@ cmd_run() {
         done
         research_docker_args+=( -w /app "$IMAGE_NAME" python /app/src/core/runner.py "${research_args[@]}" )
         docker "${research_docker_args[@]}"
-        return
+        local _rc=$?
+        # Stage 2 ran with the ideas/ mount dropped, so the runner's in-container
+        # "completed" status update no-oped and the idea would stay in_progress
+        # forever. Finalize it here on success, in a throwaway container that
+        # mounts ONLY ideas/ (never the workspace or source), so the idea is
+        # archived to ideas/completed while the source URL stays unreadable to
+        # the optimizing agent. A failed run is deliberately left in_progress for
+        # inspection/resume, matching runner.py's own policy.
+        if [ "$_rc" -eq 0 ]; then
+            docker run --rm -e PYTHONPATH=/app/src:/app \
+                -v "$PROJECT_ROOT/ideas:/app/ideas" -w /app "$IMAGE_NAME" \
+                python -c "from pathlib import Path; from core.idea_manager import IdeaManager; IdeaManager(Path('/app/ideas')).update_status('${idea_id}', 'completed')" \
+                || echo -e "${YELLOW}Note: could not finalize idea status; left in_progress${NC}"
+        fi
+        return "$_rc"
     fi
 
     # Forward run: single container, mount declared resources read-only at

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -920,12 +920,52 @@ cmd_run() {
     )
 
     # Ideas that declare host-local resources (local_resources paths, local
-    # papers) get a sidecar written at submit time: ideas/mounts/<idea_id>.txt,
-    # one absolute host path per line. Mount each existing path read-only at
-    # its identical in-container location so staging works unmodified inside
-    # Docker.
+    # papers, a continuation source repo) get a sidecar written at submit
+    # time: ideas/mounts/<idea_id>.txt, one absolute host path per line.
     local idea_id="$1"
     local mounts_file="$PROJECT_ROOT/ideas/mounts/${idea_id}.txt"
+
+    # continue-research runs as two stages under one command. Stage 1 (prepare)
+    # needs the source repo + host materials mounted; Stage 2 (research, where
+    # the optimizing agent runs) must NOT see them. We enforce that with two
+    # containers: a PREPARE container that mounts the materials and runs
+    # `--prepare-only` (Stage 1), then a RESEARCH container that mounts only
+    # the workspace and runs Stage 2. runner.py detects the continuation
+    # contract and skips Stage 1 in the research container (the workspace is
+    # already prepared), so the materials are needed only in the prepare
+    # container. --prepare-only is a no-op on a forward idea, so a
+    # false-positive detection cannot run a forward pipeline with materials
+    # mounted (see run_research).
+    local is_continuation=false
+    if _idea_is_continuation "$idea_id"; then
+        is_continuation=true
+    fi
+
+    if [ "$is_continuation" = true ]; then
+        echo -e "${BLUE}continue-research: Stage 1 (prepare) in a materials-mounted container${NC}"
+        local prep_args=( "${docker_args[@]}" )
+        if [ -f "$mounts_file" ]; then
+            while IFS= read -r host_path; do
+                [ -z "$host_path" ] && continue
+                if [ -e "$host_path" ]; then
+                    prep_args+=( -v "$host_path:$host_path:ro" )
+                    echo -e "${BLUE}Mounting material (prepare only):${NC} $host_path"
+                else
+                    echo -e "${YELLOW}[SKIP]${NC} declared path not found: $host_path"
+                fi
+            done < "$mounts_file"
+        fi
+        prep_args+=( -w /app "$IMAGE_NAME" python /app/src/core/runner.py "$@" --prepare-only )
+        docker "${prep_args[@]}" || { echo -e "${RED}Prepare stage failed${NC}"; exit 1; }
+
+        echo -e "${BLUE}continue-research: Stage 2 (research) with NO source materials mounted${NC}"
+        docker_args+=( -w /app "$IMAGE_NAME" python /app/src/core/runner.py "$@" )
+        docker "${docker_args[@]}"
+        return
+    fi
+
+    # Forward run: single container, mount declared resources read-only at
+    # their identical in-container location so staging works unmodified.
     if [ -f "$mounts_file" ]; then
         while IFS= read -r host_path; do
             [ -z "$host_path" ] && continue
@@ -943,6 +983,22 @@ cmd_run() {
 
     docker_args+=( -w /app "$IMAGE_NAME" python /app/src/core/runner.py "$@" )
     docker "${docker_args[@]}"
+}
+
+# Whether an idea declares a continuation contract (source_repo). Detection is
+# a mount-boundary optimization only; runner.py's contract check is
+# authoritative, and --prepare-only is a no-op on a forward idea, so a
+# false positive here is harmless. Matches a `source_repo:` line inside the
+# idea YAML for this id, wherever IdeaManager stored it under ideas/.
+_idea_is_continuation() {
+    local idea_id="$1"
+    local f
+    while IFS= read -r f; do
+        if grep -qE '^\s*source_repo\s*:' "$f" 2>/dev/null; then
+            return 0
+        fi
+    done < <(grep -rl -- "$idea_id" "$PROJECT_ROOT/ideas" --include='*.yaml' 2>/dev/null)
+    return 1
 }
 
 # -----------------------------------------------------------------------------

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -720,6 +720,108 @@ cmd_submit_local() {
 }
 
 # -----------------------------------------------------------------------------
+# continue-research: convert <repo> <intention.md> into a continuation idea.
+# Mirrors submit-local's container mount setup. The conversion validates a
+# LOCAL repo path (it must exist and is resolved to absolute), so the repo is
+# mounted read-only at its identical host path; a remote URL needs no mount.
+# Actually running the idea is a separate `./neurico run <idea>` (which applies
+# the two-container prepare/research split), so --run is not handled here.
+# -----------------------------------------------------------------------------
+cmd_continue_research() {
+    if [ -z "$1" ] || [ -z "$2" ]; then
+        echo -e "${RED}Usage: $0 continue-research <repo> <intention.md> [--submit] [--provider claude|codex|gemini]${NC}"
+        exit 1
+    fi
+
+    ensure_directories
+    check_env_file
+    warn_if_outdated
+
+    local repo="$1"
+    local intention_file="$2"
+    shift 2
+
+    local passthrough=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --run)
+                echo -e "${YELLOW}Note: --run is not handled by the container wrapper.${NC}"
+                echo -e "      Convert (optionally with --submit), then run separately:"
+                echo -e "        ./neurico run <idea_id>"
+                ;;
+            *) passthrough+=("$1") ;;
+        esac
+        shift
+    done
+
+    if [ ! -f "$intention_file" ]; then
+        echo -e "${RED}Error: intention file not found: $intention_file${NC}"
+        exit 1
+    fi
+    local intention_abs intention_dir intention_name
+    intention_abs=$(cd "$(dirname "$intention_file")" && pwd)/$(basename "$intention_file")
+    intention_dir=$(dirname "$intention_abs")
+    intention_name=$(basename "$intention_abs")
+
+    local gpu_flags=$(get_gpu_flags)
+    local user_flags=$(get_user_flags)
+    local credential_mounts=$(get_cli_credential_mounts)
+    local workspace_dir=$(get_workspace_dir)
+    local tty_flag=$(get_tty_flag)
+
+    local docker_args=( run $tty_flag --rm )
+    local helper_args=()
+    eval "helper_args=( $gpu_flags $user_flags $credential_mounts )"
+    docker_args+=(
+        "${helper_args[@]}"
+        --env-file "$PROJECT_ROOT/.env"
+        -e NEURICO_WORKSPACE=/workspaces
+        -v "$workspace_dir:/workspaces"
+        -v "$PROJECT_ROOT/ideas:/app/ideas"
+        -v "$PROJECT_ROOT/logs:/app/logs"
+        -v "$PROJECT_ROOT/config:/app/config:ro"
+        -v "$PROJECT_ROOT/templates:/app/templates:ro"
+        -v "$intention_dir:/input:ro"
+    )
+
+    # A LOCAL repo must be readable in-container at its identical host path, so
+    # continue_research.py's exists()/resolve() succeeds and the source_repo it
+    # records matches the path `./neurico run` will later mount. A remote URL
+    # (http/https/git@) is cloned at adoption time and needs no mount.
+    case "$repo" in
+        http://*|https://*|git@*) ;;
+        *)
+            if [ ! -e "$repo" ]; then
+                echo -e "${RED}Error: repository path not found: $repo${NC}"
+                exit 1
+            fi
+            local repo_abs
+            repo_abs=$(cd "$repo" 2>/dev/null && pwd || echo "")
+            if [ -z "$repo_abs" ]; then
+                echo -e "${RED}Error: repository path is not a directory: $repo${NC}"
+                exit 1
+            fi
+            docker_args+=( -v "$repo_abs:$repo_abs:ro" )
+            repo="$repo_abs"
+            ;;
+    esac
+
+    # Host cwd at its identical path, so any relative paths in the intention
+    # resolve and canonicalize the same way they would natively.
+    if [ "$PWD" != "/" ] && [ "$PWD" != "$PROJECT_ROOT" ]; then
+        docker_args+=( -v "$PWD:$PWD:ro" )
+    fi
+    docker_args+=( -e NEURICO_HOST_CWD="$PWD" -e NEURICO_IN_DOCKER=1 )
+
+    docker_args+=( -w /app "$IMAGE_NAME"
+                   python /app/src/cli/continue_research.py "$repo" "/input/$intention_name"
+                   "${passthrough[@]}" )
+
+    echo -e "${BLUE}Converting continuation intention...${NC}"
+    docker "${docker_args[@]}"
+}
+
+# -----------------------------------------------------------------------------
 # Submit a research idea
 # -----------------------------------------------------------------------------
 cmd_submit() {
@@ -2205,6 +2307,7 @@ cmd_help() {
     echo "  shell                     Start an interactive shell"
     echo "  fetch <url> [--submit]    Fetch idea from IdeaHub"
     echo "  submit-local <idea.md> [--submit]  Convert a local idea file (markdown/text)"
+    echo "  continue-research <repo> <intention.md> [--submit]  Adopt-and-optimize an existing repo"
     echo "  submit <idea.yaml>        Submit a research idea"
     echo "  run <id> [options]        Run research exploration"
     echo "  hitl-web <id>             Open the containerized HITL workspace page"
@@ -2267,6 +2370,9 @@ case "$ACTION" in
         ;;
     submit-local)
         cmd_submit_local "$@"
+        ;;
+    continue-research)
+        cmd_continue_research "$@"
         ;;
     submit)
         cmd_submit "$@"

--- a/neurico
+++ b/neurico
@@ -8,6 +8,7 @@
 # Usage:
 #   ./neurico fetch <url>              # Fetch from IdeaHub
 #   ./neurico submit-local <idea.md>   # Submit a local idea file
+#   ./neurico continue-research <repo> <intention.md>   # Adopt-and-optimize a repo
 #   ./neurico submit <idea.yaml>       # Submit an idea
 #   ./neurico run <id> [options]       # Run research
 #   ./neurico hitl-web <id>            # Open the HITL web client

--- a/src/agents/eval_verifier.py
+++ b/src/agents/eval_verifier.py
@@ -50,8 +50,19 @@ VERDICT_CHECKS = {
     'routing': lambda contract: bool(contract['mandated_functions']),
     'transcription': lambda contract: bool(contract['evaluation'].get('metrics')),
     'format': lambda contract: bool(contract['evaluation'].get('results_format')),
+    # continue-research: the verifier must independently confirm the generated
+    # eval.py actually ENFORCES each declared invariant (reads the protected
+    # baseline and recomputes hashes; runs each check command), not just that a
+    # passing baseline reported them. Applicable whenever the continuation
+    # contract declares protected_path or check invariants.
+    'invariants': lambda contract: bool(contract['invariants']),
 }
 VERDICT_CHECK_VALUES = ('pass', 'fail', 'not_applicable')
+# Checks that need only be reported when the contract makes them applicable.
+# The original three are always required (reported not_applicable when they do
+# not apply); invariants is continuation-only, so a non-continuation verdict is
+# not obliged to mention it.
+OPTIONAL_UNLESS_APPLICABLE = {'invariants'}
 
 
 def has_user_eval_contract(idea: Dict[str, Any]) -> bool:
@@ -83,9 +94,22 @@ def extract_eval_contract(idea: Dict[str, Any]) -> Dict[str, Any]:
         func for func in (resources.get('functions') or [])
         if isinstance(func, dict) and func.get('required_for_evaluation')
     ]
+    # Continuation invariants the generated eval.py must enforce, normalized to
+    # {protected_paths: [...], checks: [...]} for the prompt and the predicate.
+    from core.local_resources import (
+        protected_path_prefixes,
+        continuation_check_commands,
+    )
+    invariants = {
+        'protected_paths': protected_path_prefixes(idea),
+        'checks': continuation_check_commands(idea),
+    }
+    if not (invariants['protected_paths'] or invariants['checks']):
+        invariants = {}
     return {
         'evaluation': evaluation,
         'mandated_functions': mandated,
+        'invariants': invariants,
     }
 
 
@@ -408,7 +432,12 @@ def interpret_verdict(
                        f"expected one of {list(VERDICT_CHECK_VALUES)}")
             elif value == 'fail':
                 failed.append(name)
-        missing = [name for name in VERDICT_CHECKS if name not in checks]
+        missing = [
+            name for name in VERDICT_CHECKS
+            if name not in checks
+            and (name not in OPTIONAL_UNLESS_APPLICABLE
+                 or VERDICT_CHECKS[name](contract))
+        ]
         if missing:
             reject(f"verification.json 'checks' must report every mandated check "
                    f"(use 'not_applicable' when a check does not apply); missing: {missing}")

--- a/src/agents/rule_maker_bootstrap.py
+++ b/src/agents/rule_maker_bootstrap.py
@@ -126,9 +126,13 @@ def run_bootstrap_rule_maker(
     timeout: int = 1800,
     full_permissions: bool = True,
     log_dir: Optional[Path] = None,
+    prompt_suffix: str = "",
 ) -> Dict[str, Any]:
     """
     Launch the bootstrap rule_maker agent against a workspace.
+
+    prompt_suffix is appended to the prompt: used on an eval-verifier retry to
+    feed the verifier's findings back so the regenerated harness fixes them.
 
     Returns a dict with success, return_code, elapsed_time, transcript_file,
     prompt_file, and a per-output-file existence summary.
@@ -150,6 +154,8 @@ def run_bootstrap_rule_maker(
         work_dir=work_dir,
         templates_dir=Path(templates_dir),
     )
+    if prompt_suffix:
+        prompt = prompt + "\n\n" + prompt_suffix
 
     if log_dir is not None:
         log_dir = Path(log_dir)

--- a/src/cli/continue_research.py
+++ b/src/cli/continue_research.py
@@ -1,0 +1,525 @@
+"""
+Convert continuation intention files into NeuriCo idea YAML format.
+
+Continue-research counterpart of submit_local.py: the user provides an
+existing repository (local path or GitHub URL) plus an intention file stating
+what to optimize and what must not break. The converter produces an idea
+whose continuation section drives the continue-research pipeline: the repo is
+adopted into a workspace, its current state is scored as an AutoResearch
+baseline, and iterations then optimize toward the stated goal.
+
+No GitHub repository is created at submit time: the workspace comes from
+adopting the user's repository when the run starts.
+
+Usage:
+    python continue_research.py <repo> <intention.md>
+    python continue_research.py https://github.com/user/project intention.md --submit --run
+"""
+
+import sys
+import os
+import re
+from pathlib import Path
+import yaml
+from dotenv import load_dotenv
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Load environment variables from .env.local or .env
+env_local = Path(__file__).parent.parent.parent / ".env.local"
+env_file = Path(__file__).parent.parent.parent / ".env"
+
+if env_local.exists():
+    load_dotenv(env_local)
+elif env_file.exists():
+    load_dotenv(env_file)
+
+# Conversion building blocks shared with the other converter CLIs
+from cli.idea_conversion import (
+    LOCAL_DECLARATION_RULES,
+    SUPPORTED_SUFFIXES,
+    infer_domain,
+    load_schema_reference,
+    make_llm_client,
+    parse_conversion,
+    read_idea_file,
+    save_yaml_file,
+)
+
+
+
+def _convert_without_llm(intention_content: dict, repo: str) -> dict:
+    """
+    Convert intention content to NeuriCo YAML format without using an LLM.
+
+    Produces a minimal but valid continuation idea using the file content
+    directly: the whole description becomes the goal, and no invariants are
+    extracted (structured extraction needs the LLM; the user can add them to
+    the YAML by hand).
+
+    Args:
+        intention_content: Dictionary with intention content from read_idea_file()
+        repo: Repository path or URL being continued
+
+    Returns:
+        Dictionary with 'parsed' and 'yaml_string' keys
+    """
+    title = intention_content.get('title') or 'Untitled Continuation'
+    description = intention_content.get('description', '')
+    tags = intention_content.get('tags', [])
+    source_path = intention_content.get('path', '')
+
+    # Infer domain from content
+    domain = infer_domain(title, description, tags)
+
+    goal = description.strip()
+    # Truncate very long goals to keep it reasonable
+    if len(goal) > 500:
+        goal = goal[:497] + '...'
+
+    # Build the idea structure
+    idea_data = {
+        'idea': {
+            'title': title,
+            'domain': domain,
+            'hypothesis': f"The existing work at {repo} can be improved: {goal}"[:500],
+            'continuation': {
+                'source_repo': repo,
+                'goal': goal,
+            },
+            'background': {
+                'description': description,
+            },
+            'metadata': {
+                'source': 'continuation',
+                'source_path': source_path,
+            },
+        }
+    }
+
+    if tags:
+        idea_data['idea']['metadata']['tags'] = tags
+
+    author = intention_content.get('author')
+    if author:
+        idea_data['idea']['metadata']['author'] = author
+
+    # Generate clean YAML string
+    yaml_string = yaml.dump(idea_data, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+    print("   ⚠️  This is a rough template-based conversion.")
+    print("   Invariants and evaluation metrics were NOT extracted; add them")
+    print("   to the YAML by hand before running.")
+
+    # Template conversion cannot extract structured local_resources; a path
+    # left only in background.description is never staged or mounted, so the
+    # faithfulness gate below will (correctly) reject the submission.
+    from core.local_resources import find_path_tokens
+    leftover = find_path_tokens(description)
+    if leftover:
+        print("   ⚠️  Local paths detected in the intention text:")
+        for token in leftover:
+            print(f"      - {token}")
+        print("   Without an API key they cannot be extracted into local_resources;")
+        print("   add a local_resources block to the YAML by hand (path + usage),")
+        print("   or set an API key and re-run the conversion.")
+
+    return {'parsed': idea_data, 'yaml_string': yaml_string, 'fallback': True}
+
+
+def convert_to_yaml(intention_content: dict, repo: str) -> dict:
+    """
+    Use GPT to convert intention content to NeuriCo continuation YAML format.
+
+    Args:
+        intention_content: Dictionary with intention content
+        repo: Repository path or URL being continued
+
+    Returns:
+        Dictionary in NeuriCo format
+    """
+    print("\n🤖 Converting to NeuriCo format using GPT...")
+
+    client, model_name = make_llm_client()
+    if client is None:
+        return _convert_without_llm(intention_content, repo)
+
+    schema_content = load_schema_reference()
+
+    # Build domain reference dynamically from config (single source of truth)
+    from core.config_loader import ConfigLoader
+    loader = ConfigLoader()
+    domains_cfg = loader.get_domains_config().get('domains', {})
+    domain_lines = [
+        f"     - {name}: {entry.get('description', '')}".rstrip()
+        for name, entry in domains_cfg.items()
+    ]
+    domain_reference = "\n".join(domain_lines)
+
+    # Create prompt for GPT - minimal formatting only
+    prompt = f"""You are converting a continue-research request into a simple YAML format.
+The user has an existing repository and wants an AI research pipeline to
+continue the work from its current state.
+
+# Source Repository
+
+{repo}
+
+# Intention Content
+
+Title: {intention_content.get('title', 'No title')}
+Tags: {', '.join(intention_content.get('tags', []))}
+Author: {intention_content.get('author') or 'Unknown'}
+
+Description/Content:
+{intention_content.get('description', 'No description')}
+
+# Task
+
+Convert this to a minimal YAML file with ONLY the information provided. Do NOT invent or make up:
+- Goals, constraints, or invariants that are not stated
+- Specific datasets (unless mentioned in the content)
+- Baselines or metrics (unless specified)
+- Commands that are not stated in the content
+
+# Schema Reference
+
+{schema_content}
+
+# Instructions
+
+1. **Required fields**:
+   - title: Use the provided title
+   - domain: Pick the best fit from this list (defined in config/domains.yaml):
+{domain_reference}
+   - hypothesis: Restate the optimization goal as a testable statement about
+     the existing work
+
+2. **Continuation section** (required for this request):
+   - source_repo: Copy the Source Repository above EXACTLY as given
+   - goal: The direction of improvement, in one or two sentences from the content
+   - invariants: One entry per "must not break / must not change / must keep
+     working" constraint in the content:
+       kind protected_path: files or directories no iteration may modify
+         (path, workspace-relative)
+       kind check: a runnable command that must keep passing; copy the
+         command VERBATIM from the content, do NOT invent one. If the content
+         demands something keep working but gives no command, use kind
+         statement instead.
+       kind statement: a prose constraint with no runnable check
+     Give each invariant the reason stated in the content.
+   - When the goal contains explicit numeric thresholds, ALSO transcribe each
+     one as an evaluation.metrics entry (name + definition + target) so the
+     scoring contract can carry it verbatim.
+
+3. {LOCAL_DECLARATION_RULES}
+
+4. **DO NOT include**:
+   - methodology (agent will design this)
+   - expected_outputs (agent will determine)
+   - evaluation_criteria (use the evaluation block for explicitly stated
+     metrics; otherwise the rule maker will establish criteria)
+   - Any made-up datasets, baselines, metrics, or commands
+
+Keep it minimal. The agent does the research.
+
+# Output Format
+
+Return ONLY clean, valid YAML content starting with "idea:".
+
+IMPORTANT formatting rules:
+- Use single quotes for strings with special characters (colons, quotes, etc.)
+- Use the literal block scalar style (|) for multi-line text to avoid escape sequences
+- Ensure all unicode characters (ü, &, etc.) are preserved as-is, not escaped
+- Do not include markdown code fences (```yaml) or explanations
+- Make the YAML clean and readable
+"""
+
+    try:
+        print("   Calling GPT API...")
+        response = client.chat.completions.create(
+            model=model_name,
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a research assistant that formats continue-research requests into minimal YAML. Only include information explicitly provided - do not invent goals, constraints, datasets, or commands. Return valid YAML without markdown formatting."
+                },
+                {
+                    "role": "user",
+                    "content": prompt
+                }
+            ],
+            temperature=0.1,  # Lower temperature for more conservative output
+            max_tokens=2000  # Reduced since we want minimal output
+        )
+
+        yaml_content = response.choices[0].message.content.strip()
+        print("   ✓ Conversion complete")
+        return parse_conversion(yaml_content)
+
+    except Exception as e:
+        print(f"⚠️  GPT API call failed: {e}")
+        print("   Falling back to template-based conversion.")
+        return _convert_without_llm(intention_content, repo)
+
+
+def enforce_source_repo(result: dict, repo: str) -> dict:
+    """
+    Deterministically pin continuation.source_repo to the CLI argument.
+
+    The prompt tells the model to copy the repository verbatim, but the field
+    is load-bearing (adoption clones from it), so it is set here rather than
+    trusted. Errors out if the model produced no continuation section with a
+    goal: without a goal there is nothing to optimize toward.
+    """
+    parsed = result['parsed']
+    idea = parsed.get('idea') if isinstance(parsed, dict) else None
+    if not isinstance(idea, dict):
+        print("❌ Error: conversion did not produce a valid idea structure")
+        sys.exit(1)
+
+    continuation = idea.get('continuation')
+    if not isinstance(continuation, dict) or not str(continuation.get('goal', '')).strip():
+        print("❌ Error: no optimization goal found in the intention file.")
+        print("   State clearly what should be improved and re-run.")
+        sys.exit(1)
+
+    if continuation.get('source_repo') != repo:
+        continuation['source_repo'] = repo
+        result['yaml_string'] = yaml.dump(parsed, default_flow_style=False,
+                                          sort_keys=False, allow_unicode=True)
+    return result
+
+
+
+def main():
+    """Main function."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Convert continuation intention files into NeuriCo idea YAML format"
+    )
+    parser.add_argument(
+        "repo",
+        help="Existing repository to continue (local path or GitHub URL)"
+    )
+    parser.add_argument(
+        "intention_file",
+        help="Path to intention file (.md, .markdown, or .txt): the goal and constraints"
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Output YAML file path (default: auto-generate in ideas/)",
+        default=None
+    )
+    parser.add_argument(
+        "--submit",
+        action="store_true",
+        help="Automatically submit the idea after conversion"
+    )
+    parser.add_argument(
+        "--provider",
+        choices=["claude", "gemini", "codex"],
+        default=None,
+        help="AI provider for --run execution"
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Immediately run continue-research after submission (requires --submit)"
+    )
+    parser.add_argument(
+        "--autoresearch-iterations",
+        type=int,
+        default=1,
+        help="Number of AutoResearch iterations to run after the baseline (default: 1)"
+    )
+    parser.add_argument(
+        "--full-permissions",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Allow full permissions to CLI agents (claude: --dangerously-skip-permissions, others: --yolo) (default: True, use --no-full-permissions to disable)"
+    )
+
+    args = parser.parse_args()
+
+    # Validate --run requires --submit
+    if args.run and not args.submit:
+        print("❌ Error: --run requires --submit flag")
+        sys.exit(1)
+
+    # Validate the repository argument: a URL is checked at adoption time, a
+    # local path must exist now
+    if not args.repo.startswith(('http://', 'https://', 'git@')):
+        repo_path = Path(args.repo).expanduser()
+        if not repo_path.exists():
+            print(f"❌ Error: repository path not found: {args.repo}")
+            sys.exit(1)
+        args.repo = str(repo_path.resolve())
+
+    # Validate input file
+    intention_file = Path(args.intention_file)
+    if not intention_file.exists():
+        print(f"❌ Error: File not found: {intention_file}")
+        sys.exit(1)
+    if intention_file.suffix.lower() not in SUPPORTED_SUFFIXES:
+        print(f"❌ Error: Unsupported file type: {intention_file.suffix}")
+        print(f"   Supported types: {', '.join(sorted(SUPPORTED_SUFFIXES))}")
+        sys.exit(1)
+
+    print("=" * 80)
+    print("Continue Research to NeuriCo Converter")
+    print("=" * 80)
+
+    # Step 1: Read content
+    intention_content = read_idea_file(intention_file)
+
+    if intention_content.get('title'):
+        print(f"\n✓ Found intention: {intention_content['title']}")
+
+    # Step 2: Convert with GPT
+    result = convert_to_yaml(intention_content, args.repo)
+    result = enforce_source_repo(result, args.repo)
+
+    # Faithfulness check: every local path mentioned in the source file must
+    # survive conversion verbatim. A dropped path means the agent would never
+    # learn the resource exists, so this is a hard failure.
+    from core.local_resources import missing_paths_in_idea
+    dropped = missing_paths_in_idea(intention_content['raw_text'], result['parsed'])
+    if dropped:
+        print("\n❌ Error: conversion dropped local paths mentioned in the intention:")
+        for token in dropped:
+            print(f"   - {token}")
+        print("   Re-run the conversion, or state each path's usage more explicitly")
+        print("   in the intention file so it lands in local_resources.")
+        sys.exit(1)
+
+    # Canonicalize relative paths to host-absolute while the submitter's
+    # working directory still gives them meaning. Inside Docker, run.sh
+    # passes the host cwd via NEURICO_HOST_CWD (and mounts it at the same
+    # location) so the recorded paths keep host semantics for the mounts
+    # sidecar and for staging at run time.
+    from core.local_resources import canonicalize_local_paths
+    host_cwd = os.environ.get('NEURICO_HOST_CWD')
+    rewrites = canonicalize_local_paths(
+        result['parsed'].get('idea', {}),
+        base_dir=Path(host_cwd) if host_cwd else None)
+    if rewrites:
+        print("\n📍 Canonicalized relative resource paths:")
+        for before, after in rewrites:
+            print(f"   {before} -> {after}")
+        result['yaml_string'] = yaml.dump(
+            result['parsed'], default_flow_style=False,
+            sort_keys=False, allow_unicode=True)
+
+    # Step 3: Save file
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write(result['yaml_string'])
+    else:
+        output_path = save_yaml_file(
+            result, str(intention_file),
+            author=intention_content.get('author'),
+            source_kind='continuation',
+            fallback_filename=f"continuation_{intention_file.stem}")
+
+    print(f"\n✅ Idea saved to: {output_path}")
+
+    # A template-fallback conversion carries the user's words only as prose:
+    # no invariants and no evaluation metrics were extracted, so nothing in
+    # the intention would be mechanically enforced. Submitting that
+    # automatically would start an unprotected run while KNOWING the
+    # conversion is incomplete — refuse, mirroring the faithfulness gate.
+    if args.submit and result.get('fallback'):
+        print("\n❌ Error: the conversion ran without an LLM, so invariants and")
+        print("   evaluation metrics from the intention were NOT extracted and")
+        print("   would not be enforced. Refusing --submit.")
+        print(f"   Edit {output_path} by hand (add continuation.invariants and")
+        print("   evaluation as needed), then submit the YAML directly:")
+        print(f"   python src/cli/submit.py {output_path}")
+        sys.exit(1)
+
+    # Step 4: Optionally submit
+    if args.submit:
+        print("\n📤 Submitting idea to NeuriCo...")
+        from core.idea_manager import IdeaManager
+
+        manager = IdeaManager()
+        idea_id = manager.submit_idea(result['parsed'], validate=True)
+
+        print(f"\n✓ Idea submitted successfully: {idea_id}")
+
+        # Optionally run continue-research immediately
+        in_docker = (os.environ.get('NEURICO_IN_DOCKER')
+                     or os.path.exists('/.dockerenv'))
+        if args.run and in_docker:
+            # Running in-process here would bypass the host-side
+            # `./neurico run`, which is the only path that mounts the
+            # declared local resources and the continuation source repo
+            # (ideas/mounts/<idea_id>.txt) into the research container.
+            # docker/run.sh intercepts --run and dispatches to cmd_run
+            # itself; reaching this branch means continue_research was
+            # invoked in Docker directly.
+            print("\n⚠️  --run inside the submission container would not see the")
+            print("   declared local resources or the source repository. Run")
+            print("   instead (from the host):")
+            print(f"   ./neurico run {idea_id} --provider "
+                  f"{args.provider or 'claude'} --full-permissions")
+        elif args.run:
+            print("\n" + "=" * 80)
+            print("RUNNING CONTINUE-RESEARCH")
+            print("=" * 80)
+
+            try:
+                from core.runner import ResearchRunner
+
+                runner = ResearchRunner(use_github=False)
+
+                provider = args.provider or "claude"
+                print(f"\n🤖 Starting continue-research with provider: {provider}")
+
+                run_result = runner.run_research(
+                    idea_id=idea_id,
+                    provider=provider,
+                    full_permissions=args.full_permissions,
+                    multi_agent=True,
+                    write_paper=False,
+                    autoresearch=True,
+                    autoresearch_iterations=args.autoresearch_iterations,
+                )
+
+                print("\n" + "=" * 80)
+                if run_result.get('success'):
+                    print("✅ CONTINUE-RESEARCH COMPLETED SUCCESSFULLY")
+                else:
+                    print("⚠️  CONTINUE-RESEARCH COMPLETED (with issues)")
+                print(f"   Location: {run_result['work_dir']}")
+                print("=" * 80)
+
+            except Exception as e:
+                print(f"\n❌ Continue-research execution failed: {e}")
+                print(f"   You can retry with: ./neurico run {idea_id} --provider claude --full-permissions")
+
+        else:
+            print("\n" + "=" * 80)
+            print("NEXT STEPS")
+            print("=" * 80)
+            provider_str = f" --provider {args.provider}" if args.provider else ""
+            print(f"\nRun the continuation:")
+            print(f"  ./neurico run {idea_id}{provider_str} --full-permissions")
+    else:
+        print(f"\nTo submit this idea:")
+        print(f"  python src/cli/submit.py {output_path}")
+
+    print("\n" + "=" * 80)
+    print("Done!")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cli/idea_conversion.py
+++ b/src/cli/idea_conversion.py
@@ -1,0 +1,307 @@
+"""
+Idea Conversion Helpers
+
+Building blocks for converting a free-form idea source into NeuriCo idea YAML.
+Currently used by the continuation intention converter (continue_research.py);
+written to be reusable by other converters (submit_local, fetch_from_ideahub),
+though those have not yet been migrated onto it.
+
+- Reading local idea files (frontmatter, heading-derived titles)
+- LLM client selection (OpenRouter preferred, direct OpenAI fallback)
+- Cleanup of raw LLM output (code fences, placeholder author)
+- The extraction rules for local resources and evaluation specs, embedded
+  verbatim in the converter prompt so the contract semantics are consistent
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+import yaml
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+SUPPORTED_SUFFIXES = {'.md', '.markdown', '.txt'}
+
+
+# Shared prompt fragment: how converters must handle locally declared
+# resources and explicit evaluation expectations. Used by submit_local.py and
+# continue_research.py so both entry points produce identical contract fields.
+LOCAL_DECLARATION_RULES = """\
+**Local resources**: The idea may declare datasets or functions that already
+exist on this machine.
+   - Copy every local path VERBATIM. Do NOT rewrite, resolve, or drop local paths.
+   - If the content states what a local dataset or function is FOR (its usage),
+     put it under local_resources:
+       datasets: path + usage (+ name)
+       functions: path + entrypoint + usage
+     If the content says evaluation must run through a function, also set
+     required_for_evaluation: true on that function.
+   - Mark a dataset sealed: true when the content presents it as held-out
+     evaluation data the experiment must not see or fit to (a benchmark, a
+     test set, "never train on this"). Training and general-purpose data
+     stays unsealed. When one dataset has distinct parts, declare separate
+     entries (the training part unsealed, the held-out part sealed).
+   - Local paths whose usage is NOT stated stay in the matching background
+     field instead (datasets source, code_references repo, papers path).
+
+**Evaluation spec**: Only if the content gives explicit metric names,
+   success thresholds, or an expected results format, transcribe them
+   VERBATIM into the evaluation block (metrics: name + definition + target;
+   results_format). Do not reinterpret numbers and do not invent metrics
+   that are not stated. Include results_format ONLY if the content itself
+   describes an output artifact or file format; never copy one from the
+   schema examples."""
+
+
+def read_idea_file(file_path: Path) -> dict:
+    """
+    Read an idea (or intention) from a local markdown or text file.
+
+    Supports optional YAML frontmatter (delimited by ---) for title, tags,
+    and author. Falls back to the first markdown heading for the title, then
+    to the filename.
+
+    Args:
+        file_path: Path to the local file
+
+    Returns:
+        Dictionary with extracted content (path, title, description, tags,
+        author, raw_text)
+    """
+    print(f"📥 Reading idea from local file...")
+    print(f"   Path: {file_path}")
+
+    try:
+        raw_text = file_path.read_text(encoding='utf-8')
+    except OSError as e:
+        print(f"❌ Error reading file: {e}")
+        sys.exit(1)
+
+    body = raw_text
+    title = None
+    tags = []
+    author = None
+
+    # Parse optional YAML frontmatter
+    frontmatter_match = re.match(r'^---\s*\n(.*?)\n---\s*\n', raw_text, re.DOTALL)
+    if frontmatter_match:
+        try:
+            frontmatter = yaml.safe_load(frontmatter_match.group(1)) or {}
+        except yaml.YAMLError:
+            frontmatter = {}
+        if isinstance(frontmatter, dict):
+            title = frontmatter.get('title')
+            author = frontmatter.get('author')
+            fm_tags = frontmatter.get('tags')
+            if isinstance(fm_tags, list):
+                tags = [str(t) for t in fm_tags]
+            elif isinstance(fm_tags, str):
+                tags = [t.strip() for t in fm_tags.split(',') if t.strip()]
+        body = raw_text[frontmatter_match.end():]
+
+    # Fall back to the first markdown heading for the title
+    heading_match = re.search(r'^#{1,3}\s+(.+?)\s*$', body, re.MULTILINE)
+    if not title and heading_match:
+        title = heading_match.group(1).strip()
+
+    # Drop the heading line from the description when it duplicates the title
+    if title and heading_match and heading_match.group(1).strip() == title.strip():
+        body = body[:heading_match.start()] + body[heading_match.end():]
+
+    # Last resort: derive the title from the filename
+    if not title:
+        title = file_path.stem.replace('_', ' ').replace('-', ' ').strip().title()
+
+    description = body.strip()
+    if not description:
+        print(f"❌ Error: file has no content beyond the title")
+        sys.exit(1)
+
+    return {
+        'path': str(file_path),
+        'title': title,
+        'description': description,
+        'tags': tags,
+        'author': author,
+        'raw_text': raw_text
+    }
+
+
+def make_llm_client():
+    """
+    Build the conversion LLM client: prefer OpenRouter (the repo default),
+    fall back to a direct OpenAI key.
+
+    Returns:
+        Tuple of (client, model_name), or (None, None) when no key is set or
+        the openai package is unavailable (callers fall back to
+        template-based conversion). Prints the reason when returning None.
+    """
+    openrouter_key = os.getenv('OPENROUTER_KEY') or os.getenv('OPENROUTER_API_KEY')
+    api_key = openrouter_key or os.getenv('OPENAI_API_KEY')
+    if not api_key:
+        print("ℹ️  No OPENROUTER_KEY or OPENAI_API_KEY set — using template-based conversion instead.")
+        return None, None
+
+    try:
+        from openai import OpenAI
+    except ImportError:
+        print("ℹ️  openai package not installed — using template-based conversion instead.")
+        return None, None
+
+    if openrouter_key:
+        return OpenAI(api_key=api_key, base_url=OPENROUTER_BASE_URL), "openai/gpt-4.1"
+    return OpenAI(api_key=api_key), "gpt-4.1"
+
+
+def load_schema_reference() -> str:
+    """Read ideas/schema.yaml for embedding in conversion prompts."""
+    schema_path = Path(__file__).parent.parent.parent / "ideas" / "schema.yaml"
+    with open(schema_path, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+def parse_conversion(yaml_content: str) -> dict:
+    """
+    Turn raw LLM output into the conversion result dict.
+
+    Strips markdown code fences, parses the YAML (with the historical
+    second-chance parse on error), and removes the 'Unknown' author
+    placeholder when the model emitted it despite being told to omit it.
+
+    Args:
+        yaml_content: Raw text returned by the conversion LLM
+
+    Returns:
+        Dictionary with 'parsed' and 'yaml_string' keys
+    """
+    yaml_content = re.sub(r'^```ya?ml\s*\n', '', yaml_content.strip())
+    yaml_content = re.sub(r'\n```\s*$', '', yaml_content)
+    yaml_content = yaml_content.strip()
+
+    try:
+        parsed = yaml.safe_load(yaml_content)
+    except yaml.YAMLError as e:
+        print(f"⚠️  Warning: Generated YAML may have issues: {e}")
+        print("   Attempting to fix...")
+        # Try to parse anyway
+        parsed = yaml.safe_load(yaml_content)
+
+    parsed, yaml_content = drop_placeholder_author(parsed, yaml_content)
+    return {'parsed': parsed, 'yaml_string': yaml_content}
+
+
+def drop_placeholder_author(parsed: dict, yaml_string: str) -> tuple:
+    """
+    Remove metadata.author when the model emitted the 'Unknown' placeholder
+    despite being told to omit it. Regenerates the YAML string only when a
+    drop actually happened, so faithful conversions stay byte-identical.
+    """
+    try:
+        metadata = parsed['idea']['metadata']
+        author = metadata.get('author')
+    except (KeyError, TypeError):
+        return parsed, yaml_string
+
+    if isinstance(author, str) and author.strip().lower() in ('unknown', ''):
+        del metadata['author']
+        if not metadata:
+            del parsed['idea']['metadata']
+        yaml_string = yaml.dump(parsed, default_flow_style=False,
+                                sort_keys=False, allow_unicode=True)
+    return parsed, yaml_string
+
+
+def infer_domain(title: str, description: str, tags: list) -> str:
+    """Infer research domain from title, description, and tags using keyword matching.
+
+    Reads keywords from config/domains.yaml — no hardcoding here.
+    """
+    from core.config_loader import ConfigLoader
+    loader = ConfigLoader()
+    keyword_map = loader.get_all_domain_keywords()
+    default = loader.get_default_domain()
+
+    text = f"{title} {description} {' '.join(tags)}".lower()
+    best_domain = default
+    best_count = 0
+    for domain, keywords in keyword_map.items():
+        count = sum(1 for kw in keywords if kw in text)
+        if count > best_count:
+            best_count = count
+            best_domain = domain
+    return best_domain
+
+
+def save_yaml_file(result: dict, source_ref: str, author: str = None, *,
+                   source_kind: str, fallback_filename: str,
+                   source_key: str = 'source_path') -> Path:
+    """
+    Save a converted idea as a YAML file under ideas/.
+
+    Parameterized by provenance so different converters can reuse it: the
+    metadata `source` tag (source_kind), which metadata key carries the
+    original reference (source_key: source_path for files, source_url for
+    IdeaHub), and the filename used when the idea has no usable title
+    (fallback_filename). Currently the continuation converter uses it.
+
+    Args:
+        result: Dictionary with 'parsed' and 'yaml_string' keys (mutated:
+                parsed gains the provenance metadata)
+        source_ref: Original file path or URL the idea came from
+        author: Optional author name
+
+    Returns:
+        Path to saved file
+    """
+    idea_data = result['parsed']
+    yaml_string = result['yaml_string']
+
+    # Generate filename from title, falling back to the caller's derivation
+    if 'idea' in idea_data and 'title' in idea_data['idea']:
+        title = idea_data['idea']['title']
+        # Sanitize title for filename
+        filename = re.sub(r'[^\w\s-]', '', title.lower())
+        filename = re.sub(r'[-\s]+', '_', filename)
+        filename = filename[:50]  # Limit length
+    else:
+        filename = fallback_filename
+
+    # Add metadata about source to the parsed data (for submission later)
+    if 'idea' not in idea_data:
+        idea_data = {'idea': idea_data}
+
+    if 'metadata' not in idea_data['idea']:
+        idea_data['idea']['metadata'] = {}
+
+    idea_data['idea']['metadata']['source'] = source_kind
+    idea_data['idea']['metadata'][source_key] = source_ref
+
+    if author and 'author' not in idea_data['idea']['metadata']:
+        idea_data['idea']['metadata']['author'] = author
+
+    # Update the result AND regenerate the YAML text from the mutated tree, so
+    # the provenance metadata we just added actually lands in the saved file
+    # (the raw model output written verbatim would not carry it).
+    result['parsed'] = idea_data
+    yaml_string = yaml.dump(idea_data, default_flow_style=False, sort_keys=False)
+    result['yaml_string'] = yaml_string
+
+    # Save to ideas/ directory
+    ideas_dir = Path(__file__).parent.parent.parent / "ideas"
+    ideas_dir.mkdir(exist_ok=True)
+
+    output_path = ideas_dir / f"{filename}.yaml"
+
+    # Check if file exists
+    counter = 1
+    while output_path.exists():
+        output_path = ideas_dir / f"{filename}_{counter}.yaml"
+        counter += 1
+
+    # Save the GPT-generated YAML string directly
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write(yaml_string)
+
+    return output_path

--- a/src/core/continuation_prepare.py
+++ b/src/core/continuation_prepare.py
@@ -37,10 +37,13 @@ from typing import Any, Callable, Dict, List, Optional
 # the workspace while agents run (the same protection every NeuriCo run gets).
 SEALED_STAGING_DIR = "data/.test"
 
-# Trusted baseline of protected-path content, written by Stage 1 and read by the
+# Trusted baseline of the protected paths, written by Stage 1 and read by the
 # generated eval.py to enforce `protected_path` invariants as a hard scoring
 # guardrail (the `protected_paths_unchanged` property). Written in this trusted
-# phase before the optimizing agent exists, so its hashes cannot be forged.
+# phase before the optimizing agent exists. Records the git commit the protected
+# paths were captured in, not a hash: git is the single source of truth for
+# whether they changed, so there is no hand-rolled hash for eval.py to mirror
+# (and drift from).
 PROTECTED_BASELINE_FILE = "scoring/protected_baseline.json"
 
 
@@ -52,92 +55,53 @@ def _gitignore_add(work_dir: Path, line: str) -> None:
         gitignore.write_text(prefix + line + "\n", encoding="utf-8")
 
 
-def _hash_entry(digest: "hashlib._Hash", rel: str, path: Path) -> None:
-    """Fold one filesystem entry into digest, covering the kinds of change a
-    protected-path guardrail must catch: content, permission bits, symlink
-    identity, and the existence of (even empty) directories.
-
-    The generated eval.py MUST mirror this exactly (see
-    templates/agents/rule_maker_bootstrap.txt), or the baseline written here and
-    the runtime recomputation would disagree.
-    """
-    import os
-    import stat as stat_mod
-
-    digest.update(rel.encode("utf-8"))
-    digest.update(b"\0")
-    lst = path.lstat()
-    if stat_mod.S_ISLNK(lst.st_mode):
-        # Symlink: record BOTH its identity (target string, so a repointed link
-        # counts even if the new target reads the same) AND the content behind
-        # it (so a change to the target's bytes under an unchanged link counts).
-        # Cycle-safe: _content_signature walks real files via rglob, which does
-        # not follow symlinked directories.
-        digest.update(b"link\0")
-        digest.update(os.readlink(path).encode("utf-8"))
-        try:
-            resolved = path.resolve()
-            if resolved.is_file() or resolved.is_dir():
-                digest.update(b"\0target\0")
-                digest.update(_content_signature(resolved).encode("utf-8"))
-        except (OSError, RuntimeError):
-            pass  # broken or cyclic link: identity string already recorded
-    elif path.is_dir():
-        # Record directory existence so an added/removed EMPTY directory counts.
-        digest.update(b"dir\0")
-        digest.update(f"{stat_mod.S_IMODE(lst.st_mode):04o}".encode("utf-8"))
-    else:
-        digest.update(b"file\0")
-        digest.update(f"{stat_mod.S_IMODE(lst.st_mode):04o}".encode("utf-8"))
-        digest.update(b"\0")
-        digest.update(path.read_bytes())
-
-
-def _hash_protected_path(root: Path) -> str:
-    """Change-detecting hash of a protected file or directory tree.
-
-    Covers content, permission bits, symlink identity, and empty directories,
-    so a chmod, a repointed symlink, or an added/removed empty directory under a
-    protected prefix all change the hash (bytes-only hashing missed all three).
-    A directory folds in every entry's relative path so adding, removing,
-    renaming, or editing anything under the prefix changes it.
-    """
-    root = Path(root)
-    digest = hashlib.sha256()
-    if root.is_symlink() or root.is_file() or not root.is_dir():
-        _hash_entry(digest, "", root)
-        return digest.hexdigest()
-    # A real directory root: fold in the root's OWN mode first (a chmod on the
-    # protected directory itself must count), then every descendant.
-    _hash_entry(digest, "", root)
-    for path in sorted(root.rglob("*"), key=lambda p: p.relative_to(root).as_posix()):
-        _hash_entry(digest, path.relative_to(root).as_posix(), path)
-    return digest.hexdigest()
-
-
-def write_protected_baseline(idea: Dict[str, Any], work_dir: Path) -> Dict[str, str]:
-    """Record sha256 of each declared `protected_path` into the trusted baseline.
+def write_protected_baseline(idea: Dict[str, Any], work_dir: Path) -> Dict[str, Any]:
+    """Anchor the `protected_path` invariants to a git baseline commit.
 
     Written in Stage 1 (no optimizing agent) so the generated eval.py can flag
-    any change to a protected path. Returns the {path: sha256} map (empty when
-    no protected_path invariants are declared, in which case no file is written).
+    any change to a protected path. We use git purely as an IMMUTABLE, content-
+    addressed baseline STORE: force-add each declared protected path (so even a
+    gitignored one is captured), commit if that staged anything, and record the
+    resulting commit sha. eval.py reads the baseline objects back with
+    `git ls-tree` / `git cat-file blob` (which the agent cannot forge at a fixed
+    sha) and compares them to the real filesystem with plain Python reads.
+
+    It deliberately does NOT record a hand-rolled hash (that had to be mirrored
+    in eval.py byte-for-byte and drifted), and eval.py deliberately does NOT use
+    `git diff` / `git ls-files` to detect change: the Stage 2 agent controls the
+    workspace .git (index skip bits, clean filters, core.fileMode, .gitignore),
+    each of which can make git's working-tree view report a modified protected
+    file as clean. Reading immutable blobs + raw filesystem bytes is immune to
+    all of those, and the comparison lives only in eval.py, so nothing drifts.
+
+    Returns {"baseline_ref": <sha>, "paths": [...]} (empty, and no file written,
+    when no protected_path invariants are declared).
     """
     from core.local_resources import protected_path_prefixes
+    from core.repo_adoption import _git
 
     work_dir = Path(work_dir)
-    baseline: Dict[str, str] = {}
-    for rel in protected_path_prefixes(idea):
-        target = work_dir / rel
-        if target.exists():
-            baseline[rel] = _hash_protected_path(target)
-        # A declared protected path that is absent at prepare time is recorded
-        # as a sentinel, so its later CREATION is also a guardrail violation.
-        else:
-            baseline[rel] = "__absent__"
-    if baseline:
-        dst = work_dir / PROTECTED_BASELINE_FILE
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        dst.write_text(json.dumps(baseline, indent=2, sort_keys=True), encoding="utf-8")
+    paths = list(protected_path_prefixes(idea))
+    if not paths:
+        return {}
+
+    # Force-add every declared path that exists (-f so a gitignored protected
+    # path is still tracked in the baseline). A path absent at prepare time is
+    # still recorded: its later creation shows up as a diff or an untracked file.
+    for rel in paths:
+        if (work_dir / rel).exists():
+            _git(work_dir, "add", "-f", "--", rel)
+    # Commit only if force-adding staged something new; otherwise the current
+    # HEAD (the anchor commit) already captures the protected paths.
+    if _git(work_dir, "diff", "--cached", "--quiet").returncode != 0:
+        _git(work_dir, "commit", "-m",
+             "continue-research: protected-path baseline")
+    baseline_ref = _git(work_dir, "rev-parse", "HEAD").stdout.strip()
+
+    baseline: Dict[str, Any] = {"baseline_ref": baseline_ref, "paths": paths}
+    dst = work_dir / PROTECTED_BASELINE_FILE
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(json.dumps(baseline, indent=2, sort_keys=True), encoding="utf-8")
     return baseline
 
 
@@ -457,10 +421,11 @@ def prepare_continuation_workspace(
     #    goal + invariants + the data/.test held-out reference.
     _write_workspace_idea(idea, work_dir)
 
-    # 4b. Record the trusted baseline hashes of every declared protected_path,
-    #    computed here (no optimizing agent) from the adopted+staged tree. The
-    #    generated eval.py compares against this to enforce protected_path
-    #    invariants as the hard `protected_paths_unchanged` scoring guardrail.
+    # 4b. Anchor every declared protected_path to a git baseline commit here (no
+    #    optimizing agent), from the adopted+staged tree. The generated eval.py
+    #    asks git whether any protected path differs from this ref to enforce
+    #    protected_path invariants as the hard `protected_paths_unchanged`
+    #    scoring guardrail.
     write_protected_baseline(idea, work_dir)
 
     # 5. Generate the scorer AND score the baseline, all in this trusted phase,

--- a/src/core/continuation_prepare.py
+++ b/src/core/continuation_prepare.py
@@ -1,0 +1,329 @@
+"""
+Continuation preparation -- Stage 1 of continue-research.
+
+Turns an existing repository + a continuation contract (goal, invariants) +
+declared evaluation materials into a STANDARD NeuriCo workspace, then stops.
+
+The point of the two-stage design: NO optimizing (reward-seeking) agent runs
+here. Adoption, held-out staging, and scorer generation are the trusted setup,
+and they complete before Stage 2 ever spawns the optimizing agent. So the agent
+never coexists with the raw materials, the scorer generation, or any protocol
+regeneration -- which is what removes the whole class of tampering/leak bugs
+the single-stage design kept hitting.
+
+The output is an ordinary NeuriCo workspace:
+
+    <work_dir>/
+        <adopted repo>                 fresh git history + anchor commit
+        scoring/{eval.py,targets.json,interface.md}   rule-maker generated
+        data/.test/...                 held-out materials, gitignored
+        .neurico/idea.yaml             redacted continuation contract
+
+Stage 2 (a plain NeuriCo run) consumes this exactly as it would any workspace;
+it needs no continue-research-specific code.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+# Held-out evaluation data lands here, gitignored. eval.py reads it at this
+# workspace-relative path; Stage 2's ordinary scoring seal relocates it out of
+# the workspace while agents run (the same protection every NeuriCo run gets).
+SEALED_STAGING_DIR = "data/.test"
+
+# Trusted baseline of protected-path content, written by Stage 1 and read by the
+# generated eval.py to enforce `protected_path` invariants as a hard scoring
+# guardrail (the `protected_paths_unchanged` property). Written in this trusted
+# phase before the optimizing agent exists, so its hashes cannot be forged.
+PROTECTED_BASELINE_FILE = "scoring/protected_baseline.json"
+
+
+def _gitignore_add(work_dir: Path, line: str) -> None:
+    gitignore = Path(work_dir) / ".gitignore"
+    existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    if line not in existing.splitlines():
+        prefix = existing.rstrip("\n") + "\n" if existing.strip() else ""
+        gitignore.write_text(prefix + line + "\n", encoding="utf-8")
+
+
+def _hash_protected_path(root: Path) -> str:
+    """sha256 of a protected file, or of a directory tree (sorted relpath+bytes).
+
+    A directory hash folds in each file's relative path and content so adding,
+    removing, renaming, or editing any file under a protected prefix changes it.
+    """
+    root = Path(root)
+    digest = hashlib.sha256()
+    if root.is_file():
+        digest.update(root.read_bytes())
+        return digest.hexdigest()
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        digest.update(path.relative_to(root).as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def write_protected_baseline(idea: Dict[str, Any], work_dir: Path) -> Dict[str, str]:
+    """Record sha256 of each declared `protected_path` into the trusted baseline.
+
+    Written in Stage 1 (no optimizing agent) so the generated eval.py can flag
+    any change to a protected path. Returns the {path: sha256} map (empty when
+    no protected_path invariants are declared, in which case no file is written).
+    """
+    from core.local_resources import protected_path_prefixes
+
+    work_dir = Path(work_dir)
+    baseline: Dict[str, str] = {}
+    for rel in protected_path_prefixes(idea):
+        target = work_dir / rel
+        if target.exists():
+            baseline[rel] = _hash_protected_path(target)
+        # A declared protected path that is absent at prepare time is recorded
+        # as a sentinel, so its later CREATION is also a guardrail violation.
+        else:
+            baseline[rel] = "__absent__"
+    if baseline:
+        dst = work_dir / PROTECTED_BASELINE_FILE
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text(json.dumps(baseline, indent=2, sort_keys=True), encoding="utf-8")
+    return baseline
+
+
+def _resolve_source(raw: str, work_dir: Path, base_dir: Optional[Path]) -> Path:
+    """Resolve a declared held-out source path.
+
+    An absolute or ~ path is a host material; a relative path is resolved
+    against base_dir (submitting dir) if given, else treated as in-workspace.
+    """
+    p = Path(raw).expanduser()
+    if p.is_absolute():
+        return p
+    if base_dir is not None:
+        candidate = (Path(base_dir) / p)
+        if candidate.exists():
+            return candidate
+    return Path(work_dir) / p
+
+
+def stage_held_out_data(idea: Dict[str, Any], work_dir: Path,
+                        base_dir: Optional[Path] = None) -> List[str]:
+    """Copy declared held-out (sealed) datasets into gitignored data/.test.
+
+    A simple, trusted copy: Stage 1 has no optimizing agent, so there is
+    nothing to hide from at this point. Each sealed entry's ``path`` is
+    rewritten to its eval-facing ``data/.test/<name>``. An in-workspace source
+    (held-out data committed inside the adopted repo) is MOVED, so only the
+    gitignored copy remains; an external host source is copied.
+    """
+    from core.local_resources import sealed_dataset_entries
+
+    entries = sealed_dataset_entries(idea)
+    if not entries:
+        return []
+    dest_root = Path(work_dir) / "data" / ".test"
+    dest_root.mkdir(parents=True, exist_ok=True)
+    staged: List[str] = []
+    for entry in entries:
+        raw = str(entry.get("source_path") or entry.get("path") or "").strip()
+        if not raw:
+            continue
+        # Sanitize the declared name to a bare basename so a name containing
+        # '/' or '..' cannot escape data/.test (the contract is trusted, but
+        # this matches stage_local_resources and costs nothing).
+        name = Path(str(entry.get("name") or Path(raw).name)).name
+        if not name or name in (".", ".."):
+            raise ValueError(
+                f"held-out dataset has an unusable name: {entry.get('name')!r}")
+        dst = dest_root / name
+        rewritten = f"{SEALED_STAGING_DIR}/{name}"
+        # Idempotent re-prepare: the path was already rewritten to the
+        # eval-facing form, OR the destination already holds the staged copy
+        # (a resume after Stage 1 partially completed -- e.g. baseline scoring
+        # failed after the move). In both cases the move is done; just
+        # (re)assert the eval-facing path so the in-memory idea is consistent.
+        if raw.replace("\\", "/").startswith(SEALED_STAGING_DIR + "/") or dst.exists():
+            entry.setdefault("source_path", raw)
+            entry["path"] = rewritten
+            staged.append(name)
+            continue
+        src = _resolve_source(raw, work_dir, base_dir)
+        if not src.exists():
+            raise FileNotFoundError(
+                f"held-out dataset source not found: {raw} (resolved {src})")
+        if src.resolve() != dst.resolve():
+            if src.is_dir():
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(src, dst, symlinks=False)
+            else:
+                shutil.copy2(src, dst, follow_symlinks=True)
+            # Move semantics for an in-workspace (in-repo) source: remove the
+            # readable original so only the gitignored data/.test copy remains.
+            try:
+                src.resolve().relative_to(Path(work_dir).resolve())
+                if src.is_dir():
+                    shutil.rmtree(src)
+                elif src.exists():
+                    src.unlink()
+            except ValueError:
+                pass  # external host source -- leave it in place
+        entry["source_path"] = raw
+        entry["path"] = rewritten
+        staged.append(name)
+    _gitignore_add(work_dir, "data/.test/")
+    return staged
+
+
+def _idea_without_sealed(idea: Dict[str, Any]) -> Dict[str, Any]:
+    """A copy of the idea with sealed datasets removed from local_resources,
+    so the normal stager handles only non-held-out resources."""
+    out = copy.deepcopy(idea)
+    inner = out.get("idea", out)
+    resources = inner.get("local_resources") if isinstance(inner, dict) else None
+    if isinstance(resources, dict) and isinstance(resources.get("datasets"), list):
+        resources["datasets"] = [
+            d for d in resources["datasets"]
+            if not (isinstance(d, dict) and d.get("sealed"))
+        ]
+    return out
+
+
+PREPARED_MARKER = ".neurico/continuation_prepared.json"
+
+
+def _write_prepared_marker(work_dir: Path, idea_id: str) -> None:
+    """Record that Stage 1 finished, so the runner's isolation backstop can
+    tell a properly prepared workspace from a mid-prepare one."""
+    import json
+    target = Path(work_dir) / PREPARED_MARKER
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps({"idea_id": idea_id, "stage": "prepared"}, indent=2) + "\n",
+        encoding="utf-8")
+
+
+def _write_workspace_idea(idea: Dict[str, Any], work_dir: Path) -> None:
+    """Write the redacted continuation contract to .neurico/idea.yaml so the
+    bootstrap rule maker (which substitutes {idea_yaml}) and Stage 2 both see
+    the goal, invariants, and the data/.test held-out reference."""
+    import yaml
+    from core.local_resources import workspace_contract_copy
+
+    target = Path(work_dir) / ".neurico" / "idea.yaml"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with open(target, "w", encoding="utf-8") as handle:
+        yaml.dump(workspace_contract_copy(idea), handle,
+                  default_flow_style=False, sort_keys=False)
+
+
+def prepare_continuation_workspace(
+    idea: Dict[str, Any],
+    idea_id: str,
+    work_dir: Path,
+    *,
+    templates_dir: Path,
+    provider: str = "claude",
+    full_permissions: bool = True,
+    github_manager=None,
+    rule_maker_timeout: int = 1800,
+    scorer_timeout: int = 600,
+    manifest_trimmer_timeout: int = 300,
+    autoresearch_history_dir: Optional[Path] = None,
+    prepare_workspace: Optional[Callable[[Path], None]] = None,
+    base_dir: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Stage 1: build a SCORED standard NeuriCo workspace from a continuation
+    contract.
+
+    Runs only the trusted setup agents (manifest trimmer, bootstrap rule maker)
+    and the scorer -- NO optimizing (reward-seeking) agent. On return,
+    ``work_dir`` is an ordinary NeuriCo workspace with a scored baseline and a
+    recorded ``current_best`` in ``.neurico/autoresearch_state.json``, ready for
+    a plain ``continue_from_current_best`` (Stage 2) with no continue-research
+    code.
+    """
+    from core.repo_adoption import adopt_repository
+    from core.local_resources import stage_local_resources
+    from core.autoresearch import construct_bootstrap_initial_node
+
+    work_dir = Path(work_dir)
+
+    # 1+2. Adopt the repo (fresh git history, source remotes scrubbed, nested
+    #    .git removed), staging held-out materials into the gitignored
+    #    data/.test BEFORE the anchor commit via the pre-commit hook. Ordering
+    #    matters: an in-repo held-out file must be moved out before the commit,
+    #    or the fresh history (and the GitHub backup) would capture the
+    #    plaintext -- readable by the Stage 2 agent through `git show`.
+    adoption = adopt_repository(
+        idea, idea_id, work_dir, github_manager=github_manager, provider=provider,
+        pre_commit_hook=lambda wd: stage_held_out_data(idea, wd, base_dir=base_dir))
+
+    # Re-assert the eval-facing held-out paths in this process. On a fresh
+    # adoption the hook already staged and rewrote them; on an idempotent
+    # resume the hook did not run (the anchor commit already exists), so this
+    # call performs the rewrite (and is a no-op move -- the data is already in
+    # data/.test). Either way the in-memory idea ends up consistent.
+    held_out = stage_held_out_data(idea, work_dir, base_dir=base_dir)
+
+    # 3. Non-sealed local resources through the normal stager.
+    stage_local_resources(work_dir, _idea_without_sealed(idea), base_dir=base_dir)
+
+    # 4. Publish the full (redacted) contract so the rule maker and Stage 2 see
+    #    goal + invariants + the data/.test held-out reference.
+    _write_workspace_idea(idea, work_dir)
+
+    # 4b. Record the trusted baseline hashes of every declared protected_path,
+    #    computed here (no optimizing agent) from the adopted+staged tree. The
+    #    generated eval.py compares against this to enforce protected_path
+    #    invariants as the hard `protected_paths_unchanged` scoring guardrail.
+    write_protected_baseline(idea, work_dir)
+
+    # 5. Generate the scorer AND score the baseline, all in this trusted phase,
+    #    by reusing main's bootstrap-baseline path. construct_bootstrap runs the
+    #    manifest trimmer + bootstrap rule maker (which bakes the declared
+    #    check-invariants in as guardrail properties), scores the adopted repo
+    #    against the held-out data, and records current_best. No optimizing
+    #    agent runs. On return the workspace is a standard scored NeuriCo
+    #    workspace ready for --continue-autoresearch.
+    baseline = construct_bootstrap_initial_node(
+        idea=idea,
+        idea_id=idea_id,
+        work_dir=work_dir,
+        templates_dir=Path(templates_dir),
+        provider=provider,
+        full_permissions=full_permissions,
+        rule_maker_timeout=rule_maker_timeout,
+        scorer_timeout=scorer_timeout,
+        manifest_trimmer_timeout=manifest_trimmer_timeout,
+        autoresearch_history_dir=autoresearch_history_dir,
+        prepare_workspace=prepare_workspace,
+    )
+    if not baseline.get("success"):
+        raise RuntimeError(
+            f"continuation prepare: baseline construction failed: "
+            f"{baseline.get('reason') or baseline}")
+
+    # Trusted "Stage 1 complete" marker. The runner uses it (together with a
+    # check that the source materials are no longer readable) as a
+    # defense-in-depth backstop so Stage 2 never runs in a container that still
+    # has the source repo / held-out materials mounted.
+    _write_prepared_marker(work_dir, idea_id)
+
+    # The workspace is now a plain scored NeuriCo workspace. Stage 2
+    # (continue_from_current_best) consumes it with no continue-research code.
+    return {
+        "work_dir": str(work_dir),
+        "prepared": True,
+        "adoption": adoption,
+        "held_out": held_out,
+        "baseline": baseline,
+        "current_best_sha": baseline.get("current_best_sha"),
+        "scoring_ready": True,
+    }

--- a/src/core/continuation_prepare.py
+++ b/src/core/continuation_prepare.py
@@ -68,10 +68,20 @@ def _hash_entry(digest: "hashlib._Hash", rel: str, path: Path) -> None:
     digest.update(b"\0")
     lst = path.lstat()
     if stat_mod.S_ISLNK(lst.st_mode):
-        # Symlink identity: the target string, not the target's bytes. A
-        # repointed symlink is a change even if the new target reads the same.
+        # Symlink: record BOTH its identity (target string, so a repointed link
+        # counts even if the new target reads the same) AND the content behind
+        # it (so a change to the target's bytes under an unchanged link counts).
+        # Cycle-safe: _content_signature walks real files via rglob, which does
+        # not follow symlinked directories.
         digest.update(b"link\0")
         digest.update(os.readlink(path).encode("utf-8"))
+        try:
+            resolved = path.resolve()
+            if resolved.is_file() or resolved.is_dir():
+                digest.update(b"\0target\0")
+                digest.update(_content_signature(resolved).encode("utf-8"))
+        except (OSError, RuntimeError):
+            pass  # broken or cyclic link: identity string already recorded
     elif path.is_dir():
         # Record directory existence so an added/removed EMPTY directory counts.
         digest.update(b"dir\0")
@@ -97,6 +107,9 @@ def _hash_protected_path(root: Path) -> str:
     if root.is_symlink() or root.is_file() or not root.is_dir():
         _hash_entry(digest, "", root)
         return digest.hexdigest()
+    # A real directory root: fold in the root's OWN mode first (a chmod on the
+    # protected directory itself must count), then every descendant.
+    _hash_entry(digest, "", root)
     for path in sorted(root.rglob("*"), key=lambda p: p.relative_to(root).as_posix()):
         _hash_entry(digest, path.relative_to(root).as_posix(), path)
     return digest.hexdigest()
@@ -222,12 +235,20 @@ def stage_held_out_data(idea: Dict[str, Any], work_dir: Path,
         dst = dest_root / name
         rewritten = f"{SEALED_STAGING_DIR}/{name}"
         src = None if already_rewritten else _resolve_source(raw, work_dir, base_dir)
-        # Idempotent re-prepare: the path was already rewritten to the
-        # eval-facing form, OR an existing destination already matches the
-        # declared source (a resume after Stage 1 partially completed). Accept
-        # the existing copy only when it is VERIFIED against the source, so a
-        # partial or stale destination is never mistaken for a complete stage.
-        if already_rewritten or (
+        # Accept the already-staged destination in three idempotent cases:
+        #   - the path was already rewritten to the eval-facing form;
+        #   - the source is GONE and the destination exists: this is an in-repo
+        #     sealed source that the pre-commit-hook pass already MOVED (the
+        #     source is removed only AFTER a complete copy, so source-absent +
+        #     destination-present means the move finished). stage_held_out_data
+        #     runs twice per prepare (in the hook, then again after), so the
+        #     second pass MUST accept the moved copy rather than fail;
+        #   - the source is still present AND its content matches the staged
+        #     copy (an interrupted-then-resumed prepare).
+        # A destination that exists but MISMATCHES a still-present source is a
+        # partial/stale copy and falls through to re-stage.
+        moved_source = dst.exists() and src is not None and not src.exists()
+        if already_rewritten or moved_source or (
                 dst.exists() and src is not None and src.exists()
                 and _same_content(src, dst)):
             entry.setdefault("source_path", raw)

--- a/src/core/continuation_prepare.py
+++ b/src/core/continuation_prepare.py
@@ -52,21 +52,53 @@ def _gitignore_add(work_dir: Path, line: str) -> None:
         gitignore.write_text(prefix + line + "\n", encoding="utf-8")
 
 
-def _hash_protected_path(root: Path) -> str:
-    """sha256 of a protected file, or of a directory tree (sorted relpath+bytes).
+def _hash_entry(digest: "hashlib._Hash", rel: str, path: Path) -> None:
+    """Fold one filesystem entry into digest, covering the kinds of change a
+    protected-path guardrail must catch: content, permission bits, symlink
+    identity, and the existence of (even empty) directories.
 
-    A directory hash folds in each file's relative path and content so adding,
-    removing, renaming, or editing any file under a protected prefix changes it.
+    The generated eval.py MUST mirror this exactly (see
+    templates/agents/rule_maker_bootstrap.txt), or the baseline written here and
+    the runtime recomputation would disagree.
+    """
+    import os
+    import stat as stat_mod
+
+    digest.update(rel.encode("utf-8"))
+    digest.update(b"\0")
+    lst = path.lstat()
+    if stat_mod.S_ISLNK(lst.st_mode):
+        # Symlink identity: the target string, not the target's bytes. A
+        # repointed symlink is a change even if the new target reads the same.
+        digest.update(b"link\0")
+        digest.update(os.readlink(path).encode("utf-8"))
+    elif path.is_dir():
+        # Record directory existence so an added/removed EMPTY directory counts.
+        digest.update(b"dir\0")
+        digest.update(f"{stat_mod.S_IMODE(lst.st_mode):04o}".encode("utf-8"))
+    else:
+        digest.update(b"file\0")
+        digest.update(f"{stat_mod.S_IMODE(lst.st_mode):04o}".encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+
+
+def _hash_protected_path(root: Path) -> str:
+    """Change-detecting hash of a protected file or directory tree.
+
+    Covers content, permission bits, symlink identity, and empty directories,
+    so a chmod, a repointed symlink, or an added/removed empty directory under a
+    protected prefix all change the hash (bytes-only hashing missed all three).
+    A directory folds in every entry's relative path so adding, removing,
+    renaming, or editing anything under the prefix changes it.
     """
     root = Path(root)
     digest = hashlib.sha256()
-    if root.is_file():
-        digest.update(root.read_bytes())
+    if root.is_symlink() or root.is_file() or not root.is_dir():
+        _hash_entry(digest, "", root)
         return digest.hexdigest()
-    for path in sorted(p for p in root.rglob("*") if p.is_file()):
-        digest.update(path.relative_to(root).as_posix().encode("utf-8"))
-        digest.update(b"\0")
-        digest.update(path.read_bytes())
+    for path in sorted(root.rglob("*"), key=lambda p: p.relative_to(root).as_posix()):
+        _hash_entry(digest, path.relative_to(root).as_posix(), path)
     return digest.hexdigest()
 
 
@@ -112,6 +144,35 @@ def _resolve_source(raw: str, work_dir: Path, base_dir: Optional[Path]) -> Path:
     return Path(work_dir) / p
 
 
+def _content_signature(root: Path) -> str:
+    """sha256 of a file's bytes, or of a directory tree (sorted relpath+bytes)."""
+    root = Path(root)
+    digest = hashlib.sha256()
+    if root.is_file():
+        digest.update(root.read_bytes())
+        return digest.hexdigest()
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        digest.update(path.relative_to(root).as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _same_content(a: Path, b: Path) -> bool:
+    """True when two paths hold identical content (file bytes, or dir tree).
+
+    Used to accept an already-staged held-out destination only when it still
+    matches its declared source, so a partial, stale, or wrong existing copy is
+    re-staged instead of trusted on existence alone.
+    """
+    a, b = Path(a), Path(b)
+    if a.is_dir() != b.is_dir():
+        return False
+    if a.is_file() and a.stat().st_size != b.stat().st_size:
+        return False
+    return _content_signature(a) == _content_signature(b)
+
+
 def stage_held_out_data(idea: Dict[str, Any], work_dir: Path,
                         base_dir: Optional[Path] = None) -> List[str]:
     """Copy declared held-out (sealed) datasets into gitignored data/.test.
@@ -130,6 +191,7 @@ def stage_held_out_data(idea: Dict[str, Any], work_dir: Path,
     dest_root = Path(work_dir) / "data" / ".test"
     dest_root.mkdir(parents=True, exist_ok=True)
     staged: List[str] = []
+    taken: set = set()
     for entry in entries:
         raw = str(entry.get("source_path") or entry.get("path") or "").strip()
         if not raw:
@@ -141,22 +203,41 @@ def stage_held_out_data(idea: Dict[str, Any], work_dir: Path,
         if not name or name in (".", ".."):
             raise ValueError(
                 f"held-out dataset has an unusable name: {entry.get('name')!r}")
+        # Disambiguate a basename collision: two declared sources with the same
+        # basename would otherwise map to the same data/.test/<name>, and the
+        # second would silently resolve to the first's bytes. Suffix later
+        # collisions (name.jsonl -> name-2.jsonl) so every source keeps its own
+        # copy. An already-rewritten eval-facing path keeps its resolved name.
+        already_rewritten = raw.replace("\\", "/").startswith(
+            SEALED_STAGING_DIR + "/")
+        if already_rewritten:
+            name = Path(raw).name
+        elif name in taken:
+            stem, suffix = Path(name).stem, Path(name).suffix
+            n = 2
+            while f"{stem}-{n}{suffix}" in taken:
+                n += 1
+            name = f"{stem}-{n}{suffix}"
+        taken.add(name)
         dst = dest_root / name
         rewritten = f"{SEALED_STAGING_DIR}/{name}"
+        src = None if already_rewritten else _resolve_source(raw, work_dir, base_dir)
         # Idempotent re-prepare: the path was already rewritten to the
-        # eval-facing form, OR the destination already holds the staged copy
-        # (a resume after Stage 1 partially completed -- e.g. baseline scoring
-        # failed after the move). In both cases the move is done; just
-        # (re)assert the eval-facing path so the in-memory idea is consistent.
-        if raw.replace("\\", "/").startswith(SEALED_STAGING_DIR + "/") or dst.exists():
+        # eval-facing form, OR an existing destination already matches the
+        # declared source (a resume after Stage 1 partially completed). Accept
+        # the existing copy only when it is VERIFIED against the source, so a
+        # partial or stale destination is never mistaken for a complete stage.
+        if already_rewritten or (
+                dst.exists() and src is not None and src.exists()
+                and _same_content(src, dst)):
             entry.setdefault("source_path", raw)
             entry["path"] = rewritten
             staged.append(name)
             continue
-        src = _resolve_source(raw, work_dir, base_dir)
-        if not src.exists():
+        if src is None or not src.exists():
             raise FileNotFoundError(
-                f"held-out dataset source not found: {raw} (resolved {src})")
+                f"held-out dataset source not found: {raw} "
+                f"(resolved {src if src is not None else raw})")
         if src.resolve() != dst.resolve():
             if src.is_dir():
                 if dst.exists():
@@ -223,6 +304,79 @@ def _write_workspace_idea(idea: Dict[str, Any], work_dir: Path) -> None:
                   default_flow_style=False, sort_keys=False)
 
 
+def verify_invariant_guardrails(idea: Dict[str, Any], work_dir: Path) -> None:
+    """Confirm the generated eval.py actually enforces every declared invariant.
+
+    The eval_verifier only checks routing/transcription/format, so a generated
+    eval.py could silently omit or misimplement a `protected_path` or `check`
+    guardrail. This is a mechanical, behavioral cross-check run in Stage 1 (no
+    optimizing agent): after the baseline is scored, every declared invariant
+    must have produced its guardrail property AND passed at baseline (nothing
+    has changed yet, and the check command is expected to pass on the adopted
+    repo). A missing or failing guardrail fails Stage 1 loudly rather than
+    letting an unenforced invariant reach optimization.
+    """
+    from core.local_resources import (
+        protected_path_prefixes,
+        continuation_check_commands,
+    )
+
+    work_dir = Path(work_dir)
+    protected = protected_path_prefixes(idea)
+    checks = continuation_check_commands(idea)
+    if not protected and not checks:
+        return
+
+    def _load(rel: str) -> Dict[str, Any]:
+        try:
+            payload = json.loads((work_dir / rel).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(
+                f"continuation invariant check: cannot read {rel}: {exc}")
+        props = payload.get("properties")
+        return props if isinstance(props, dict) else {}
+
+    targets = _load("scoring/targets.json")
+    results = _load("scoring/results.json")
+    problems: List[str] = []
+
+    if protected:
+        prop = results.get("protected_paths_unchanged")
+        if prop is None:
+            problems.append(
+                "declared protected_path invariant(s) but the generated eval.py "
+                "produced no 'protected_paths_unchanged' property")
+        elif not prop.get("satisfied"):
+            problems.append(
+                "'protected_paths_unchanged' did not pass at baseline "
+                f"(value {prop.get('value')!r}); nothing has changed, so the "
+                "generated protected-path check is misimplemented")
+
+    # Each declared check command must appear as a user guardrail property
+    # (matched by source_text) and pass at baseline.
+    scored_by_cmd = {
+        str(spec.get("source_text")).strip(): name
+        for name, spec in targets.items()
+        if isinstance(spec, dict) and spec.get("source") == "user"
+        and spec.get("source_text")
+    }
+    for cmd in checks:
+        name = scored_by_cmd.get(cmd)
+        if name is None:
+            problems.append(
+                f"check invariant not encoded as a guardrail property: {cmd!r}")
+            continue
+        prop = results.get(name)
+        if prop is None or not prop.get("satisfied"):
+            problems.append(
+                f"check guardrail {name!r} for {cmd!r} did not pass at baseline")
+
+    if problems:
+        raise RuntimeError(
+            "continuation invariants are not correctly enforced by the "
+            "generated eval.py:\n  - " + "\n  - ".join(problems))
+
+
 def prepare_continuation_workspace(
     idea: Dict[str, Any],
     idea_id: str,
@@ -232,6 +386,8 @@ def prepare_continuation_workspace(
     provider: str = "claude",
     full_permissions: bool = True,
     github_manager=None,
+    private: bool = False,
+    no_hash: bool = False,
     rule_maker_timeout: int = 1800,
     scorer_timeout: int = 600,
     manifest_trimmer_timeout: int = 300,
@@ -263,6 +419,7 @@ def prepare_continuation_workspace(
     #    plaintext -- readable by the Stage 2 agent through `git show`.
     adoption = adopt_repository(
         idea, idea_id, work_dir, github_manager=github_manager, provider=provider,
+        private=private, no_hash=no_hash,
         pre_commit_hook=lambda wd: stage_held_out_data(idea, wd, base_dir=base_dir))
 
     # Re-assert the eval-facing held-out paths in this process. On a fresh
@@ -309,6 +466,12 @@ def prepare_continuation_workspace(
         raise RuntimeError(
             f"continuation prepare: baseline construction failed: "
             f"{baseline.get('reason') or baseline}")
+
+    # 5b. Mechanical cross-check that the generated eval.py actually enforces
+    #    every declared invariant (the eval_verifier does not). Runs here, in
+    #    the trusted phase, so an omitted or misimplemented guardrail fails
+    #    Stage 1 rather than silently reaching optimization.
+    verify_invariant_guardrails(idea, work_dir)
 
     # Trusted "Stage 1 complete" marker. The runner uses it (together with a
     # check that the source materials are no longer readable) as a

--- a/src/core/idea_manager.py
+++ b/src/core/idea_manager.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from core.config_loader import ConfigLoader
 from core.local_resources import (
     collect_host_paths,
+    validate_continuation,
     validate_evaluation_spec,
     validate_local_resources,
 )
@@ -244,6 +245,11 @@ class IdeaManager:
         ev_errors, ev_warnings = validate_evaluation_spec(idea)
         errors.extend(ev_errors)
         warnings.extend(ev_warnings)
+
+        # Validate continuation spec (continue-research mode)
+        ct_errors, ct_warnings = validate_continuation(idea)
+        errors.extend(ct_errors)
+        warnings.extend(ct_warnings)
 
         valid = len(errors) == 0
 

--- a/src/core/local_resources.py
+++ b/src/core/local_resources.py
@@ -762,3 +762,263 @@ def validate_evaluation_spec(idea: Dict[str, Any]) -> Tuple[List[str], List[str]
                     )
 
     return errors, warnings
+
+
+# ==========================================================================
+# Continue-research contract helpers (ported for the two-stage redesign):
+# the continuation contract (goal, invariants) and its validation. No sealed-
+# store / fingerprint / regeneration machinery is ported; held-out staging is
+# a simple copy in the Stage-1 prepare flow (see continuation_prepare.py).
+# ==========================================================================
+
+INVARIANT_KINDS = {
+    'protected_path': 'path',
+    'check': 'command',
+    'statement': 'text',
+}
+
+
+def normalize_protected_path(raw: str) -> str:
+    """
+    Canonical normalization of one protected_path declaration: exact './'
+    prefixes removed (never a character-set strip, which would eat the
+    leading dot of '.github' or '.env'), trailing slashes dropped.
+
+    Raises ValueError for declarations that cannot name a workspace-relative
+    prefix (empty, '.', absolute, or '..' traversal) so the guard fails
+    closed instead of silently watching the wrong path.
+    """
+    path = str(raw).strip().replace('\\', '/')
+    if path.startswith('/'):
+        raise ValueError(
+            f"protected path {raw!r} is absolute; declare it relative to "
+            f"the workspace root")
+    # Component-wise canonicalization: drops empty ('a//b') and '.' parts,
+    # so equivalent declarations normalize identically, and catches '..'
+    # ANYWHERE — including a trailing 'src/..', which resolves to the
+    # workspace root and would otherwise sail past prefix/substring checks.
+    parts = [part for part in path.split('/') if part not in ('', '.')]
+    if any(part == '..' for part in parts):
+        raise ValueError(
+            f"protected path {raw!r} escapes or renames the workspace root "
+            f"('..' components are not allowed)")
+    if not parts:
+        raise ValueError(
+            f"protected path {raw!r} does not name a workspace-relative "
+            f"prefix (protecting the entire workspace is not supported)")
+    return '/'.join(parts)
+
+
+def protected_path_prefixes(idea: Dict[str, Any]) -> List[str]:
+    """
+    Normalized workspace-relative prefixes of protected_path invariants.
+
+    One canonical normalization for every consumer of protected paths, so
+    the guard and any prompt rendering can never drift on what counts as
+    inside a protected prefix. Raises ValueError (via
+    normalize_protected_path) on declarations that cannot be protected;
+    validate_continuation rejects those at submit time, and a runtime caller
+    treats the exception as a guard failure, never a silent skip.
+    """
+    idea_spec = idea.get('idea', idea) if isinstance(idea, dict) else {}
+    if not isinstance(idea_spec, dict):
+        return []
+    continuation = idea_spec.get('continuation')
+    if not isinstance(continuation, dict):
+        return []
+    return [
+        normalize_protected_path(invariant['path'])
+        for invariant in (continuation.get('invariants') or [])
+        if isinstance(invariant, dict)
+        and invariant.get('kind') == 'protected_path'
+        and invariant.get('path')
+    ]
+
+
+def _protected_digest(path: Path) -> str:
+    """Content hash plus permission bits, so a chmod-only change to a
+    protected file is detected; content-only hashing would miss a mode
+    change that Git still records in an accepted checkpoint."""
+    mode = path.stat().st_mode & 0o777
+    return f"{mode:04o}:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def snapshot_protected_paths(work_dir: Path,
+                             idea: Dict[str, Any]) -> Dict[str, Dict[str, str]]:
+    """
+    Content fingerprint of every protected prefix: {prefix: {relpath: digest}}.
+
+    Walks the filesystem directly rather than asking git, so files git
+    ignores (model weights, generated configs, .env files) are covered, and
+    symlinks are fingerprinted by their target string rather than followed.
+    A missing prefix snapshots as an empty mapping, so its later appearance
+    is a change like any other. Compare two snapshots with
+    protected_path_changes().
+
+    Args:
+        work_dir: Workspace root directory
+        idea: Full idea specification (or inner idea dict)
+
+    Returns:
+        {prefix: {relpath: digest}} for every protected prefix
+    """
+    work_dir = Path(work_dir)
+    snapshot: Dict[str, Dict[str, str]] = {}
+    for prefix in protected_path_prefixes(idea):
+        files: Dict[str, str] = {}
+        root = work_dir / prefix
+        if root.is_symlink():
+            files[''] = 'link:' + os.readlink(root)
+        elif root.is_file():
+            files[''] = _protected_digest(root)
+        elif root.is_dir():
+            for path in sorted(root.rglob('*')):
+                rel = path.relative_to(root).as_posix()
+                if path.is_symlink():
+                    files[rel] = 'link:' + os.readlink(path)
+                elif path.is_file():
+                    files[rel] = _protected_digest(path)
+        snapshot[prefix] = files
+    return snapshot
+
+
+def protected_path_changes(before: Dict[str, Dict[str, str]],
+                           after: Dict[str, Dict[str, str]]) -> List[str]:
+    """
+    Workspace-relative paths whose content changed between two protected
+    snapshots (modified, created, or deleted files alike).
+    """
+    changes: List[str] = []
+    for prefix in before:
+        b = before[prefix]
+        a = after.get(prefix, {})
+        for rel in sorted(set(b) | set(a)):
+            if b.get(rel) != a.get(rel):
+                changes.append(f"{prefix}/{rel}" if rel else prefix)
+    return sorted(set(changes))
+
+
+def sealed_dataset_entries(idea: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """All dataset entries declared sealed (any path form)."""
+    idea_spec = idea.get('idea', idea) if isinstance(idea, dict) else {}
+    if not isinstance(idea_spec, dict):
+        return []
+    resources = idea_spec.get('local_resources')
+    if not isinstance(resources, dict):
+        return []
+    return [entry for entry in resources.get('datasets') or []
+            if isinstance(entry, dict) and entry.get('sealed')]
+
+
+
+def validate_continuation(idea: Dict[str, Any]) -> Tuple[List[str], List[str]]:
+    """
+    Validate the idea.continuation section (continue-research mode).
+
+    Requires source_repo and goal; each invariant must name a supported kind
+    and carry that kind's field (protected_path: path, check: command,
+    statement: text). A missing reason is a warning: agents obey constraints
+    better when told why they exist.
+
+    Args:
+        idea: The inner idea dictionary (idea_spec['idea'])
+
+    Returns:
+        Tuple of (errors, warnings) message lists
+    """
+    errors = []
+    warnings = []
+
+    continuation = idea.get('continuation')
+    if continuation is None:
+        return errors, warnings
+
+    if not isinstance(continuation, dict):
+        errors.append("continuation must be a mapping with 'source_repo' and 'goal'")
+        return errors, warnings
+
+    if not continuation.get('source_repo'):
+        errors.append("continuation: missing 'source_repo' (repository path or URL)")
+    goal = continuation.get('goal')
+    if not goal or not str(goal).strip():
+        errors.append("continuation: missing 'goal' (what to optimize is required)")
+    elif len(str(goal).strip()) < 10:
+        warnings.append("continuation.goal is very short; state the direction of "
+                        "improvement so proposals stay aimed at it")
+
+    invariants = continuation.get('invariants')
+    if invariants is None:
+        return errors, warnings
+    if not isinstance(invariants, list):
+        errors.append("continuation.invariants must be a list")
+        return errors, warnings
+
+    for idx, invariant in enumerate(invariants):
+        label = f"continuation.invariants[{idx}]"
+        if not isinstance(invariant, dict):
+            errors.append(f"{label}: must be a mapping with 'kind'")
+            continue
+        kind = invariant.get('kind')
+        if kind not in INVARIANT_KINDS:
+            errors.append(f"{label}: unknown kind '{kind}' "
+                          f"(supported: {', '.join(INVARIANT_KINDS)})")
+            continue
+        required_field = INVARIANT_KINDS[kind]
+        if not invariant.get(required_field):
+            errors.append(f"{label}: kind '{kind}' requires '{required_field}'")
+        if kind == 'protected_path' and invariant.get('path'):
+            try:
+                normalize_protected_path(invariant['path'])
+            except ValueError as exc:
+                errors.append(f"{label}: {exc}")
+        if not invariant.get('reason'):
+            warnings.append(f"{label}: no 'reason' given; agents follow constraints "
+                            f"better when told why they exist")
+
+    return errors, warnings
+
+
+def validate_evaluation_spec(idea: Dict[str, Any]) -> Tuple[List[str], List[str]]:
+    """
+    Validate the idea.evaluation section (structured metrics and format).
+
+    Args:
+        idea: The inner idea dictionary (idea_spec['idea'])
+
+    Returns:
+        Tuple of (errors, warnings) message lists
+    """
+    errors = []
+    warnings = []
+
+    evaluation = idea.get('evaluation')
+    if evaluation is None:
+        return errors, warnings
+
+    if not isinstance(evaluation, dict):
+        errors.append("evaluation must be a mapping with 'metrics' and/or 'results_format'")
+        return errors, warnings
+
+    metrics = evaluation.get('metrics')
+    if metrics is not None:
+        if not isinstance(metrics, list):
+            errors.append("evaluation.metrics must be a list")
+        else:
+            if len(metrics) == 0:
+                warnings.append("evaluation.metrics is empty")
+            for idx, metric in enumerate(metrics):
+                label = f"evaluation.metrics[{idx}]"
+                if not isinstance(metric, dict):
+                    errors.append(f"{label}: must be a mapping with 'name' and 'definition'")
+                    continue
+                if not metric.get('name'):
+                    errors.append(f"{label}: missing 'name'")
+                if not metric.get('definition'):
+                    errors.append(f"{label}: missing 'definition'")
+                if not metric.get('target'):
+                    warnings.append(
+                        f"{label}: no 'target' given; the rule maker will set one "
+                        f"and tag it source: derived"
+                    )
+
+    return errors, warnings

--- a/src/core/local_resources.py
+++ b/src/core/local_resources.py
@@ -327,6 +327,14 @@ def workspace_contract_copy(idea_spec: Dict[str, Any]) -> Dict[str, Any]:
     source_path values and the submitting file's metadata.source_path —
     must not leak into it. The submitted yaml under ideas/ keeps them; only
     the workspace copy is redacted.
+
+    For a continuation idea this file is also the optimizing agent's task
+    description, so it must not hand the agent a pointer back to the original
+    source. continuation.source_repo (the host path or clone URL of the repo
+    the held-out data came from) is dropped: leaving it would let a Stage 2
+    agent re-read the local repo or re-clone the URL and recover the held-out
+    data or its history. (Native runs share the host and remain a trusted
+    boundary regardless; this removes the easy, incidental signpost.)
     """
     import copy
 
@@ -345,6 +353,10 @@ def workspace_contract_copy(idea_spec: Dict[str, Any]) -> Dict[str, Any]:
             for entry in resources.get(kind) or []:
                 if isinstance(entry, dict):
                     entry.pop('source_path', None)
+
+    continuation = idea.get('continuation')
+    if isinstance(continuation, dict):
+        continuation.pop('source_repo', None)
     return clean
 
 
@@ -715,6 +727,14 @@ def collect_host_paths(idea: Dict[str, Any]) -> List[str]:
             if isinstance(paper, dict):
                 add(paper.get('path'))
 
+    # Continue-research: the Stage 1 prepare container adopts the source repo by
+    # reading it from the container filesystem, so a LOCAL source_repo must be
+    # mounted. add() skips remote URLs (http/https/git@), which are cloned and
+    # need no mount.
+    continuation = idea.get('continuation')
+    if isinstance(continuation, dict):
+        add(continuation.get('source_repo'))
+
     return paths
 
 
@@ -832,6 +852,27 @@ def protected_path_prefixes(idea: Dict[str, Any]) -> List[str]:
         if isinstance(invariant, dict)
         and invariant.get('kind') == 'protected_path'
         and invariant.get('path')
+    ]
+
+
+def continuation_check_commands(idea: Dict[str, Any]) -> List[str]:
+    """The command strings of every `check` invariant, in declaration order.
+
+    Used to confirm the generated eval.py encoded each declared check as a
+    guardrail property (a companion to protected_path_prefixes).
+    """
+    idea_spec = idea.get('idea', idea) if isinstance(idea, dict) else {}
+    if not isinstance(idea_spec, dict):
+        return []
+    continuation = idea_spec.get('continuation')
+    if not isinstance(continuation, dict):
+        return []
+    return [
+        str(invariant['command']).strip()
+        for invariant in (continuation.get('invariants') or [])
+        if isinstance(invariant, dict)
+        and invariant.get('kind') == 'check'
+        and invariant.get('command')
     ]
 
 

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -1889,6 +1889,27 @@ class ResearchPipelineOrchestrator:
             print("⚠️  Bootstrap rule_maker stage failed -- aborting before scorer.")
             return results
 
+        # STAGE B2b: Eval verifier. The bootstrap rule_maker just generated the
+        # scoring harness; when the idea declares an evaluation contract or
+        # continuation invariants, independently review that eval.py actually
+        # enforces them (reads protected_baseline and recomputes hashes, runs
+        # check commands) before the scorer runs. On a failed verdict the rule
+        # maker is re-run once with the findings, then re-verified; still failing
+        # aborts before the scorer.
+        verified = self._verify_bootstrap_eval_contract(
+            idea=idea,
+            curated_manifest=curated_manifest,
+            provider=provider,
+            timeout=rule_maker_timeout,
+            full_permissions=full_permissions,
+        )
+        results["stages"][BOOTSTRAP_RULE_MAKER_STAGE]["verification"] = verified
+        if not verified.get("passed", True):
+            print()
+            print("⚠️  Eval verifier rejected the bootstrap scoring contract "
+                  "after retry -- aborting before scorer.")
+            return results
+
         # STAGE B3: Scorer (executes scoring/eval.py against the existing artifacts).
         results["stages"][SCORER_STAGE] = self._run_scorer(
             timeout=scorer_timeout, idea=idea)
@@ -2043,6 +2064,66 @@ class ResearchPipelineOrchestrator:
                 BOOTSTRAP_RULE_MAKER_STAGE, success=False, outputs={"error": str(e)}
             )
             return {"success": False, "error": str(e)}
+
+    def _verify_bootstrap_eval_contract(
+        self,
+        idea: Dict[str, Any],
+        curated_manifest: Dict[str, Any],
+        provider: str,
+        timeout: int,
+        full_permissions: bool,
+    ) -> Dict[str, Any]:
+        """Review the bootstrap-generated scoring harness against the idea's
+        evaluation contract and continuation invariants.
+
+        The bootstrap path (used by continue-research Stage 1) never invoked the
+        eval verifier, so a generated eval.py that omitted or faked a
+        protected_path / check guardrail was never independently reviewed. This
+        runs the same verifier + one-retry loop the non-bootstrap rule maker
+        uses. Returns {'passed': bool, ...}; a True passthrough when the idea
+        declares no contract keeps the previous behavior for plain ideas.
+        """
+        if not has_user_eval_contract(idea):
+            return {"passed": True, "skipped": True}
+
+        print()
+        print("─" * 80)
+        print("STAGE: EVAL VERIFIER (bootstrap; evaluation contract / invariants declared)")
+        print("─" * 80)
+
+        verdict = run_eval_verifier(
+            idea=idea, work_dir=self.work_dir, provider=provider,
+            templates_dir=self.templates_dir, full_permissions=full_permissions)
+        if verdict.get("success") and verdict.get("passed"):
+            return {"passed": True, "verdict": verdict}
+
+        print()
+        print("↻ Verifier rejected the bootstrap scoring contract -- re-running "
+              "the bootstrap rule maker once with the findings appended.")
+        sealed_dir = self._seal_bootstrap_inputs()
+        try:
+            retry = run_bootstrap_rule_maker(
+                curated_manifest=curated_manifest,
+                work_dir=self.work_dir,
+                provider=provider,
+                templates_dir=self.templates_dir,
+                timeout=timeout,
+                full_permissions=full_permissions,
+                log_dir=self.work_dir / ".neurico" / "bootstrap_logs",
+                prompt_suffix=format_violations_for_retry(
+                    verdict.get("violations")),
+            )
+        finally:
+            self._unseal_bootstrap_inputs(sealed_dir)
+        if not retry.get("success"):
+            return {"passed": False, "verdict": verdict,
+                    "retry_generation_failed": True}
+
+        verdict = run_eval_verifier(
+            idea=idea, work_dir=self.work_dir, provider=provider,
+            templates_dir=self.templates_dir, full_permissions=full_permissions)
+        return {"passed": bool(verdict.get("success") and verdict.get("passed")),
+                "verdict": verdict}
 
     def _bootstrap_sealed_dir_for(self) -> Path:
         """Sibling sealed dir for bootstrap mode."""

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -1892,8 +1892,8 @@ class ResearchPipelineOrchestrator:
         # STAGE B2b: Eval verifier. The bootstrap rule_maker just generated the
         # scoring harness; when the idea declares an evaluation contract or
         # continuation invariants, independently review that eval.py actually
-        # enforces them (reads protected_baseline and recomputes hashes, runs
-        # check commands) before the scorer runs. On a failed verdict the rule
+        # enforces them (checks protected paths against the git baseline_ref,
+        # runs check commands) before the scorer runs. On a failed verdict the rule
         # maker is re-run once with the findings, then re-verified; still failing
         # aborts before the scorer.
         verified = self._verify_bootstrap_eval_contract(

--- a/src/core/repo_adoption.py
+++ b/src/core/repo_adoption.py
@@ -247,7 +247,12 @@ def adopt_repository(
     gitignore = work_dir / ".gitignore"
     existing = gitignore.read_text(encoding='utf-8') if gitignore.exists() else ""
     if "__pycache__/" not in existing.splitlines():
-        section = "\n# Added at adoption for continue-research checkpoints\n__pycache__/\n*.pyc\n"
+        # The prepared marker is a transient Stage-1 signal, not part of the
+        # tracked workspace: leaving it untracked would make the continuation
+        # validator see a dirty tree and could reject Stage 2. (.neurico/idea.yaml
+        # stays tracked -- it is the redacted contract Stage 2 and the backup use.)
+        section = ("\n# Added at adoption for continue-research checkpoints\n"
+                   "__pycache__/\n*.pyc\n.neurico/continuation_prepared.json\n")
         gitignore.write_text(existing.rstrip("\n") + "\n" + section if existing
                              else section.lstrip("\n"), encoding='utf-8')
     # Move in-repo held-out data into gitignored data/.test BEFORE the anchor

--- a/src/core/repo_adoption.py
+++ b/src/core/repo_adoption.py
@@ -1,0 +1,311 @@
+"""
+Repo Adoption - Turn an existing repository into a continue-research workspace
+
+Continue-research runs start from a repository the user already has (local
+path or GitHub URL) rather than a NeuriCo-created workspace. Adoption makes a
+private working copy under the runs directory, never touching the original:
+
+1. Clone (URL) or copy (local path) the source into the workspace directory
+2. Ensure the copy is a git repository with a committed state, so the
+   AutoResearch checkpoint machinery has an anchor
+3. Optionally create a NeuriCo research repo on GitHub and point origin at
+   it; the source's own remote, when present, is kept as 'upstream'
+4. Record the adoption in .neurico/adoption.json and write the canonical
+   .neurico/idea.yaml
+
+Adoption is idempotent: a workspace with an adoption record is left as-is so
+interrupted runs can resume.
+"""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+import json
+import os
+import shutil
+import subprocess
+
+REMOTE_PREFIXES = ('http://', 'https://', 'git@')
+
+ADOPTION_RECORD = ".neurico/adoption.json"
+
+
+def is_remote_repo(source: str) -> bool:
+    """True when the continuation source is a URL rather than a local path."""
+    return str(source).startswith(REMOTE_PREFIXES)
+
+
+def _sealed_entries_inside_repo(idea: Dict[str, Any],
+                                repo_root: Optional[Path]) -> bool:
+    """True when any sealed dataset's source lives inside the repository
+    being adopted (a relative declaration is in-repo by construction)."""
+    from core.local_resources import sealed_dataset_entries
+
+    for entry in sealed_dataset_entries(idea):
+        raw = str(entry.get('source_path') or entry.get('path') or '')
+        if not raw or raw.startswith(('http://', 'https://', 'git@')):
+            continue
+        path = Path(raw).expanduser()
+        if not path.is_absolute():
+            return True
+        if repo_root is not None:
+            try:
+                path.resolve().relative_to(Path(repo_root).resolve())
+                return True
+            except (ValueError, OSError):
+                continue
+    return False
+
+
+def _warn_external_symlinks(work_dir: Path, source_root: Path) -> None:
+    """
+    Flag copied symlinks that will not survive the move into the workspace.
+
+    Relative links are resolved against their location in the COPY and are
+    fine when they stay inside the workspace (ordinary in-repo links).
+    Absolute links are broken either way: a target outside the source repo
+    is external material that was deliberately NOT copied in, and a target
+    INSIDE the source repo points at the read-only mount during runs and
+    dangles entirely once the source is unmounted or on another machine —
+    it should be declared relative in the source repo instead.
+    """
+    work_resolved = work_dir.resolve()
+    external = []
+    absolute_into_source = []
+    for path in work_dir.rglob('*'):
+        if not path.is_symlink():
+            continue
+        raw_target = Path(os.readlink(path))
+        rel_name = path.relative_to(work_dir)
+        if raw_target.is_absolute():
+            try:
+                raw_target.resolve().relative_to(Path(source_root).resolve())
+                absolute_into_source.append(f"{rel_name} -> {raw_target}")
+            except (ValueError, OSError):
+                external.append(f"{rel_name} -> {raw_target}")
+        else:
+            resolved = (path.parent / raw_target).resolve()
+            try:
+                resolved.relative_to(work_resolved)
+            except ValueError:
+                external.append(f"{rel_name} -> {raw_target}")
+    if external:
+        print("   ⚠️  Symlinks pointing outside the repository were preserved "
+              "as links (their targets are NOT copied in and will not resolve "
+              "in the workspace):")
+        for entry in external:
+            print(f"      - {entry}")
+    if absolute_into_source:
+        print("   ⚠️  Symlinks with ABSOLUTE targets inside the source "
+              "repository will dangle once the source is not mounted; "
+              "consider making them relative in the source repo:")
+        for entry in absolute_into_source:
+            print(f"      - {entry}")
+
+
+def _git(work_dir: Path, *args: str) -> subprocess.CompletedProcess:
+    """Run a git command in the workspace with a stable committer identity."""
+    return subprocess.run(
+        ["git", "-c", "user.email=neurico@local", "-c", "user.name=NeuriCo", *args],
+        cwd=str(work_dir),
+        capture_output=True,
+        text=True,
+    )
+
+
+def adopt_repository(
+    idea: Dict[str, Any],
+    idea_id: str,
+    work_dir: Path,
+    github_manager=None,
+    provider: Optional[str] = None,
+    private: bool = False,
+    no_hash: bool = False,
+    pre_commit_hook: Optional[Callable[[Path], None]] = None,
+) -> Dict[str, Any]:
+    """
+    Adopt the continuation source repository into work_dir.
+
+    Args:
+        idea: Full idea specification (must carry idea.continuation.source_repo)
+        idea_id: Idea identifier (used for GitHub repo naming)
+        work_dir: Workspace directory to adopt into
+        github_manager: When provided, create a NeuriCo research repo and
+            point origin at it (mirrors the normal-run GitHub option)
+        provider: AI provider name for repo naming
+        private: Create the GitHub repo as private
+        no_hash: Skip the random hash in the GitHub repo name
+        pre_commit_hook: Called with work_dir after the source is copied and
+            its history dropped but BEFORE the anchor commit and any push.
+            Continue-research uses this to move in-repo held-out data into the
+            gitignored data/.test, so sealed bytes never enter the fresh
+            history or the GitHub backup. Not called on an idempotent resume
+            (the anchor commit already exists).
+
+    Returns:
+        Dict with: adopted (False when resuming an existing adoption),
+        source_repo, mode ('clone' | 'copy'), github_url (None without GitHub)
+
+    Raises:
+        ValueError: If the source is missing, is the workspace itself, or the
+            workspace is non-empty without an adoption record
+        FileNotFoundError: If a local source path does not exist (in Docker
+            this usually means the path was not mounted; run.sh mounts the
+            paths listed in ideas/mounts/<idea_id>.txt)
+        RuntimeError: If cloning fails
+    """
+    work_dir = Path(work_dir)
+    source = str(idea.get('idea', {}).get('continuation', {}).get('source_repo', '')).strip()
+    if not source:
+        raise ValueError("adopt_repository: idea has no continuation.source_repo")
+
+    # Idempotent resume: a recorded adoption is left untouched
+    record_path = work_dir / ADOPTION_RECORD
+    if record_path.exists():
+        try:
+            record = json.loads(record_path.read_text(encoding='utf-8'))
+        except (OSError, json.JSONDecodeError):
+            record = {}
+        print(f"↩️  Workspace already adopted from {record.get('source_repo', source)}; resuming.")
+        record['adopted'] = False
+        return record
+
+    if work_dir.exists() and any(work_dir.iterdir()):
+        raise ValueError(
+            f"Workspace {work_dir} is not empty and has no adoption record. "
+            "Use --force-fresh semantics by removing it, or pick a new idea id."
+        )
+
+    print(f"📦 Adopting repository for continue-research")
+    print(f"   Source: {source}")
+    print(f"   Workspace: {work_dir}")
+
+    if is_remote_repo(source):
+        mode = 'clone'
+        work_dir.parent.mkdir(parents=True, exist_ok=True)
+        clone = subprocess.run(
+            ["git", "clone", source, str(work_dir)],
+            capture_output=True, text=True,
+        )
+        if clone.returncode != 0:
+            raise RuntimeError(f"git clone failed for {source}: {clone.stderr.strip()}")
+    else:
+        mode = 'copy'
+        source_path = Path(source).expanduser()
+        if not source_path.exists():
+            raise FileNotFoundError(
+                f"continuation source repo not found: {source_path} "
+                "(inside Docker, local paths must be mounted; run.sh mounts "
+                f"the paths listed in ideas/mounts/{idea_id}.txt)"
+            )
+        source_resolved = source_path.resolve()
+        work_resolved = work_dir.resolve() if work_dir.exists() else work_dir
+        if source_resolved == work_resolved or work_dir.is_relative_to(source_resolved):
+            raise ValueError(
+                f"continuation source {source_resolved} overlaps the workspace "
+                f"{work_dir}; adoption must copy, never adopt in place"
+            )
+        # symlinks=True preserves links as links: dereferencing would turn a
+        # symlink to external material (a private dataset, a config file, a
+        # huge directory) into real workspace content that later commits and
+        # pushes would publish.
+        shutil.copytree(source_resolved, work_dir, dirs_exist_ok=True,
+                        symlinks=True, ignore_dangling_symlinks=True)
+        _warn_external_symlinks(work_dir, source_resolved)
+
+    # A sealed dataset that lives inside the source repository also lives in
+    # its git HISTORY: preserving that history would keep the sealed bytes
+    # readable through git long after staging removes the working copy.
+    # Adopt with a fresh history instead — the checkpoint machinery only
+    # needs an anchor commit.
+    sealed_in_repo = _sealed_entries_inside_repo(
+        idea, source_resolved if mode == 'copy' else work_dir.resolve())
+    # Always adopt with a FRESH git history: drop every .git directory
+    # (top-level and any nested submodule / vendored repo) before the anchor
+    # commit. This guarantees (a) the source's own remotes -- which may embed
+    # credentials and point at the user's real repository -- never survive
+    # into the agent-visible workspace, and (b) no git history (top-level or
+    # nested) retains sealed bytes that were committed inside the source repo.
+    for git_dir in [work_dir / ".git", *work_dir.rglob(".git")]:
+        if git_dir.is_dir():
+            shutil.rmtree(git_dir, ignore_errors=True)
+        elif git_dir.exists() or git_dir.is_symlink():
+            git_dir.unlink()  # a gitfile pointer (worktree / submodule)
+    if sealed_in_repo:
+        print("   🔒 Sealed data lives inside the source repository; adopting "
+              "with a fresh git history (the original history would retain "
+              "the sealed bytes).")
+
+    # Ensure a git anchor for the checkpoint machinery: init when the source
+    # was not a repo, and commit any dirty state so the adopted baseline is
+    # exactly what the checkpoints reproduce
+    if not (work_dir / ".git").exists():
+        _git(work_dir, "init")
+
+    # Keep Python bytecode out of iteration checkpoints; adopted repos often
+    # have no .gitignore of their own
+    gitignore = work_dir / ".gitignore"
+    existing = gitignore.read_text(encoding='utf-8') if gitignore.exists() else ""
+    if "__pycache__/" not in existing.splitlines():
+        section = "\n# Added at adoption for continue-research checkpoints\n__pycache__/\n*.pyc\n"
+        gitignore.write_text(existing.rstrip("\n") + "\n" + section if existing
+                             else section.lstrip("\n"), encoding='utf-8')
+    # Move in-repo held-out data into gitignored data/.test BEFORE the anchor
+    # commit, so the plaintext never lands in the fresh history (which the
+    # Stage 2 agent can read via `git show`) or in the GitHub backup. Dropping
+    # the source history removed the OLD bytes; without this the fresh commit
+    # would re-add them.
+    if pre_commit_hook is not None:
+        pre_commit_hook(work_dir)
+
+    status = _git(work_dir, "status", "--porcelain")
+    if status.stdout.strip():
+        _git(work_dir, "add", "-A")
+        _git(work_dir, "commit", "-m", f"Adopt {source} for continue-research")
+
+    # Optional GitHub backup repo, mirroring the normal-run GitHub option.
+    # The fresh history above dropped every source remote, so there is no
+    # credential-bearing 'origin' left to rename; we just point origin at the
+    # new NeuriCo backup repo.
+    github_url = None
+    if github_manager is not None:
+        try:
+            idea_spec = idea.get('idea', {})
+            repo_info = github_manager.create_research_repo(
+                idea_id=idea_id,
+                title=idea_spec.get('title', idea_id),
+                description=f"Continue-research: {idea_spec.get('title', idea_id)}",
+                private=private,
+                domain=idea_spec.get('domain', 'research'),
+                provider=provider,
+                no_hash=no_hash,
+            )
+            github_url = repo_info['repo_url']
+            _git(work_dir, "remote", "add", "origin", repo_info['clone_url'])
+            push = _git(work_dir, "push", "-u", "origin", "HEAD")
+            if push.returncode != 0:
+                print(f"⚠️  Initial push to {github_url} failed: {push.stderr.strip()}")
+            else:
+                print(f"✅ Adopted workspace backed up to: {github_url}")
+        except Exception as e:
+            print(f"⚠️  GitHub repository creation failed: {e}")
+            print("   Continuing with the local workspace only.")
+            github_url = None
+
+    # Record the adoption. The record keeps only the repo's name for a local
+    # source (full URLs are remote provenance and stay). The canonical
+    # .neurico/idea.yaml is written by the caller (continuation_prepare) AFTER
+    # held-out staging rewrites the sealed paths, so it is not written here
+    # (a pre-staging copy would only be clobbered).
+    record = {
+        'source_repo': source if is_remote_repo(source) else Path(source).name,
+        'mode': mode,
+        'adopted_at': datetime.now().isoformat(),
+        'github_url': github_url,
+    }
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    record_path.write_text(json.dumps(record, indent=2) + "\n", encoding='utf-8')
+
+    print(f"✓ Repository adopted ({mode})")
+    record['adopted'] = True
+    return record

--- a/src/core/repo_adoption.py
+++ b/src/core/repo_adoption.py
@@ -292,13 +292,16 @@ def adopt_repository(
             print("   Continuing with the local workspace only.")
             github_url = None
 
-    # Record the adoption. The record keeps only the repo's name for a local
-    # source (full URLs are remote provenance and stay). The canonical
+    # Record the adoption. .neurico/ is committed (only __pycache__ is
+    # gitignored) and rides into the GitHub backup, so the record must not
+    # carry a re-usable pointer back to the source: keep only the repo's bare
+    # name, for a remote URL as well as a local path. Nothing reads source_repo
+    # back from this record; it is provenance only. The canonical
     # .neurico/idea.yaml is written by the caller (continuation_prepare) AFTER
     # held-out staging rewrites the sealed paths, so it is not written here
     # (a pre-staging copy would only be clobbered).
     record = {
-        'source_repo': source if is_remote_repo(source) else Path(source).name,
+        'source_repo': Path(source.rstrip('/')).name,
         'mode': mode,
         'adopted_at': datetime.now().isoformat(),
         'github_url': github_url,

--- a/src/core/repo_adoption.py
+++ b/src/core/repo_adoption.py
@@ -242,18 +242,23 @@ def adopt_repository(
     if not (work_dir / ".git").exists():
         _git(work_dir, "init")
 
-    # Keep Python bytecode out of iteration checkpoints; adopted repos often
-    # have no .gitignore of their own
+    # Keep Python bytecode and the transient Stage-1 marker out of iteration
+    # checkpoints; adopted repos often have no .gitignore of their own. Each
+    # rule is added independently of the others: an adopted repo that ALREADY
+    # ignores __pycache__/ must still get the marker rule, otherwise the prepared
+    # marker lands as an untracked file, the continuation validator sees a dirty
+    # tree, and Stage 2 can be rejected. (.neurico/idea.yaml stays tracked -- it
+    # is the redacted contract Stage 2 and the backup use.)
     gitignore = work_dir / ".gitignore"
     existing = gitignore.read_text(encoding='utf-8') if gitignore.exists() else ""
-    if "__pycache__/" not in existing.splitlines():
-        # The prepared marker is a transient Stage-1 signal, not part of the
-        # tracked workspace: leaving it untracked would make the continuation
-        # validator see a dirty tree and could reject Stage 2. (.neurico/idea.yaml
-        # stays tracked -- it is the redacted contract Stage 2 and the backup use.)
+    lines = existing.splitlines()
+    needed = [r for r in ("__pycache__/", "*.pyc",
+                          ".neurico/continuation_prepared.json")
+              if r not in lines]
+    if needed:
         section = ("\n# Added at adoption for continue-research checkpoints\n"
-                   "__pycache__/\n*.pyc\n.neurico/continuation_prepared.json\n")
-        gitignore.write_text(existing.rstrip("\n") + "\n" + section if existing
+                   + "\n".join(needed) + "\n")
+        gitignore.write_text((existing.rstrip("\n") + "\n" + section) if existing
                              else section.lstrip("\n"), encoding='utf-8')
     # Move in-repo held-out data into gitignored data/.test BEFORE the anchor
     # commit, so the plaintext never lands in the fresh history (which the

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -306,8 +306,17 @@ class ResearchRunner:
             print("   Bootstrap AutoResearch baseline: enabled")
         print("=" * 80)
 
-        # Load idea
+        # Load idea. The continuation research container does NOT mount the host
+        # ideas/ directory (its submitted YAML retains the source repo URL, which
+        # the optimizing agent must not see), so fall back to the redacted
+        # contract the prepare stage wrote into the workspace. That copy has
+        # source_repo stripped but keeps the goal + invariants Stage 2 needs.
         idea = self.idea_manager.get_idea(idea_id)
+        if idea is None:
+            import yaml as _yaml
+            workspace_idea = (self.runs_dir / idea_id / ".neurico" / "idea.yaml")
+            if workspace_idea.exists():
+                idea = _yaml.safe_load(workspace_idea.read_text(encoding="utf-8"))
         if idea is None:
             raise ValueError(f"Idea not found: {idea_id}")
         attach_runtime_compute_backend(idea, compute_backend)
@@ -329,8 +338,14 @@ class ResearchRunner:
         # optimizing agent) prepares a scored standard NeuriCo workspace; Stage
         # 2 is a plain continuation on it. Detected here, before the forward
         # workspace setup, because Stage 1's adoption needs an empty work_dir.
-        if isinstance(idea_spec.get("continuation"), dict) and \
-                idea_spec["continuation"].get("source_repo"):
+        # source_repo marks a fresh continuation; on the research-stage re-entry
+        # the redacted workspace idea has no source_repo, so the prepared marker
+        # (written by Stage 1) is the signal that this is a continuation to
+        # resume into Stage 2.
+        from core.continuation_prepare import PREPARED_MARKER as _PREP_MARKER
+        _cont = idea_spec.get("continuation")
+        _prepared = (self.runs_dir / idea_id / _PREP_MARKER).exists()
+        if isinstance(_cont, dict) and (_cont.get("source_repo") or _prepared):
             return self._run_continuation(
                 idea=idea,
                 idea_id=idea_id,
@@ -1190,6 +1205,7 @@ https://github.com/ChicagoHAI/neurico
             autoresearch_state_current_best_sha,
         )
         from core.repo_adoption import ADOPTION_RECORD
+        from core.continuation_prepare import PREPARED_MARKER
 
         work_dir = (self.runs_dir / idea_id).resolve()
         github_manager = self.github_manager if self.use_github else None
@@ -1213,15 +1229,20 @@ https://github.com/ChicagoHAI/neurico
             print(f"🧹 --force-fresh: previous continuation workspace moved to "
                   f"{stale}")
 
-        # Skip Stage 1 when the workspace is already a prepared, scored
-        # NeuriCo workspace (adoption record + a recorded current_best). This
-        # makes the two-container Docker flow clean: the prepare container runs
-        # Stage 1 with --prepare-only, and the research container -- which does
-        # NOT mount the source materials -- re-enters here, finds the workspace
-        # prepared, and runs only Stage 2. Native single-process runs fall
-        # through and prepare a fresh workspace.
+        # Skip Stage 1 only when Stage 1 FULLY completed: adoption record, a
+        # recorded current_best, AND the prepared marker. The marker is written
+        # last, after invariant verification passes, so it is the authoritative
+        # "prepare finished cleanly" signal. Keying only on adoption +
+        # current_best would treat a workspace whose invariant verification
+        # FAILED (after current_best was already recorded) as prepared, skip
+        # verification on retry, and continue with the rejected evaluator. The
+        # marker closes that: a failed prepare leaves no marker, so the next run
+        # re-runs Stage 1 and re-verifies. Enables the clean two-container Docker
+        # flow the same way (the prepare container writes the marker; the
+        # research container sees it and runs only Stage 2).
         already_prepared = (
             (work_dir / ADOPTION_RECORD).exists()
+            and (work_dir / PREPARED_MARKER).exists()
             and autoresearch_state_current_best_sha(
                 read_autoresearch_state(work_dir)) is not None
         )

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -17,6 +17,7 @@ import subprocess
 import shlex
 import sys
 import os
+import json
 import yaml
 
 # Force UTF-8 stdout/stderr on Windows where the default is cp1252.
@@ -202,6 +203,7 @@ class ResearchRunner:
         continue_autoresearch: bool = False,
         continue_recover: bool = False,
         bootstrap_autoresearch_baseline: bool = False,
+        prepare_only: bool = False,
         proposer_timeout: int = 900,
         compute_backend: str = "local",
         hitl_autoresearch: Optional[str] = None,
@@ -321,6 +323,44 @@ class ResearchRunner:
 
         # Update status
         self.idea_manager.update_status(idea_id, "in_progress")
+
+        # continue-research: an idea carrying a continuation contract is run as
+        # two consecutive stages under this one command. Stage 1 (trusted, no
+        # optimizing agent) prepares a scored standard NeuriCo workspace; Stage
+        # 2 is a plain continuation on it. Detected here, before the forward
+        # workspace setup, because Stage 1's adoption needs an empty work_dir.
+        if isinstance(idea_spec.get("continuation"), dict) and \
+                idea_spec["continuation"].get("source_repo"):
+            return self._run_continuation(
+                idea=idea,
+                idea_id=idea_id,
+                title=title,
+                provider=provider,
+                full_permissions=full_permissions,
+                rule_maker_timeout=rule_maker_timeout,
+                scorer_timeout=scorer_timeout,
+                manifest_trimmer_timeout=manifest_trimmer_timeout,
+                autoresearch_iterations=autoresearch_iterations,
+                autoresearch_history_dir=autoresearch_history_dir,
+                proposer_timeout=proposer_timeout,
+                comment_timeout=timeout,
+                compute_backend=compute_backend,
+                private=private,
+                no_hash=no_hash,
+                write_paper=write_paper,
+                paper_style=paper_style,
+                paper_timeout=paper_timeout,
+                prepare_only=prepare_only,
+            )
+
+        # --prepare-only is meaningful only for a continuation idea (it splits
+        # Stage 1 into the Docker prepare container). For a forward idea it is
+        # a no-op, so a misrouted prepare container never runs the full forward
+        # pipeline with materials mounted.
+        if prepare_only:
+            print("ℹ️  --prepare-only has no effect on a non-continuation idea; "
+                  "nothing to prepare.")
+            return {"idea_id": idea_id, "success": True, "prepared": False}
 
         # Setup working directory (GitHub repo or local runs/)
         github_url = None
@@ -1076,6 +1116,212 @@ https://github.com/ChicagoHAI/neurico
 
         return {"work_dir": work_dir, "github_url": github_url, "success": result["success"]}
 
+    @staticmethod
+    def _continuation_materials_readable(idea: Dict[str, Any]) -> list:
+        """Declared continuation source materials that are still readable on
+        this filesystem: the local source repo and any absolute (host) sealed
+        dataset source. In-repo sealed sources are moved into data/.test during
+        Stage 1 (their originals deleted), and data/.test itself is the accepted
+        residual every NeuriCo run carries, so neither is reported here."""
+        from core.repo_adoption import is_remote_repo
+        from core.local_resources import sealed_dataset_entries
+
+        inner = idea.get("idea", idea) if isinstance(idea, dict) else {}
+        exposed = []
+        source_repo = str((inner.get("continuation") or {}).get("source_repo") or "").strip()
+        if source_repo and not is_remote_repo(source_repo):
+            p = Path(source_repo).expanduser()
+            if p.exists():
+                exposed.append(str(p))
+        for entry in sealed_dataset_entries(idea):
+            raw = str(entry.get("source_path") or entry.get("path") or "").strip()
+            if not raw or raw.replace("\\", "/").startswith("data/.test/"):
+                continue
+            p = Path(raw).expanduser()
+            if p.is_absolute() and p.exists():
+                exposed.append(str(p))
+        return exposed
+
+    def _run_continuation(
+        self,
+        *,
+        idea: Dict[str, Any],
+        idea_id: str,
+        title: str,
+        provider: str,
+        full_permissions: bool,
+        rule_maker_timeout: int,
+        scorer_timeout: int,
+        manifest_trimmer_timeout: int,
+        autoresearch_iterations: int,
+        autoresearch_history_dir: Optional[Path],
+        proposer_timeout: int,
+        comment_timeout: int,
+        compute_backend: str,
+        private: bool,
+        no_hash: bool,
+        write_paper: bool,
+        paper_style: Optional[str],
+        paper_timeout: int,
+        prepare_only: bool,
+    ) -> Dict[str, Any]:
+        """continue-research dispatch: Stage 1 (prepare) then Stage 2 (plain
+        continuation).
+
+        Stage 1 is trusted setup with NO optimizing agent: adopt the source
+        repo, stage held-out materials into gitignored data/.test, and generate
+        + score the baseline via main's bootstrap path, producing a standard
+        scored NeuriCo workspace. Stage 2 is an ordinary
+        ``continue_from_current_best`` run on that workspace -- it sees no
+        source materials, does no protocol regeneration, and does no
+        re-baseline, so the whole class of agent-tampering/leak bugs the
+        single-stage design hit cannot occur here.
+
+        With ``prepare_only`` the command stops after Stage 1 (used by the
+        Docker prepare container, which mounts the source materials; the
+        separate research container then runs Stage 2 without them).
+        """
+        from core.continuation_prepare import prepare_continuation_workspace
+        from core.autoresearch import (
+            continue_from_current_best,
+            read_autoresearch_state,
+            autoresearch_state_current_best_sha,
+        )
+        from core.repo_adoption import ADOPTION_RECORD
+
+        work_dir = (self.runs_dir / idea_id).resolve()
+        github_manager = self.github_manager if self.use_github else None
+        github_url = None
+
+        # Skip Stage 1 when the workspace is already a prepared, scored
+        # NeuriCo workspace (adoption record + a recorded current_best). This
+        # makes the two-container Docker flow clean: the prepare container runs
+        # Stage 1 with --prepare-only, and the research container -- which does
+        # NOT mount the source materials -- re-enters here, finds the workspace
+        # prepared, and runs only Stage 2. Native single-process runs fall
+        # through and prepare a fresh workspace.
+        already_prepared = (
+            (work_dir / ADOPTION_RECORD).exists()
+            and autoresearch_state_current_best_sha(
+                read_autoresearch_state(work_dir)) is not None
+        )
+
+        prepared: Dict[str, Any] = {"work_dir": str(work_dir), "prepared": True,
+                                    "reused_existing": True}
+        if already_prepared:
+            print("=" * 80)
+            print("CONTINUE-RESEARCH STAGE 1: workspace already prepared; skipping")
+            print("=" * 80)
+            # Surface the backup repo URL created by Stage 1 (the prepare
+            # container / earlier native run) so Stage 2's finalize still pushes
+            # to it. Without this a resumed / research-container Stage 2 loses it.
+            try:
+                record = json.loads(
+                    (work_dir / ADOPTION_RECORD).read_text(encoding="utf-8"))
+                github_url = record.get("github_url")
+            except (OSError, json.JSONDecodeError):
+                github_url = None
+        else:
+            # ---- Stage 1: prepare a scored standard NeuriCo workspace ----
+            print("=" * 80)
+            print("CONTINUE-RESEARCH STAGE 1: prepare (trusted setup, no optimizing agent)")
+            print("=" * 80)
+            prepared = prepare_continuation_workspace(
+                idea=idea,
+                idea_id=idea_id,
+                work_dir=work_dir,
+                templates_dir=self.project_root / "templates",
+                provider=provider,
+                full_permissions=full_permissions,
+                github_manager=github_manager,
+                rule_maker_timeout=rule_maker_timeout,
+                scorer_timeout=scorer_timeout,
+                manifest_trimmer_timeout=manifest_trimmer_timeout,
+                autoresearch_history_dir=autoresearch_history_dir,
+                prepare_workspace=lambda wd: self._copy_workspace_resources(
+                    wd, compute_backend=compute_backend),
+            )
+            github_url = (prepared.get("adoption") or {}).get("github_url")
+
+        if prepare_only:
+            print("\n📦 Continuation workspace prepared; exiting before Stage 2 "
+                  "(--prepare-only).")
+            return {
+                "work_dir": str(work_dir),
+                "github_url": github_url,
+                "success": True,
+                "prepared": True,
+                "continuation_prepare": prepared,
+            }
+
+        # Isolation backstop (defense-in-depth): Stage 2 runs the OPTIMIZING
+        # agent. In Docker it must run in the research container, which does NOT
+        # mount the source repo or the external held-out materials. The
+        # two-container split is chosen by a run.sh grep heuristic; a
+        # misdetected continuation could be routed to a single container with
+        # materials mounted and reach here. If we are in a container and the
+        # source materials are still readable, refuse rather than let the agent
+        # see them. Native runs (no container) are unaffected -- there is no
+        # container boundary to enforce, matching every other native run.
+        in_container = Path("/.dockerenv").exists() or Path("/run/.containerenv").exists()
+        if in_container:
+            exposed = self._continuation_materials_readable(idea)
+            if exposed:
+                raise RuntimeError(
+                    "Refusing to run continue-research Stage 2 (the optimizing "
+                    "agent) while source materials are still readable in this "
+                    "container: " + ", ".join(exposed) + ". The research "
+                    "container must run without the source repo / held-out "
+                    "materials mounted. This usually means the continuation was "
+                    "misrouted into a single-container run; re-run so Stage 1 "
+                    "(prepare, --prepare-only) and Stage 2 use separate "
+                    "containers.")
+
+        # ---- Stage 2: plain continuation on the prepared workspace ----
+        print("=" * 80)
+        print("CONTINUE-RESEARCH STAGE 2: continue (plain NeuriCo autoresearch)")
+        print("=" * 80)
+        success = False
+        pipeline_result: Dict[str, Any] = {}
+        try:
+            pipeline_result = continue_from_current_best(
+                idea=idea,
+                idea_id=idea_id,
+                work_dir=work_dir,
+                templates_dir=self.project_root / "templates",
+                provider=provider,
+                full_permissions=full_permissions,
+                scorer_timeout=scorer_timeout,
+                iterations=autoresearch_iterations,
+                autoresearch_history_dir=autoresearch_history_dir,
+                proposer_timeout=proposer_timeout,
+                comment_timeout=comment_timeout,
+            )
+            success = pipeline_result.get("success", False)
+            if write_paper and success:
+                self._run_paper_writer_stage(
+                    idea=idea,
+                    work_dir=work_dir,
+                    provider=provider,
+                    paper_style=paper_style,
+                    paper_timeout=paper_timeout,
+                    full_permissions=full_permissions,
+                )
+        except Exception as e:
+            print(f"\n❌ Continue-research Stage 2 error: {e}")
+            success = False
+        finally:
+            self._finalize_research(idea_id, work_dir, github_url, title,
+                                    provider, success)
+
+        return {
+            "work_dir": str(work_dir),
+            "github_url": github_url,
+            "success": success,
+            "continuation_prepare": prepared,
+            "autoresearch": pipeline_result.get("autoresearch"),
+        }
+
     def _run_paper_writer_stage(
         self,
         idea: Dict[str, Any],
@@ -1471,6 +1717,14 @@ def main():
         "Does not run AutoResearch iterations.",
     )
     parser.add_argument(
+        "--prepare-only",
+        action="store_true",
+        help="continue-research only: run Stage 1 (prepare a scored workspace "
+        "from the source repo + materials) and stop before Stage 2. Used by "
+        "the Docker prepare container so the source materials are never "
+        "mounted into the research container that runs Stage 2.",
+    )
+    parser.add_argument(
         "--proposer-timeout",
         type=int,
         default=900,
@@ -1579,6 +1833,7 @@ def main():
             continue_autoresearch=args.continue_autoresearch,
             continue_recover=args.continue_recover,
             bootstrap_autoresearch_baseline=args.bootstrap_autoresearch_baseline,
+            prepare_only=args.prepare_only,
             proposer_timeout=args.proposer_timeout,
             compute_backend=args.compute_backend,
             hitl_autoresearch=args.hitl_autoresearch,

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -351,6 +351,7 @@ class ResearchRunner:
                 paper_style=paper_style,
                 paper_timeout=paper_timeout,
                 prepare_only=prepare_only,
+                force_fresh=force_fresh,
             )
 
         # --prepare-only is meaningful only for a continuation idea (it splits
@@ -1164,6 +1165,7 @@ https://github.com/ChicagoHAI/neurico
         paper_style: Optional[str],
         paper_timeout: int,
         prepare_only: bool,
+        force_fresh: bool = False,
     ) -> Dict[str, Any]:
         """continue-research dispatch: Stage 1 (prepare) then Stage 2 (plain
         continuation).
@@ -1192,6 +1194,24 @@ https://github.com/ChicagoHAI/neurico
         work_dir = (self.runs_dir / idea_id).resolve()
         github_manager = self.github_manager if self.use_github else None
         github_url = None
+
+        # --force-fresh: discard any prepared or in-progress continuation
+        # workspace so Stage 1 re-adopts from scratch. Without this, an existing
+        # adoption record plus a recorded current_best makes already_prepared
+        # true below and Stage 1 is skipped, silently continuing from stale
+        # repo/held-out/evaluator/baseline state against the user's explicit
+        # request. Move rather than delete, mirroring the forward path's
+        # treatment of a superseded workspace.
+        if force_fresh and work_dir.exists():
+            import shutil
+            stale = work_dir.with_name(f"{work_dir.name}.superseded")
+            n = 1
+            while stale.exists():
+                n += 1
+                stale = work_dir.with_name(f"{work_dir.name}.superseded-{n}")
+            shutil.move(str(work_dir), str(stale))
+            print(f"🧹 --force-fresh: previous continuation workspace moved to "
+                  f"{stale}")
 
         # Skip Stage 1 when the workspace is already a prepared, scored
         # NeuriCo workspace (adoption record + a recorded current_best). This
@@ -1234,6 +1254,8 @@ https://github.com/ChicagoHAI/neurico
                 provider=provider,
                 full_permissions=full_permissions,
                 github_manager=github_manager,
+                private=private,
+                no_hash=no_hash,
                 rule_maker_timeout=rule_maker_timeout,
                 scorer_timeout=scorer_timeout,
                 manifest_trimmer_timeout=manifest_trimmer_timeout,

--- a/src/core/scoring_seal.py
+++ b/src/core/scoring_seal.py
@@ -23,6 +23,13 @@ SEALED_PATHS: list[str] = [
     # contract; quotes eval.py internals as evidence, so it must be hidden
     # from the runner alongside them. Absent files are skipped by the seal.
     "scoring/verification.json",
+    # Trusted continuation baseline of protected-path hashes (continue-research).
+    # It is the reference the generated eval.py compares against to enforce
+    # protected_path invariants, so it MUST NOT stay writable while the
+    # optimizing agent runs -- otherwise an iteration could rewrite a protected
+    # file and its recorded hash together and pass. Sealed like eval.py: hidden
+    # from the workspace during Stage 2, copied into the isolated scorer tree.
+    "scoring/protected_baseline.json",
     "data/.test/",
 ]
 SEALED_REQUIRED_PATHS = ("scoring/eval.py", "scoring/targets.json")

--- a/templates/agents/eval_verifier.txt
+++ b/templates/agents/eval_verifier.txt
@@ -83,12 +83,20 @@ hardcodes the property to 1.0, or computes it from something other than the
 real filesystem/command, is a FAIL.
 
 ✓ For every path in the contract's `invariants.protected_paths`: eval.py MUST
-  read the trusted baseline `scoring/protected_baseline.json`, RECOMPUTE each
-  recorded path's hash from the live filesystem (covering file content,
-  permission bits, symlink identity, and directory entries), compare to the
-  recorded hash, and emit a `protected_paths_unchanged` property that is 1.0
-  only when ALL match and 0.0 on ANY mismatch. If the property is a constant,
-  ignores the baseline, or hashes something else, FAIL with the quoted line.
+  read the trusted baseline `scoring/protected_baseline.json` (keys `baseline_ref`
+  and `paths`) and emit a `protected_paths_unchanged` property that is 1.0 only
+  when every protected path is byte-identical to `baseline_ref`, 0.0 otherwise.
+  It MUST establish this by reading the IMMUTABLE baseline objects
+  (`git ls-tree -r <baseline_ref>` + `git cat-file blob <sha>`) and comparing them
+  to the REAL filesystem with plain Python (open().read(), os.readlink, os.lstat
+  for the exec bit, os.walk for additions). It MUST NOT decide "unchanged" via
+  `git diff`, `git ls-files`, `git status`, `git checkout`, or the index -- those
+  read git's agent-controllable working-tree view and are exploitable
+  (assume-unchanged / skip-worktree, clean filters, core.fileMode, gitignore). If
+  eval.py uses ANY of those to determine the property, hard-codes it, or ignores
+  `baseline_ref`, FAIL with the quoted line. Confirm the 0.0 path is reachable (a
+  content/mode mismatch, an added or deleted path, or a missing baseline object
+  yields 0.0).
 
 ✓ For every command in the contract's `invariants.checks`: eval.py MUST run
   THAT command verbatim via subprocess from the workspace root and map exit 0

--- a/templates/agents/eval_verifier.txt
+++ b/templates/agents/eval_verifier.txt
@@ -73,6 +73,31 @@ interface.md and eval.py must together produce results in the user's
 declared shape. Missing fields the user asked for are a FAIL; extra fields
 are acceptable.
 
+CHECK 4: INVARIANTS (only when the contract lists `invariants`)
+─────────────────────────────────────────────────────────────────────────────
+
+continue-research declares continuation invariants the generated eval.py MUST
+enforce as scoring guardrails. Read eval.py and confirm it actually ENFORCES
+each one -- do not trust that a property NAME merely appears. A harness that
+hardcodes the property to 1.0, or computes it from something other than the
+real filesystem/command, is a FAIL.
+
+✓ For every path in the contract's `invariants.protected_paths`: eval.py MUST
+  read the trusted baseline `scoring/protected_baseline.json`, RECOMPUTE each
+  recorded path's hash from the live filesystem (covering file content,
+  permission bits, symlink identity, and directory entries), compare to the
+  recorded hash, and emit a `protected_paths_unchanged` property that is 1.0
+  only when ALL match and 0.0 on ANY mismatch. If the property is a constant,
+  ignores the baseline, or hashes something else, FAIL with the quoted line.
+
+✓ For every command in the contract's `invariants.checks`: eval.py MUST run
+  THAT command verbatim via subprocess from the workspace root and map exit 0
+  to a passing guardrail property, nonzero to failing. A check that is faked,
+  altered, or never executed is a FAIL.
+
+Confirm the FAILURE behavior is reachable (the comparison/exit-code path can
+return 0.0), not just that the baseline case returns 1.0.
+
 ═══════════════════════════════════════════════════════════════════════════════
                           VERDICT: {verdict_file}
 ═══════════════════════════════════════════════════════════════════════════════
@@ -85,11 +110,12 @@ INCLUDING the field order):
   "checks": {
     "routing": "pass" | "fail" | "not_applicable",
     "transcription": "pass" | "fail" | "not_applicable",
-    "format": "pass" | "fail" | "not_applicable"
+    "format": "pass" | "fail" | "not_applicable",
+    "invariants": "pass" | "fail" | "not_applicable"
   },
   "violations": [
     {
-      "check": "routing" | "transcription" | "format",
+      "check": "routing" | "transcription" | "format" | "invariants",
       "detail": "<one sentence: what is wrong>",
       "evidence": "<short verbatim quote from the offending file, with path>"
     }

--- a/templates/agents/rule_maker_bootstrap.txt
+++ b/templates/agents/rule_maker_bootstrap.txt
@@ -245,13 +245,27 @@ The idea may carry structured declarations that BIND your design. Check
      rejects any iteration that breaks one.
    ✓ Each invariant of kind `protected_path` MUST become a guardrail property
      named `protected_paths_unchanged`. A trusted file `scoring/protected_baseline.json`
-     (already present) maps each protected path to its sha256 recorded at preparation
-     time. eval.py MUST recompute the sha256 of every path in that file (hashing a
-     directory as sorted relpath + bytes so any add/remove/edit under it counts) and
-     compare to the recorded hash. Set the property value to 1.0 only if ALL protected
-     paths match their recorded hash, otherwise 0.0. Use target 1.0, direction max.
-     This makes "the agent must not modify these paths" a HARD scoring guardrail that
-     fails the iteration on any change.
+     (already present) maps each protected path to a hash recorded at preparation
+     time. eval.py MUST recompute each path's hash with the EXACT algorithm below
+     and compare to the recorded hash. Set the property value to 1.0 only if ALL
+     protected paths match their recorded hash, otherwise 0.0. Use target 1.0,
+     direction max. This makes "the agent must not modify these paths" a HARD scoring
+     guardrail that fails the iteration on any change.
+
+     The hash MUST match this algorithm byte-for-byte (a plain content-only hash
+     will disagree with the baseline and always report 0.0). For each protected
+     root, feed a single sha256 with, per entry, in this order:
+       - the entry's relative path (posix, "" for a file/symlink root), then a NUL;
+       - if it is a symlink: b"link\0" then os.readlink(path) (its TARGET STRING,
+         not the target's bytes);
+       - elif it is a directory: b"dir\0" then its 4-digit octal permission bits
+         (records even EMPTY directories);
+       - else (a file): b"file\0", its 4-digit octal permission bits, a NUL, then
+         the file bytes.
+     For a directory root, iterate every entry under it (os.walk / rglob) sorted by
+     relative posix path and fold each in as above; for a file or symlink root, fold
+     the single entry with relative path "". This covers content, permission bits,
+     symlink identity, and empty directories.
    ✓ Invariants of kind `statement` are NOT properties (not mechanically checkable);
      do not encode them in targets.json.
 

--- a/templates/agents/rule_maker_bootstrap.txt
+++ b/templates/agents/rule_maker_bootstrap.txt
@@ -256,8 +256,11 @@ The idea may carry structured declarations that BIND your design. Check
      will disagree with the baseline and always report 0.0). For each protected
      root, feed a single sha256 with, per entry, in this order:
        - the entry's relative path (posix, "" for a file/symlink root), then a NUL;
-       - if it is a symlink: b"link\0" then os.readlink(path) (its TARGET STRING,
-         not the target's bytes);
+       - if it is a symlink: b"link\0" then os.readlink(path) (its target
+         STRING); then, if the resolved target exists, b"\0target\0" followed by
+         a content signature of the target (sha256 of the file's bytes, or of
+         the resolved directory tree as sorted "relpath\0bytes"), so a change to
+         the content behind an unchanged link is caught too;
        - elif it is a directory: b"dir\0" then its 4-digit octal permission bits
          (records even EMPTY directories);
        - else (a file): b"file\0", its 4-digit octal permission bits, a NUL, then

--- a/templates/agents/rule_maker_bootstrap.txt
+++ b/templates/agents/rule_maker_bootstrap.txt
@@ -206,6 +206,60 @@ fields of the output you chose to measure, and why those reflect task
 success).
 
 ═══════════════════════════════════════════════════════════════════════════════
+              USER-DECLARED EVALUATION CONTRACT (WHEN PRESENT)
+═══════════════════════════════════════════════════════════════════════════════
+
+The idea may carry structured declarations that BIND your design. Check
+.neurico/idea.yaml for them; if absent, skip this section.
+
+1. `evaluation.metrics` — the user's own metrics.
+   ✓ Each declared metric becomes a property under its EXACT user-given
+     name. Express the user's target numerically in the metric's units,
+     record the verbatim wording as `source_text` with `"source": "user"`,
+     and cite anchor_type stated_success_criterion.
+   ✓ Add properties of your own ONLY for aspects the user did not cover.
+
+2. `local_resources.functions` with `required_for_evaluation: true` — a
+   mandated evaluation function staged at the listed workspace path
+   (code/local/...).
+   ✓ eval.py MUST load that file and call the declared entrypoint to compute
+     the corresponding measurements. Do NOT reimplement its metric, and do
+     NOT fall back to your own computation when it errors: an error from the
+     mandated function is an eval failure the user needs to see.
+
+3. `continuation` (continue-research mode) — the workspace is an adopted
+   external repository whose current state you are scoring as the baseline;
+   AutoResearch iterations will then optimize `continuation.goal`.
+   ✓ Design the property set so progress toward the goal is measurable
+     against this baseline.
+   ✓ Each invariant of kind `check` becomes a guardrail property that runs
+     the user's command VERBATIM and scores pass as 1.0:
+       "<derived_name>": {"target": 1.0, "direction": "max",
+                          "source": "user", "source_text": "<the command>"}
+     In eval.py, run the command with subprocess from the workspace root and
+     map exit 0 to value 1.0, nonzero to 0.0. Prepend the workspace
+     .venv/bin to PATH when it exists, else the running interpreter's bin
+     directory (Path(sys.executable).parent), so tools like pytest resolve.
+     This is the one sanctioned use of subprocess in eval.py. Guardrail
+     properties are expected to be satisfied at baseline; the comparator
+     rejects any iteration that breaks one.
+   ✓ Each invariant of kind `protected_path` MUST become a guardrail property
+     named `protected_paths_unchanged`. A trusted file `scoring/protected_baseline.json`
+     (already present) maps each protected path to its sha256 recorded at preparation
+     time. eval.py MUST recompute the sha256 of every path in that file (hashing a
+     directory as sorted relpath + bytes so any add/remove/edit under it counts) and
+     compare to the recorded hash. Set the property value to 1.0 only if ALL protected
+     paths match their recorded hash, otherwise 0.0. Use target 1.0, direction max.
+     This makes "the agent must not modify these paths" a HARD scoring guardrail that
+     fails the iteration on any change.
+   ✓ Invariants of kind `statement` are NOT properties (not mechanically checkable);
+     do not encode them in targets.json.
+
+Your scoring/ outputs are reviewed against these declarations by a verifier
+before the baseline is measured; violations send the work back to you with
+the findings appended.
+
+═══════════════════════════════════════════════════════════════════════════════
                               METHODOLOGY
 ═══════════════════════════════════════════════════════════════════════════════
 

--- a/templates/agents/rule_maker_bootstrap.txt
+++ b/templates/agents/rule_maker_bootstrap.txt
@@ -245,30 +245,48 @@ The idea may carry structured declarations that BIND your design. Check
      rejects any iteration that breaks one.
    ✓ Each invariant of kind `protected_path` MUST become a guardrail property
      named `protected_paths_unchanged`. A trusted file `scoring/protected_baseline.json`
-     (already present) maps each protected path to a hash recorded at preparation
-     time. eval.py MUST recompute each path's hash with the EXACT algorithm below
-     and compare to the recorded hash. Set the property value to 1.0 only if ALL
-     protected paths match their recorded hash, otherwise 0.0. Use target 1.0,
-     direction max. This makes "the agent must not modify these paths" a HARD scoring
-     guardrail that fails the iteration on any change.
+     (already present) is a JSON object with two keys: `baseline_ref` (a git
+     commit SHA recorded at preparation time) and `paths` (the list of protected
+     workspace-relative paths). Set the property value to 1.0 only if EVERY
+     protected path is byte-identical to that baseline commit, otherwise 0.0. Use
+     target 1.0, direction max. This makes "the agent must not modify these paths"
+     a HARD scoring guardrail that fails the iteration on any change.
 
-     The hash MUST match this algorithm byte-for-byte (a plain content-only hash
-     will disagree with the baseline and always report 0.0). For each protected
-     root, feed a single sha256 with, per entry, in this order:
-       - the entry's relative path (posix, "" for a file/symlink root), then a NUL;
-       - if it is a symlink: b"link\0" then os.readlink(path) (its target
-         STRING); then, if the resolved target exists, b"\0target\0" followed by
-         a content signature of the target (sha256 of the file's bytes, or of
-         the resolved directory tree as sorted "relpath\0bytes"), so a change to
-         the content behind an unchanged link is caught too;
-       - elif it is a directory: b"dir\0" then its 4-digit octal permission bits
-         (records even EMPTY directories);
-       - else (a file): b"file\0", its 4-digit octal permission bits, a NUL, then
-         the file bytes.
-     For a directory root, iterate every entry under it (os.walk / rglob) sorted by
-     relative posix path and fold each in as above; for a file or symlink root, fold
-     the single entry with relative path "". This covers content, permission bits,
-     symlink identity, and empty directories.
+     SECURITY -- READ THIS. The optimizing agent controls the workspace's .git
+     (the index, .gitattributes, .git/config, .gitignore). You MUST NOT decide
+     "unchanged" with `git diff`, `git ls-files`, `git status`, or `git checkout`:
+     every one of those reads git's WORKING-TREE view, which the agent can make
+     lie -- an `assume-unchanged`/`skip-worktree` index bit, a `clean` filter,
+     `core.fileMode=false`, or a `.gitignore` entry each makes a MODIFIED file
+     look clean. Use git ONLY to read the IMMUTABLE baseline objects (they are
+     content-addressed and cannot be forged), and compare them to the REAL
+     filesystem with plain Python reads. From the workspace root (ROOT), for each
+     protected path P in `paths`:
+       - List the baseline entries under P FROM THE COMMIT, not the worktree:
+           git ls-tree -r -z <baseline_ref> -- P
+         Each entry has a mode (100644 file, 100755 exec file, 120000 symlink,
+         160000 gitlink), a blob SHA, and a relpath. Build {relpath: (mode, sha)}.
+       - For each baseline entry, fetch its bytes with `git cat-file blob <sha>`
+         (raw object bytes -- no filter is applied, unlike diff/checkout), and:
+           * mode 120000 (symlink): the live ROOT/relpath MUST be a symlink whose
+             os.readlink() target string EQUALS those bytes;
+           * otherwise: the live ROOT/relpath MUST be a regular file (NOT a
+             symlink) whose open(path,'rb').read() EQUALS those bytes, AND whose
+             executable bit (bool(os.lstat(path).st_mode & 0o111)) matches whether
+             mode == 100755;
+           * any mismatch, or a live path that is missing / not the right type,
+             makes the property 0.0.
+       - Detect ADDITIONS from the real filesystem, not git: os.walk(ROOT/P,
+         followlinks=False) (when P is a directory) and flag any real file or
+         symlink whose relpath is absent from the baseline map -> 0.0. This
+         catches even a .gitignore'd or otherwise untracked file.
+       - Deletions are already caught above (a baseline entry with no live file).
+     Value is 1.0 only when every protected path passes all checks. If `paths` is
+     empty or the baseline file is absent, value 1.0. If ANY git command errors
+     (e.g. a missing baseline_ref), treat it as CHANGED -> 0.0 (fail closed),
+     never 1.0. Do NOT reimplement a content hash: this direct byte comparison,
+     seeded from the immutable baseline commit, is the whole check and lives only
+     here, so there is nothing to mirror or drift.
    ✓ Invariants of kind `statement` are NOT properties (not mechanically checkable);
      do not encode them in targets.json.
 


### PR DESCRIPTION
Supersedes #143. Same feature, redesigned. The single-stage version accumulated a class of held-out-data leaks and scoring-tamper bugs that all traced to one root: the optimizing agent shared a filesystem with the trusted evaluation setup (the raw materials, the scoring-protocol generation, the baseline). This version separates those in time instead of trying to defend them in place.

## What this adds

Continue-research starts NeuriCo from an existing repository and improves it toward a user goal, instead of building a solution from scratch. The user supplies a repo (local path or GitHub URL) and an intention file declaring a continuation contract: a goal, invariants, and bring-your-own evaluation materials including held-out data.

```
./neurico continue-research <repo> <intention.md>   # convert intention to an idea with a continuation contract
./neurico run <idea>                                # adopt the repo and optimize it
```

## Two stages, one command

`./neurico run` on a continuation idea executes two stages back to back:

**Stage 1 (prepare).** Trusted setup, no optimizing agent runs. It adopts the repo with fresh git history (source remotes scrubbed, nested `.git` removed), moves declared held-out materials into a gitignored `data/.test` before the anchor commit, records a trusted baseline of protected-path hashes, then runs the bootstrap rule maker to generate `scoring/{eval.py,targets.json,interface.md}` and scores the baseline. The output is an ordinary scored NeuriCo workspace.

**Stage 2.** A plain `continue_from_current_best` run on that workspace, with no continue-research-specific code, no scoring-protocol regeneration, and no re-baseline. Stage 2 is indistinguishable from an ordinary `--continue-autoresearch`.

Because all trusted setup finishes before the optimizing agent exists, the agent never coexists with the raw source materials or with scorer/baseline establishment. That removes the tampering and leak surface the single-stage design kept hitting, rather than patching each instance.

## The continuation contract

The intention file declares a goal plus invariants. Each invariant kind is enforced concretely:

| Kind | Meaning | Enforcement |
|---|---|---|
| `protected_path` | these files/dirs must not change | Hard scoring guardrail. Stage 1 records a sha256 baseline; the generated `eval.py` emits a `protected_paths_unchanged` property that fails the iteration on any change. |
| `check` | this command must keep passing | Guardrail property that runs the command verbatim and requires exit 0. |
| `statement` | a prose constraint | Surfaced to the agents, not mechanically checkable. |

Held-out evaluation data is declared as a material and staged into `data/.test`, which is already in NeuriCo's `SEALED_PATHS`, so Stage 2 hides it from the optimizing agent and from checkpoints exactly as any scored run does.

## Docker

Native runs are a single process. Under Docker the same one command runs as two containers so the source materials never reach the optimizing agent: a prepare container that mounts the repo and host materials and runs Stage 1 with `--prepare-only`, then a research container that mounts only the workspace (no materials) and runs Stage 2. A runtime backstop in `_run_continuation` refuses to run Stage 2 in a container while the source repo or a declared material path is still readable, so a misrouted single-container run cannot expose materials.

## Files

| File | Purpose |
|---|---|
| `src/core/continuation_prepare.py` (new) | Stage 1 flow: adopt, stage held-out, write protected-path baseline, generate scorer + score baseline. |
| `src/core/repo_adoption.py` (new) | Adopt a repo into the workspace with fresh git history; a pre-commit hook stages held-out data before the anchor commit so no plaintext enters history. |
| `src/cli/continue_research.py` (new) | Intention-to-idea conversion CLI with the continuation contract; pins `source_repo` to the CLI argument and gates on conversion faithfulness. |
| `src/cli/idea_conversion.py` (new) | Shared conversion helpers used by the continuation converter. |
| `src/core/runner.py` | `_run_continuation` dispatch (Stage 1 then Stage 2), `--prepare-only`, idempotent skip when already prepared, the container isolation backstop. |
| `src/core/local_resources.py` | Continuation contract and invariant helpers (`validate_continuation`, protected-path normalization and hashing, held-out declaration). |
| `src/core/idea_manager.py` | Wires `validate_continuation` into idea validation. |
| `templates/agents/rule_maker_bootstrap.txt` | Instructs the rule maker to encode `protected_path` invariants as the `protected_paths_unchanged` guardrail against the Stage 1 baseline. |
| `docker/run.sh` | Two-container prepare then research split for a continuation idea; forward runs are unchanged. |

Roughly half the size of #143, with the whole entangled layer removed: the encryption-at-rest store, the durable protocol store, the materials fingerprint, in-loop regeneration, re-baselining, content-hash restaging, and the old two-phase mount sidecar are all gone.

## Testing

- Local unit coverage of the prepare flow, adoption fresh-history scrub, the two-stage dispatch order, `--prepare-only`, idempotent resume, held-out never entering git, and the protected-path baseline. Suite green.
- The protected-path guardrail was validated with a live bootstrap rule maker end to end: given a `protected_path` invariant and the Stage 1 baseline, the generated `eval.py` reported `protected_paths_unchanged` = 1.0 with the file unchanged and 0.0 after a simulated agent modification, so the iteration is rejected on any change.
- Adoption verified on real repos: after prepare, an in-repo held-out file is absent from the working tree and from every git object, source remotes and nested `.git` are gone, and `data/.test` is gitignored.

A full live continue-research replication (Stage 1 baseline through several Stage 2 iterations) on the cluster is the next step before merge.
