### PR TITLE
Fix Mabool package README path

### DIFF
--- a/services/paper-finder/agents/mabool/api/README.md
+++ b/services/paper-finder/agents/mabool/api/README.md
@@ -1,0 +1,3 @@
+# Mabool API
+
+API package for the Mabool paper-finder agent.

--- a/services/paper-finder/agents/mabool/api/pyproject.toml
+++ b/services/paper-finder/agents/mabool/api/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mabool-api"
 version = "0.1.0"
 requires-python = ">=3.12.8"
-readme = "../README.md"
+readme = "README.md"
 dependencies = [
     "ai2i-chain",
     "ai2i-common",


### PR DESCRIPTION
## Summary

- Add a README inside the `mabool-api` project directory.
- Point the package metadata to that local README.

## Why

The Docker build failed because Hatchling rejects `../README.md`: project README paths cannot escape the package directory.

## Test

- `uv build --package mabool-api`