### PR TITLE
feat(hitl): Add automatic manager-led research mode

### DIFF
--- a/src/agents/autoresearch_proposer.py
+++ b/src/agents/autoresearch_proposer.py
@@ -164,7 +164,6 @@ def generate_autoresearch_proposal_prompt(
         hitl_stage="proposal",
         allow_raised_ideas=False,
         hitl_mode=hitl_mode,
-        human_resolution_allowed=hitl_mode != "auto",
         public_context=context,
         whiteboard_active_tips_md=whiteboard_active_tips_md,
         compute_backend_section=_generate_compute_backend_section(idea_spec, provider=provider),

--- a/src/agents/autoresearch_proposer.py
+++ b/src/agents/autoresearch_proposer.py
@@ -106,6 +106,7 @@ def generate_autoresearch_proposal_prompt(
     hitl_idea_reporting: bool = False,
     hitl_submission: bool = False,
     hitl_autoresearch_whiteboard: bool = False,
+    hitl_mode: str = "full",
 ) -> str:
     """
     Generate the AutoResearch proposer prompt from a curated public context.
@@ -162,6 +163,8 @@ def generate_autoresearch_proposal_prompt(
         pipeline_stage="experiment_runner",
         hitl_stage="proposal",
         allow_raised_ideas=False,
+        hitl_mode=hitl_mode,
+        human_resolution_allowed=hitl_mode != "auto",
         public_context=context,
         whiteboard_active_tips_md=whiteboard_active_tips_md,
         compute_backend_section=_generate_compute_backend_section(idea_spec, provider=provider),
@@ -273,6 +276,7 @@ def run_autoresearch_proposer(
         hitl_autoresearch_whiteboard=bool(
             env_extra and env_extra.get("NEURICO_HITL_AUTORESEARCH_WHITEBOARD") == "1"
         ),
+        hitl_mode=str((env_extra or {}).get("NEURICO_HITL_MODE", "full")),
     )
     prompt = append_prompt_block(prompt, prompt_suffix)
 

--- a/src/cli/hitl_launcher.py
+++ b/src/cli/hitl_launcher.py
@@ -93,10 +93,15 @@ class HitlRunController:
                 "Choose Claude or Codex for HITL research so the workers and manager "
                 "can use the same backend."
             )
+        raw_iterations = payload.get("iterations", 1)
         try:
-            iterations = int(payload.get("iterations", 1))
-        except (TypeError, ValueError) as exc:
+            iterations = int(raw_iterations)
+        except (TypeError, ValueError, OverflowError) as exc:
             raise ValueError("Iterations must be a whole number.") from exc
+        if isinstance(raw_iterations, bool) or (
+            isinstance(raw_iterations, float) and not raw_iterations.is_integer()
+        ):
+            raise ValueError("Iterations must be a whole number.")
         if not 1 <= iterations <= 100:
             raise ValueError("Iterations must be between 1 and 100.")
         style = str(payload.get("paper_style", "auto")).strip().lower()

--- a/src/cli/hitl_launcher.py
+++ b/src/cli/hitl_launcher.py
@@ -22,6 +22,7 @@ from core.hitl_lock import (
     select_hitl_manager_provider,
 )
 from core.hitl_manager_inbox import HitlManagerInbox
+from core.hitl_mode import normalize_hitl_mode
 from core.hitl_paths import hitl_launch_requests_dir, hitl_launch_status_path
 from core.hitl_run_control import request_hitl_run_stop
 from core.hitl_util import atomic_write_json, utc_now
@@ -101,6 +102,7 @@ class HitlRunController:
         style = str(payload.get("paper_style", "auto")).strip().lower()
         if style not in {"auto", "neurips", "icml", "acl"}:
             raise ValueError("Choose a supported paper style.")
+        hitl_mode = normalize_hitl_mode(payload.get("hitl_mode")).value
 
         with self._lock:
             external_owner = active_hitl_workspace_run(self.work_dir)
@@ -140,7 +142,7 @@ class HitlRunController:
             mode = "continue" if continuation else "fresh"
             request_id = uuid.uuid4().hex
             request = {
-                "version": 1,
+                "version": 2,
                 "request_id": request_id,
                 "idea_id": self.idea_id,
                 "work_dir": str(self.work_dir.resolve()),
@@ -151,6 +153,7 @@ class HitlRunController:
                 "paper_style": None if style == "auto" else style,
                 "github": bool(payload.get("github", False)),
                 "mode": mode,
+                "hitl_mode": hitl_mode,
                 "interface": self.interface,
                 "created_at": utc_now(),
             }
@@ -171,6 +174,7 @@ class HitlRunController:
                         "created_at": request["created_at"],
                         "updated_at": request["created_at"],
                         "mode": mode,
+                        "hitl_mode": hitl_mode,
                         "provider": provider,
                     },
                 )

--- a/src/cli/hitl_run_worker.py
+++ b/src/cli/hitl_run_worker.py
@@ -167,23 +167,25 @@ def main() -> int:
         signal.signal(signal.SIGTERM, request_signal_stop)
         signal.signal(signal.SIGINT, request_signal_stop)
         started_at = utc_now()
-        atomic_write_json(
-            hitl_launch_status_path(work_dir),
-            {
-                "status": "running",
-                "pid": os.getpid(),
-                "request_id": request["request_id"],
-                "started_at": started_at,
-                "updated_at": started_at,
-                "mode": request["mode"],
-                "hitl_mode": hitl_mode,
-                "provider": request["provider"],
-            },
-        )
         continuation = request["mode"] == "continue"
         log_path = work_dir / "logs" / "hitl_runtime.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
         with activate_hitl_run_stop_control(control):
+            if control.requested():
+                raise HitlRunStopRequested("HITL run stopped before startup completed.")
+            atomic_write_json(
+                hitl_launch_status_path(work_dir),
+                {
+                    "status": "running",
+                    "pid": os.getpid(),
+                    "request_id": request["request_id"],
+                    "started_at": started_at,
+                    "updated_at": started_at,
+                    "mode": request["mode"],
+                    "hitl_mode": hitl_mode,
+                    "provider": request["provider"],
+                },
+            )
             with log_path.open("a", encoding="utf-8") as output:
                 with redirect_stdout(output), redirect_stderr(output):
                     result = ResearchRunner(

--- a/src/cli/hitl_run_worker.py
+++ b/src/cli/hitl_run_worker.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from core.config_loader import ConfigLoader  # noqa: E402
 from core.hitl_paths import hitl_launch_requests_dir, hitl_launch_status_path  # noqa: E402
+from core.hitl_mode import normalize_hitl_mode  # noqa: E402
 from core.hitl_run_control import (  # noqa: E402
     HitlRunStopControl,
     HitlRunStopRequested,
@@ -48,7 +49,7 @@ def _claim_request(path: Path) -> Path:
 
 def _load_request(path: Path) -> Dict[str, Any]:
     value = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(value, dict) or value.get("version") != 1:
+    if not isinstance(value, dict) or value.get("version") not in {1, 2}:
         raise ValueError("Unsupported HITL launch request.")
     required = (
         "request_id",
@@ -67,6 +68,9 @@ def _load_request(path: Path) -> Dict[str, Any]:
         raise ValueError("HITL launch request has an unsupported mode.")
     if value["interface"] not in {"web", "cli"}:
         raise ValueError("HITL launch request has an unsupported source interface.")
+    if value["version"] == 2 and not str(value.get("hitl_mode", "")).strip():
+        raise ValueError("HITL launch request is missing its HITL mode.")
+    value["hitl_mode"] = normalize_hitl_mode(value.get("hitl_mode")).value
 
     identity = _REQUEST_NAME.fullmatch(path.name)
     if identity is None:
@@ -109,6 +113,7 @@ def _finalize_stopped_run(
             "updated_at": stopped_at,
             "stopped_at": stopped_at,
             "mode": request.get("mode", ""),
+            "hitl_mode": request.get("hitl_mode", "full"),
             "provider": request.get("provider", ""),
             "reason": "user_requested",
         }
@@ -128,6 +133,7 @@ def _finalize_stopped_run(
                 "failed_at": failed_at,
                 "updated_at": failed_at,
                 "mode": request.get("mode", ""),
+                "hitl_mode": request.get("hitl_mode", "full"),
                 "provider": request.get("provider", ""),
                 "recovery_required": True,
                 "message": f"Run stopped, but rollback could not finish: {recovery_error}",
@@ -147,6 +153,8 @@ def main() -> int:
     try:
         request = _load_request(claimed)
         work_dir = Path(str(request["work_dir"])).resolve()
+        hitl_mode = normalize_hitl_mode(request.get("hitl_mode")).value
+        request["hitl_mode"] = hitl_mode
         project_root = PROJECT_ROOT.resolve()
         request_id = str(request["request_id"])
         control = HitlRunStopControl(work_dir, request_id)
@@ -168,6 +176,7 @@ def main() -> int:
                 "started_at": started_at,
                 "updated_at": started_at,
                 "mode": request["mode"],
+                "hitl_mode": hitl_mode,
                 "provider": request["provider"],
             },
         )
@@ -190,6 +199,7 @@ def main() -> int:
                         hitl_continue_autoresearch=(
                             str(request["interface"]) if continuation else None
                         ),
+                        hitl_mode=hitl_mode,
                     )
         if control.requested() and not bool(result.get("success", False)):
             return _finalize_stopped_run(
@@ -207,6 +217,7 @@ def main() -> int:
                 "completed_at": finished_at,
                 "updated_at": finished_at,
                 "mode": request["mode"],
+                "hitl_mode": hitl_mode,
                 "provider": request["provider"],
                 "success": bool(result.get("success", False)),
             },
@@ -231,6 +242,7 @@ def main() -> int:
                     "failed_at": failed_at,
                     "updated_at": failed_at,
                     "mode": request.get("mode", ""),
+                    "hitl_mode": request.get("hitl_mode", "full"),
                     "provider": request.get("provider", ""),
                     "message": f"Research could not start: {str(exc).strip() or exc.__class__.__name__}",
                 },

--- a/src/core/hitl.py
+++ b/src/core/hitl.py
@@ -23,6 +23,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional
 
 from core.hitl_lock import exclusive_file_lock
+from core.hitl_mode import HitlMode, normalize_hitl_mode
 from core.hitl_paths import (
     hitl_artifact_contract_path,
     hitl_idea_log_path,
@@ -837,12 +838,14 @@ class HitlRuntime:
         manager: Optional[Any] = None,
         config: Optional[Dict[str, Any]] = None,
         use_hitl_autoresearch_whiteboard: bool = False,
+        hitl_mode: HitlMode | str = HitlMode.FULL,
     ):
         if pipeline_stage not in PIPELINE_STAGES:
             raise ValueError(f"Unsupported HITL pipeline stage: {pipeline_stage}")
         self.work_dir = Path(work_dir)
         self.pipeline_stage = pipeline_stage
         self.use_hitl_autoresearch_whiteboard = use_hitl_autoresearch_whiteboard
+        self.hitl_mode = normalize_hitl_mode(hitl_mode)
         self.paths = HitlPaths(self.work_dir, pipeline_stage)
         self.paths.plan_path.parent.mkdir(parents=True, exist_ok=True)
         self.paths.hitl_dir.mkdir(parents=True, exist_ok=True)
@@ -890,8 +893,12 @@ class HitlRuntime:
         self,
         approved_proposal: str = "",
         *,
-        requires_human_approval: bool = True,
+        requires_human_approval: Optional[bool] = None,
     ) -> str:
+        if requires_human_approval is None:
+            requires_human_approval = self.requires_human_plan_approval
+        elif requires_human_approval and not self.requires_human_plan_approval:
+            requires_human_approval = False
         rel_plan = self.paths.plan_path.relative_to(self.work_dir)
         return _load_hitl_template(
             "worker_plan.txt",
@@ -901,6 +908,8 @@ class HitlRuntime:
             requires_human_approval=requires_human_approval,
             hitl_stage="plan",
             allow_raised_ideas=False,
+            hitl_mode=self.hitl_mode.value,
+            human_resolution_allowed=requires_human_approval,
         )
 
     def execution_prompt_block(self, mode: str = "execute", feedback: str = "") -> str:
@@ -913,6 +922,8 @@ class HitlRuntime:
             hitl_stage="execution",
             allow_raised_ideas=True,
             feedback=feedback,
+            hitl_mode=self.hitl_mode.value,
+            human_resolution_allowed=self.hitl_mode is HitlMode.FULL,
         )
 
     def review_prompt_block(self, feedback: str = "") -> str:
@@ -924,6 +935,8 @@ class HitlRuntime:
             hitl_stage="review",
             allow_raised_ideas=True,
             feedback=feedback,
+            hitl_mode=self.hitl_mode.value,
+            human_resolution_allowed=self.hitl_mode is HitlMode.FULL,
         )
 
     def plan_revision_prompt_block(self, feedback: str) -> str:
@@ -935,6 +948,8 @@ class HitlRuntime:
             hitl_stage="plan",
             allow_raised_ideas=False,
             feedback=feedback,
+            hitl_mode=self.hitl_mode.value,
+            human_resolution_allowed=self.hitl_mode is HitlMode.FULL,
         )
 
     def compose_worker_prompt(self, *, hitl_stage: str, phase_prompt: str) -> str:
@@ -970,6 +985,24 @@ class HitlRuntime:
             pipeline_stage=self.pipeline_stage,
             hitl_stage=hitl_stage,
             allow_raised_ideas=hitl_stage in {"execution", "review"},
+            hitl_mode=self.hitl_mode.value,
+            human_resolution_allowed=self.hitl_mode is HitlMode.FULL,
+        )
+
+    @property
+    def requires_human_plan_approval(self) -> bool:
+        return self.hitl_mode is HitlMode.FULL
+
+    def plan_has_required_approval(self) -> bool:
+        if not self.paths.plan_path.exists():
+            return False
+        from core.hitl_runtime_state import HitlRuntimeState
+
+        levels = ("A",) if self.requires_human_plan_approval else ("A", "B")
+        return HitlRuntimeState(self.work_dir).has_plan_approval(
+            pipeline_stage=self.pipeline_stage,
+            plan_fingerprint=self._current_plan_fingerprint(),
+            approval_levels=levels,
         )
 
     def plan_has_human_approval(self) -> bool:
@@ -1060,6 +1093,7 @@ class HitlRuntime:
             raised_idea=raised_idea,
             plan_text=self._read_optional(self.paths.plan_path),
             on_finalize=persist_resolution,
+            hitl_mode=self.hitl_mode,
         )
         try:
             return finalized["record"]
@@ -1097,6 +1131,12 @@ class HitlRuntime:
                     "HITL worker prompt contexts must define plan, execution, and review; "
                     f"missing: {', '.join(missing_contexts)}."
                 )
+        if requires_human_approval is None:
+            requires_human_approval = (
+                hitl_stage == "plan" and self.requires_human_plan_approval
+            )
+        elif requires_human_approval and not self.requires_human_plan_approval:
+            requires_human_approval = False
         self.stop_idea_tool_server()
         self.paths.hitl_dir.mkdir(parents=True, exist_ok=True)
         self.paths.tool_bin_dir.mkdir(parents=True, exist_ok=True)
@@ -1120,6 +1160,7 @@ class HitlRuntime:
             "level": "C",
             "provenance": provenance or {},
             "requires_human_approval": requires_human_approval,
+            "hitl_mode": self.hitl_mode.value,
             "allow_scoring_approval": allow_scoring_approval,
             "proposal_submission_validator": proposal_submission_validator,
             "proposal_review_path": str(Path(proposal_review_path).resolve())
@@ -1297,6 +1338,7 @@ class HitlRuntime:
                 "hitl_stage": str(self._tool_context.get("hitl_stage", self.current_hitl_stage)),
                 "actor": str(self._tool_context.get("actor", self.pipeline_stage)),
                 "provenance": dict(self._tool_context.get("provenance") or {}),
+                "hitl_mode": self.hitl_mode.value,
                 "prompt_block": prompt,
                 "replacement_count": 0,
                 "status": "running",
@@ -1420,6 +1462,7 @@ class HitlRuntime:
         env["NEURICO_HITL_TOKEN"] = self._tool_token
         env["NEURICO_PROJECT_ROOT"] = str(Path(__file__).resolve().parents[2])
         env["NEURICO_PYTHON"] = sys.executable
+        env["NEURICO_HITL_MODE"] = self.hitl_mode.value
         env["PATH"] = f"{self.paths.tool_bin_dir}{os.pathsep}{env.get('PATH', '')}"
         if self.use_hitl_autoresearch_whiteboard:
             from core.hitl_whiteboard import hitl_whiteboard_env
@@ -1530,6 +1573,12 @@ class HitlRuntime:
                         "proposal_idea_id": proposal_record["idea_id"],
                         "manager_idea_id": manager_record["idea_id"],
                     }
+                elif self.hitl_mode is HitlMode.AUTO:
+                    finalized["result"] = self._finalize_proposal_manager_admission(
+                        proposal_record=proposal_record,
+                        manager_record=manager_record,
+                        review=review,
+                    )
                 else:
                     finalized["result"] = self._finalize_proposal_human_admission(
                         proposal_record=proposal_record,
@@ -1556,6 +1605,7 @@ class HitlRuntime:
                         "proposal": proposal_record["proposal"],
                     },
                 },
+                hitl_mode=self.hitl_mode,
             )
             try:
                 result = finalized["result"]
@@ -1613,9 +1663,14 @@ class HitlRuntime:
             "attempt_id": proposal_record.get("attempt_id", ""),
             "manager_legality_decision_idea_id": manager_record["idea_id"],
             "admission_status": admission.get("status", ""),
-            "human_admission_decision_idea_id": admission.get("human_idea_id", ""),
             "manager_feedback": admission.get("feedback", ""),
         }
+        if admission.get("human_idea_id"):
+            payload["human_admission_decision_idea_id"] = admission["human_idea_id"]
+        if admission.get("manager_admission_idea_id"):
+            payload["manager_admission_decision_idea_id"] = admission[
+                "manager_admission_idea_id"
+            ]
         atomic_write_json(
             path,
             payload,
@@ -1721,7 +1776,32 @@ class HitlRuntime:
                 record.get("level") == "B"
                 and record.get("actor") == "manager"
                 and decision_needed
-                == "Is this AutoResearch proposal legal to show to the human for approval?"
+                == "Should this AutoResearch proposal be admitted to experiment execution?"
+            ):
+                if record.get("decision") == "O1":
+                    return {
+                        "status": "approved",
+                        "instruction": "The proposal is already admitted. Stop proposal generation now.",
+                        "proposal_idea_id": proposal_id,
+                        "proposal": proposal_record.get("proposal", ""),
+                    }
+                return {
+                    "status": "feedback",
+                    "feedback": str(record.get("manager_feedback", "")).strip(),
+                    "instruction": (
+                        "This proposal was already rejected. Create a new proposal using "
+                        "the returned feedback, then submit that new proposal in this same session."
+                    ),
+                    "proposal_idea_id": proposal_id,
+                }
+            if (
+                record.get("level") == "B"
+                and record.get("actor") == "manager"
+                and decision_needed
+                in {
+                    "Is this AutoResearch proposal legal to show to the human for approval?",
+                    "Is this AutoResearch proposal legal for admission review?",
+                }
                 and record.get("decision") == "O2"
             ):
                 return {
@@ -2903,6 +2983,7 @@ class HitlRuntime:
                 scoring_handoff_context=dict(self._tool_context.get("provenance") or {}),
                 on_finalize=persist_phase_review,
                 on_scoring_approval=persist_scoring_approval,
+                hitl_mode=self.hitl_mode,
             )
             if (
                 self._phase_finish_request_key == request_key
@@ -2944,13 +3025,17 @@ class HitlRuntime:
             instruction = "Reviewer approved this stage. Stop this worker session now."
             prompt_block = ""
             if hitl_stage == "plan":
-                if bool(self._tool_context.get("requires_human_approval")):
-                    from core.hitl_runtime_state import HitlRuntimeState
+                from core.hitl_runtime_state import HitlRuntimeState
 
-                    HitlRuntimeState(self.work_dir).mark_plan_approved(
-                        pipeline_stage=self.pipeline_stage,
-                        plan_fingerprint=plan_fingerprint,
-                    )
+                HitlRuntimeState(self.work_dir).mark_plan_approved(
+                    pipeline_stage=self.pipeline_stage,
+                    plan_fingerprint=plan_fingerprint,
+                    approval_level=(
+                        "A"
+                        if bool(self._tool_context.get("requires_human_approval"))
+                        else "B"
+                    ),
+                )
                 next_phase = "execution"
                 final = False
                 instruction = (
@@ -3345,7 +3430,11 @@ class HitlRuntime:
                 review.get("context", "Manager reviewed AutoResearch proposal legality.")
             ).strip(),
             "related_artifacts": [],
-            "decision_needed": "Is this AutoResearch proposal legal to show to the human for approval?",
+            "decision_needed": (
+                "Is this AutoResearch proposal legal for admission review?"
+                if self.hitl_mode is HitlMode.AUTO
+                else "Is this AutoResearch proposal legal to show to the human for approval?"
+            ),
             "options": options,
             "decision": "O1" if legal else "O2",
             "manager_feedback": "" if legal else str(review["manager_feedback"]).strip(),
@@ -3353,6 +3442,73 @@ class HitlRuntime:
         }
         _apply_runtime_provenance(record, self._tool_context.get("provenance"))
         return self.log.append(record, idempotent=True)
+
+    def _finalize_proposal_manager_admission(
+        self,
+        *,
+        proposal_record: Dict[str, Any],
+        manager_record: Dict[str, Any],
+        review: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Record Auto HITL's manager-owned scientific admission decision."""
+
+        status = str(review.get("status", "")).strip()
+        if status not in {"approved", "feedback"}:
+            raise HitlValidationError("Auto HITL proposal admission must approve or give feedback.")
+        approved = status == "approved"
+        manager_feedback = ""
+        if not approved:
+            manager_feedback = _require_text(
+                review.get("manager_feedback"),
+                "manager_feedback",
+                "Auto HITL proposal admission",
+            )
+            if _is_feedback_placeholder(manager_feedback):
+                raise HitlValidationError(
+                    "Auto HITL proposal feedback must contain concrete next-proposal instructions."
+                )
+        record = {
+            "pipeline_stage": self.pipeline_stage,
+            "hitl_stage": "proposal",
+            "idea_type": "decision",
+            "idea_category": "method_choice",
+            "level": "B",
+            "actor": "manager",
+            "premises": [proposal_record["idea_id"], manager_record["idea_id"]],
+            "context": str(
+                review.get("context", "Manager reviewed AutoResearch proposal admission.")
+            ).strip(),
+            "related_artifacts": [],
+            "decision_needed": (
+                "Should this AutoResearch proposal be admitted to experiment execution?"
+            ),
+            "options": _normalize_options(["Approve proposal.", "Request a new proposal."]),
+            "decision": "O1" if approved else "O2",
+            "manager_feedback": manager_feedback,
+            "raised": False,
+        }
+        _apply_runtime_provenance(record, self._tool_context.get("provenance"))
+        admission_record = self.log.append(record, idempotent=True)
+        if approved:
+            return {
+                "status": "approved",
+                "instruction": "The proposal is admitted. Stop proposal generation now.",
+                "proposal_idea_id": proposal_record["idea_id"],
+                "manager_idea_id": manager_record["idea_id"],
+                "manager_admission_idea_id": admission_record["idea_id"],
+                "proposal": proposal_record["proposal"],
+            }
+        return {
+            "status": "feedback",
+            "feedback": manager_feedback,
+            "instruction": (
+                "This proposal is rejected. Create a new proposal using this feedback, "
+                "then submit the new proposal with `hitl-submit-proposal` in this same session."
+            ),
+            "proposal_idea_id": proposal_record["idea_id"],
+            "manager_idea_id": manager_record["idea_id"],
+            "manager_admission_idea_id": admission_record["idea_id"],
+        }
 
     def _finalize_proposal_human_admission(
         self,

--- a/src/core/hitl.py
+++ b/src/core/hitl.py
@@ -909,7 +909,6 @@ class HitlRuntime:
             hitl_stage="plan",
             allow_raised_ideas=False,
             hitl_mode=self.hitl_mode.value,
-            human_resolution_allowed=requires_human_approval,
         )
 
     def execution_prompt_block(self, mode: str = "execute", feedback: str = "") -> str:
@@ -923,7 +922,6 @@ class HitlRuntime:
             allow_raised_ideas=True,
             feedback=feedback,
             hitl_mode=self.hitl_mode.value,
-            human_resolution_allowed=self.hitl_mode is HitlMode.FULL,
         )
 
     def review_prompt_block(self, feedback: str = "") -> str:
@@ -936,7 +934,6 @@ class HitlRuntime:
             allow_raised_ideas=True,
             feedback=feedback,
             hitl_mode=self.hitl_mode.value,
-            human_resolution_allowed=self.hitl_mode is HitlMode.FULL,
         )
 
     def plan_revision_prompt_block(self, feedback: str) -> str:
@@ -949,7 +946,6 @@ class HitlRuntime:
             allow_raised_ideas=False,
             feedback=feedback,
             hitl_mode=self.hitl_mode.value,
-            human_resolution_allowed=self.hitl_mode is HitlMode.FULL,
         )
 
     def compose_worker_prompt(self, *, hitl_stage: str, phase_prompt: str) -> str:
@@ -986,7 +982,6 @@ class HitlRuntime:
             hitl_stage=hitl_stage,
             allow_raised_ideas=hitl_stage in {"execution", "review"},
             hitl_mode=self.hitl_mode.value,
-            human_resolution_allowed=self.hitl_mode is HitlMode.FULL,
         )
 
     @property
@@ -3453,20 +3448,17 @@ class HitlRuntime:
         """Record Auto HITL's manager-owned scientific admission decision."""
 
         status = str(review.get("status", "")).strip()
-        if status not in {"approved", "feedback"}:
-            raise HitlValidationError("Auto HITL proposal admission must approve or give feedback.")
-        approved = status == "approved"
-        manager_feedback = ""
-        if not approved:
-            manager_feedback = _require_text(
-                review.get("manager_feedback"),
-                "manager_feedback",
-                "Auto HITL proposal admission",
+        if status == "approved":
+            approved = True
+            manager_feedback = ""
+        elif status == "feedback":
+            approved = False
+            manager_feedback = str(review["manager_feedback"]).strip()
+        else:
+            raise RuntimeError(
+                "Validated Auto HITL proposal admission reached finalization with an "
+                f"unexpected status: {status or '<empty>'}."
             )
-            if _is_feedback_placeholder(manager_feedback):
-                raise HitlValidationError(
-                    "Auto HITL proposal feedback must contain concrete next-proposal instructions."
-                )
         record = {
             "pipeline_stage": self.pipeline_stage,
             "hitl_stage": "proposal",

--- a/src/core/hitl_autoresearch.py
+++ b/src/core/hitl_autoresearch.py
@@ -49,6 +49,8 @@ from core.hitl_frontier import (
 )
 from core.hitl_git import delete_git_ref
 from core.hitl_git_state import HitlGitStateStore
+from core.hitl_manager_inbox import HitlManagerInbox
+from core.hitl_mode import HitlMode, normalize_hitl_mode
 from core.hitl_run_control import HitlRunStopRequested
 from core.hitl_runtime_state import HitlRuntimeState, worker_command_requires_resume
 from core.hitl_scoring_workspace import (
@@ -71,6 +73,17 @@ from core.scoring_seal import (
 
 HitlCommentModeHook = Callable[..., Dict[str, Any]]
 MAX_ACTIVE_HITL_FRONTIER_NODES = 10
+
+
+def _adopt_run_hitl_mode(work_dir: Path, hitl_mode: HitlMode | str) -> HitlMode:
+    """Adopt a run policy without rewriting completed decisions."""
+
+    selected = normalize_hitl_mode(hitl_mode)
+    adoption = HitlRuntimeState(work_dir).adopt_hitl_mode(selected.value)
+    request_key = str(adoption.get("discard_resolution_reply_for", "")).strip()
+    if request_key:
+        HitlManagerInbox(work_dir).discard_resolution_reply(request_key)
+    return selected
 
 
 class HitlFrontierPublicationPendingError(RuntimeError):
@@ -251,11 +264,13 @@ def run_fresh_hitl_autoresearch_initial_node(
     manager: Optional[Any] = None,
     channel: Optional[Any] = None,
     manager_config: Optional[Dict[str, Any]] = None,
+    hitl_mode: HitlMode | str = HitlMode.FULL,
 ) -> InitialAutoResearchNodeResult:
     """Run the initial scored experiment through the HITL pipeline."""
     from core.pipeline_orchestrator import ResearchPipelineOrchestrator
 
     work_dir = Path(work_dir)
+    selected_hitl_mode = _adopt_run_hitl_mode(work_dir, hitl_mode)
     existing_publication = (
         HitlRuntimeState(work_dir).initial_root_publication_transition()
     )
@@ -281,6 +296,7 @@ def run_fresh_hitl_autoresearch_initial_node(
         hitl_channel=channel,
         hitl_manager_config=manager_config,
         hitl_autoresearch=True,
+        hitl_mode=selected_hitl_mode,
     ).run_pipeline(
         idea=idea,
         provider=provider,
@@ -714,6 +730,7 @@ def continue_hitl_autoresearch(
     channel: Optional[Any] = None,
     manager_config: Optional[Dict[str, Any]] = None,
     recovered_attempt: Optional[HitlRecoveryResult] = None,
+    hitl_mode: HitlMode | str = HitlMode.FULL,
 ) -> Dict[str, Any]:
     """Continue only from the runtime-selected HITL frontier node."""
     print()
@@ -727,6 +744,7 @@ def continue_hitl_autoresearch(
 
     runtime_state = HitlRuntimeState(work_dir)
     recovery = recovered_attempt or recover_interrupted_hitl_attempt_if_needed(work_dir)
+    selected_hitl_mode = _adopt_run_hitl_mode(work_dir, hitl_mode)
     pending_worker_request = bool(
         recovery and recovery.recovery_classification == "pending_worker_request"
     )
@@ -809,6 +827,7 @@ def continue_hitl_autoresearch(
         pending_hitl_recovery=recovery
         if pending_worker_request or pending_frontier_transition
         else None,
+        hitl_mode=selected_hitl_mode,
     )
     payload = autoresearch_result_payload(result)
     payload["initial_sha"] = lineage_source_sha
@@ -847,6 +866,7 @@ class HitlAutoResearchController:
         hitl_runtime: Optional[HitlRuntime] = None,
         hitl_comment_mode: Optional[HitlCommentModeHook] = None,
         pending_hitl_recovery: Optional[HitlRecoveryResult] = None,
+        hitl_mode: HitlMode | str = HitlMode.FULL,
     ):
         self.idea = idea
         self.idea_id = idea_id
@@ -859,6 +879,7 @@ class HitlAutoResearchController:
         self.hitl_comment_mode = hitl_comment_mode
         self.hitl_frontier = HitlFrontierStore(self.work_dir)
         self.pending_hitl_recovery = pending_hitl_recovery
+        self.hitl_mode = normalize_hitl_mode(hitl_mode)
 
     def run(self, iterations: int) -> AutoResearchRunResult:
         """
@@ -2205,6 +2226,7 @@ class HitlAutoResearchController:
                 self.work_dir,
                 "experiment_runner",
                 use_hitl_autoresearch_whiteboard=True,
+                hitl_mode=self.hitl_mode,
             )
         return self.hitl_runtime
 
@@ -2360,6 +2382,7 @@ def run_hitl_autoresearch_loop(
     hitl_channel: Optional[Any] = None,
     hitl_manager_config: Optional[Dict[str, Any]] = None,
     pending_hitl_recovery: Optional[HitlRecoveryResult] = None,
+    hitl_mode: HitlMode | str = HitlMode.FULL,
 ) -> AutoResearchRunResult:
     """
     Run AutoResearch with NeuriCo's real proposer, comment handler, and scorer.
@@ -2460,9 +2483,11 @@ def run_hitl_autoresearch_loop(
                 channel=hitl_channel,
                 config=hitl_manager_config,
                 use_hitl_autoresearch_whiteboard=True,
+                hitl_mode=hitl_mode,
             )
         ),
         hitl_comment_mode=hitl_comment_mode,
         pending_hitl_recovery=pending_hitl_recovery,
+        hitl_mode=hitl_mode,
     )
     return controller.run(iterations=iterations)

--- a/src/core/hitl_manager_host.py
+++ b/src/core/hitl_manager_host.py
@@ -946,9 +946,8 @@ class HitlTerminalChannel(UserChannel):
             provider = self._read_setting(
                 "Model [claude] (claude/codex/gemini): ", "claude"
             ).lower()
-            hitl_mode = self._read_setting(
-                "HITL mode [full] (full/auto): ", "full"
-            ).lower()
+            auto = self._read_yes_no("Auto [Y] (Y/n): ", default=True)
+            hitl_mode = "auto" if auto else "full"
             iterations = self._read_setting("Iterations [2] (1-100): ", "2")
             write_paper = self._read_yes_no("Write paper? [Y/n]: ", default=True)
             paper_style = "auto"
@@ -970,9 +969,10 @@ class HitlTerminalChannel(UserChannel):
         except (ValueError, RuntimeError) as exc:
             self._write_block(self._ui.system(str(exc), tone="error"), blank_before=True)
             return {"status": "invalid"}
+        mode_label = "Auto" if hitl_mode == "auto" else "HITL"
         self._write_block(
             self._ui.system(
-                f"Started {result['mode']} research in {hitl_mode} HITL mode.",
+                f"Started {result['mode']} research in {mode_label} mode.",
                 tone="success",
             ),
         )

--- a/src/core/hitl_manager_host.py
+++ b/src/core/hitl_manager_host.py
@@ -946,6 +946,9 @@ class HitlTerminalChannel(UserChannel):
             provider = self._read_setting(
                 "Model [claude] (claude/codex/gemini): ", "claude"
             ).lower()
+            hitl_mode = self._read_setting(
+                "HITL mode [full] (full/auto): ", "full"
+            ).lower()
             iterations = self._read_setting("Iterations [2] (1-100): ", "2")
             write_paper = self._read_yes_no("Write paper? [Y/n]: ", default=True)
             paper_style = "auto"
@@ -957,6 +960,7 @@ class HitlTerminalChannel(UserChannel):
             result = self._run_launcher(
                 {
                     "provider": provider,
+                    "hitl_mode": hitl_mode,
                     "iterations": iterations,
                     "write_paper": write_paper,
                     "paper_style": paper_style,
@@ -967,7 +971,10 @@ class HitlTerminalChannel(UserChannel):
             self._write_block(self._ui.system(str(exc), tone="error"), blank_before=True)
             return {"status": "invalid"}
         self._write_block(
-            self._ui.system(f"Started {result['mode']} research.", tone="success"),
+            self._ui.system(
+                f"Started {result['mode']} research in {hitl_mode} HITL mode.",
+                tone="success",
+            ),
         )
         return dict(result)
 

--- a/src/core/hitl_manager_host.py
+++ b/src/core/hitl_manager_host.py
@@ -40,6 +40,7 @@ from core.hitl_runtime_state import HitlResolutionReplyStaleError
 _RESOLUTION_REPLY = "resolution_reply"
 _CONVERSATION = "conversation"
 _RUN_CONSUMER_HANDOFF_TIMEOUT_SECONDS = 5.0
+_MANAGER_CONSUMER_SHUTDOWN_TIMEOUT_SECONDS = 2.0
 
 
 class _HitlPromptCancelled(Exception):
@@ -300,16 +301,17 @@ class HitlWebChannel(WebChannel):
         """Mark the claimed conversation turn complete for future submissions."""
         with self._dispatch_lock:
             item_id = self._claimed_active_id
-            if self._inbox is not None and item_id:
-                if success:
-                    self._inbox.complete(item_id)
-                    self._claimed_active_id = ""
-                    self._turn_active = False
-                else:
-                    self._inbox.fail(item_id, error)
-                    self._claimed_active_id = ""
-                    self._turn_active = False
-            else:
+            try:
+                if self._inbox is not None and item_id:
+                    if success:
+                        self._inbox.complete(item_id)
+                    else:
+                        self._inbox.fail(item_id, error)
+            finally:
+                # The claim belongs to this consumer session, not to the
+                # renderer. Never let a failed durable settlement wedge a
+                # channel that a later manager consumer will reuse.
+                self._claimed_active_id = ""
                 self._turn_active = False
         self._emit({"event": "workspace_changed", "section": "inbox"})
 
@@ -1379,14 +1381,15 @@ class HitlTerminalChannel(UserChannel):
 
     def finish_active_turn(self, *, success: bool = True, error: str = "") -> None:
         item_id = self._claimed_active_id
-        if self._inbox is not None and item_id:
-            if success:
-                self._inbox.complete(item_id)
-                self._claimed_active_id = ""
-            else:
-                self._inbox.fail(item_id, error)
-                self._claimed_active_id = ""
-        self._input_ready.set()
+        try:
+            if self._inbox is not None and item_id:
+                if success:
+                    self._inbox.complete(item_id)
+                else:
+                    self._inbox.fail(item_id, error)
+        finally:
+            self._claimed_active_id = ""
+            self._input_ready.set()
 
     def consume_resolution_reply(self) -> bool:
         if self._inbox is None or self._resolution_reply_handler is None:
@@ -1602,7 +1605,9 @@ class HitlManagerHost:
 
     def stop(self) -> None:
         self._stop.set()
-        self._stop_manager_consumer()
+        # Process shutdown must not release manager ownership while its
+        # conversation thread can still mutate the workspace.
+        self._stop_manager_consumer(timeout_seconds=None)
         self.channel.close()
         if self.web_server is not None:
             self.web_server.stop()
@@ -1625,7 +1630,14 @@ class HitlManagerHost:
             self._handoff_pending = True
             self._handoff_started_at = time.monotonic()
             self._saw_handoff_run = False
-        self._stop_manager_consumer()
+        if not self._stop_manager_consumer():
+            with self._consumer_lock:
+                self._handoff_pending = False
+                self._saw_handoff_run = False
+            raise RuntimeError(
+                "NeuriCo is still finishing the active manager turn. "
+                "Wait for it to finish before starting research."
+            )
 
     def cancel_run_handoff(self) -> None:
         with self._consumer_lock:
@@ -1660,33 +1672,63 @@ class HitlManagerHost:
             if self.manager is None or self._manager_stopped:
                 self.manager = self._new_manager()
             HitlManagerInbox(self.work_dir).retry_failed()
-            self._consumer_stop = threading.Event()
+            consumer_stop = threading.Event()
+            self._consumer_stop = consumer_stop
             self._manager_consumer_lease = lease
             self._conversation_thread = threading.Thread(
                 target=self._run_conversation_loop,
+                args=(self.manager, consumer_stop),
                 daemon=True,
                 name="neurico-hitl-manager-conversation",
             )
             self._conversation_thread.start()
             return True
 
-    def _stop_manager_consumer(self) -> None:
+    def _stop_manager_consumer(
+        self,
+        *,
+        timeout_seconds: Optional[float] = _MANAGER_CONSUMER_SHUTDOWN_TIMEOUT_SECONDS,
+    ) -> bool:
+        """Stop one consumer and release its lease only after its thread exits."""
         with self._consumer_lock:
             lease = self._manager_consumer_lease
             thread = self._conversation_thread
             if lease is None:
-                return
-            self._consumer_stop.set()
+                return True
+            consumer_stop = self._consumer_stop
+            first_stop_request = not consumer_stop.is_set()
+            consumer_stop.set()
             manager = self.manager
-            if manager is not None:
+            if manager is not None and first_stop_request:
                 manager.stop()
-            self._manager_stopped = True
             if (
                 thread is not None
                 and thread.is_alive()
                 and thread is not threading.current_thread()
             ):
-                thread.join(timeout=2)
+                thread.join(timeout=timeout_seconds)
+            if thread is not None and thread.is_alive():
+                # Keep every session field and the file lease intact. A later
+                # monitor pass (or process shutdown) can finish the same
+                # teardown after the blocked backend call returns.
+                return False
+
+            # A normal conversation-loop exit settles this in its finally
+            # block. This defensive call also recovers a claim if the loop
+            # terminated before reaching that block.
+            finish_active_turn = getattr(self.channel, "finish_active_turn", None)
+            if callable(finish_active_turn):
+                try:
+                    finish_active_turn(
+                        success=False,
+                        error="Manager consumer stopped before completing the message.",
+                    )
+                except Exception:
+                    # The thread is gone and the local claim was cleared in
+                    # finish_active_turn(). A later consumer can retry the
+                    # still-durable record instead of losing ownership here.
+                    pass
+            self._manager_stopped = True
             lease.__exit__(None, None, None)
             self._manager_consumer_lease = None
             self._conversation_thread = None
@@ -1695,9 +1737,26 @@ class HitlManagerHost:
             if callable(set_resolution_handler):
                 set_resolution_handler(None)
             self._bind_passive_conversation()
+            return True
 
     def _monitor_manager_consumer(self) -> None:
         while not self._stop.wait(0.25):
+            with self._consumer_lock:
+                consumer_thread_dead = bool(
+                    self._manager_consumer_lease is not None
+                    and (
+                        self._conversation_thread is None
+                        or not self._conversation_thread.is_alive()
+                    )
+                )
+                consumer_stopping = (
+                    self._manager_consumer_lease is not None
+                    and self._consumer_stop.is_set()
+                )
+            if consumer_thread_dead or consumer_stopping:
+                self._stop_manager_consumer(timeout_seconds=0.0)
+                if self.consumes_manager_input:
+                    continue
             owner = active_hitl_workspace_run(self.work_dir)
             with self._consumer_lock:
                 if self._handoff_pending:
@@ -1714,8 +1773,11 @@ class HitlManagerHost:
             if not handoff_pending and not self.consumes_manager_input:
                 self._start_manager_consumer(strict=False)
 
-    def _run_conversation_loop(self) -> None:
-        manager = self.manager
+    def _run_conversation_loop(
+        self,
+        manager: Optional[HitlManager],
+        consumer_stop: threading.Event,
+    ) -> None:
         if manager is None:
             raise RuntimeError("The HITL manager consumer started without a manager.")
         active_poll_error: Optional[tuple[str, str]] = None
@@ -1741,7 +1803,7 @@ class HitlManagerHost:
             except Exception:
                 pass
 
-        while not self._stop.is_set() and not self._consumer_stop.is_set():
+        while not self._stop.is_set() and not consumer_stop.is_set():
             try:
                 consume_resolution = getattr(self.channel, "consume_resolution_reply", None)
                 if callable(consume_resolution) and consume_resolution():
@@ -1756,7 +1818,7 @@ class HitlManagerHost:
                         "for inspection. Conversation processing will continue.",
                     )
                     active_poll_error = signature
-                self._consumer_stop.wait(0.5)
+                consumer_stop.wait(0.5)
                 continue
             except Exception as exc:
                 signature = (type(exc).__name__, str(exc))
@@ -1766,10 +1828,18 @@ class HitlManagerHost:
                         "The message remains queued and NeuriCo will retry.",
                     )
                     active_poll_error = signature
-                self._consumer_stop.wait(0.5)
+                consumer_stop.wait(0.5)
                 continue
             if not message:
                 continue
+            if consumer_stop.is_set():
+                finish_active_turn = getattr(self.channel, "finish_active_turn", None)
+                if callable(finish_active_turn):
+                    finish_active_turn(
+                        success=False,
+                        error="Manager ownership changed before the message was processed.",
+                    )
+                break
             succeeded = False
             failure = ""
             try:
@@ -1800,5 +1870,14 @@ class HitlManagerHost:
             finally:
                 finish_active_turn = getattr(self.channel, "finish_active_turn", None)
                 if callable(finish_active_turn):
-                    finish_active_turn(success=succeeded, error=failure)
-                self.channel.status("Manager idle", thinking=False)
+                    try:
+                        finish_active_turn(success=succeeded, error=failure)
+                    except Exception:
+                        # Local claim cleanup has already happened. End this
+                        # consumer session so the monitor can create a clean
+                        # manager around the still-durable input.
+                        consumer_stop.set()
+                try:
+                    self.channel.status("Manager idle", thinking=False)
+                except Exception:
+                    consumer_stop.set()

--- a/src/core/hitl_manager_host.py
+++ b/src/core/hitl_manager_host.py
@@ -42,6 +42,10 @@ _CONVERSATION = "conversation"
 _RUN_CONSUMER_HANDOFF_TIMEOUT_SECONDS = 5.0
 
 
+class _HitlPromptCancelled(Exception):
+    """The user cancelled an in-progress terminal prompt sequence."""
+
+
 def _elapsed_phase_time(started_at: Any) -> str:
     text = str(started_at or "").strip()
     if not text:
@@ -943,19 +947,42 @@ class HitlTerminalChannel(UserChannel):
                 self._ui.section("Start research"),
                 blank_before=True,
             )
-            provider = self._read_setting(
-                "Model [claude] (claude/codex/gemini): ", "claude"
-            ).lower()
-            auto = self._read_yes_no("Auto [Y] (Y/n): ", default=True)
+            self._write_block(
+                self._ui.system("Type /cancel at any prompt to cancel setup.")
+            )
+            provider = self._read_choice(
+                "Model [claude] (claude/codex): ",
+                "claude",
+                {"claude", "codex"},
+                "Choose claude or codex.",
+                cancellable=True,
+            )
+            auto = self._read_yes_no(
+                "Auto [Y] (Y/n): ", default=True, cancellable=True
+            )
             hitl_mode = "auto" if auto else "full"
-            iterations = self._read_setting("Iterations [2] (1-100): ", "2")
-            write_paper = self._read_yes_no("Write paper? [Y/n]: ", default=True)
+            iterations = self._read_integer(
+                "Iterations [2] (1-100): ",
+                2,
+                minimum=1,
+                maximum=100,
+                cancellable=True,
+            )
+            write_paper = self._read_yes_no(
+                "Write paper? [Y/n]: ", default=True, cancellable=True
+            )
             paper_style = "auto"
             if write_paper:
-                paper_style = self._read_setting(
-                    "Paper style [auto] (auto/neurips/icml/acl): ", "auto"
-                ).lower()
-            github = self._read_yes_no("Publish to GitHub? [y/N]: ", default=False)
+                paper_style = self._read_choice(
+                    "Paper style [auto] (auto/neurips/icml/acl): ",
+                    "auto",
+                    {"auto", "neurips", "icml", "acl"},
+                    "Choose auto, neurips, icml, or acl.",
+                    cancellable=True,
+                )
+            github = self._read_yes_no(
+                "Publish to GitHub? [y/N]: ", default=False, cancellable=True
+            )
             result = self._run_launcher(
                 {
                     "provider": provider,
@@ -966,6 +993,11 @@ class HitlTerminalChannel(UserChannel):
                     "github": github,
                 }
             )
+        except _HitlPromptCancelled:
+            self._write_block(
+                self._ui.system("Research setup cancelled."), blank_before=True
+            )
+            return {"status": "cancelled"}
         except (ValueError, RuntimeError) as exc:
             self._write_block(self._ui.system(str(exc), tone="error"), blank_before=True)
             return {"status": "invalid"}
@@ -978,26 +1010,93 @@ class HitlTerminalChannel(UserChannel):
         )
         return dict(result)
 
-    def _read_setting(self, label: str, default: str) -> str:
+    def _read_setting(
+        self,
+        label: str,
+        default: str,
+        *,
+        cancellable: bool = False,
+    ) -> str:
         if self._terminal_composer is not None:
             try:
                 value = self._terminal_composer.readline(label)
             except EOFError as exc:
                 raise RuntimeError("Terminal input closed before the prompt was answered.") from exc
             except KeyboardInterrupt as exc:
+                if cancellable:
+                    raise _HitlPromptCancelled from exc
                 raise RuntimeError("Input was cancelled.") from exc
-            return value.strip() or default
-        self._write(label, end="")
-        value = sys.stdin.readline()
-        if value == "":
-            raise RuntimeError("Terminal input closed before the prompt was answered.")
-        return value.strip() or default
+        else:
+            self._write(label, end="")
+            value = sys.stdin.readline()
+            if value == "":
+                raise RuntimeError("Terminal input closed before the prompt was answered.")
+        value = value.strip()
+        if cancellable and value.lower() == "/cancel":
+            raise _HitlPromptCancelled
+        return value or default
 
-    def _read_yes_no(self, label: str, *, default: bool) -> bool:
-        value = self._read_setting(label, "y" if default else "n").lower()
-        if value not in {"y", "yes", "n", "no"}:
-            raise ValueError("Answer yes or no.")
-        return value in {"y", "yes"}
+    def _read_choice(
+        self,
+        label: str,
+        default: str,
+        choices: set[str],
+        error: str,
+        *,
+        cancellable: bool = False,
+    ) -> str:
+        while True:
+            value = self._read_setting(
+                label, default, cancellable=cancellable
+            ).lower()
+            if value in choices:
+                return value
+            self._write_block(self._ui.system(error, tone="error"))
+
+    def _read_integer(
+        self,
+        label: str,
+        default: int,
+        *,
+        minimum: int,
+        maximum: int,
+        cancellable: bool = False,
+    ) -> int:
+        while True:
+            value = self._read_setting(
+                label, str(default), cancellable=cancellable
+            )
+            try:
+                parsed = int(value)
+            except ValueError:
+                parsed = minimum - 1
+            if minimum <= parsed <= maximum:
+                return parsed
+            self._write_block(
+                self._ui.system(
+                    f"Enter a whole number from {minimum} to {maximum}.",
+                    tone="error",
+                )
+            )
+
+    def _read_yes_no(
+        self,
+        label: str,
+        *,
+        default: bool,
+        cancellable: bool = False,
+    ) -> bool:
+        while True:
+            value = self._read_setting(
+                label,
+                "y" if default else "n",
+                cancellable=cancellable,
+            ).lower()
+            if value in {"y", "yes", "n", "no"}:
+                return value in {"y", "yes"}
+            self._write_block(
+                self._ui.system("Answer Y or N.", tone="error")
+            )
 
     def present_run_status(self, status: Dict[str, Any]) -> None:
         self._cache_live_status(status)

--- a/src/core/hitl_manager_react.py
+++ b/src/core/hitl_manager_react.py
@@ -1059,7 +1059,6 @@ class HitlManager:
             plan_text=plan_text,
             raised_idea_json=json.dumps(raised_idea, indent=2, ensure_ascii=False),
             hitl_mode=selected_mode.value,
-            human_resolution_allowed=selected_mode is HitlMode.FULL,
         )
         return self.request_worker_resolution(
             command={
@@ -1174,7 +1173,6 @@ class HitlManager:
             allow_scoring_approval=allow_scoring_approval,
             is_rule_maker=(pipeline_stage == "rule_maker"),
             hitl_mode=selected_mode.value,
-            human_resolution_allowed=requires_human_approval,
         )
         return self.request_worker_resolution(
             command={
@@ -1217,11 +1215,27 @@ class HitlManager:
                     "Proposal review status must be approved, feedback, or rejected_illegal."
                 )
             self._require_text(data.get("context"), "context", "Proposal admission")
+            violations = data.get("violations", [])
+            if not isinstance(violations, list):
+                raise ValueError("violations must be an array.")
+            concrete_violations = [
+                str(violation).strip() for violation in violations if str(violation).strip()
+            ]
             if status == "rejected_illegal":
-                self._require_text(
+                if not concrete_violations:
+                    raise ValueError(
+                        "An illegal proposal review requires at least one concrete violation."
+                    )
+                feedback = self._require_text(
                     data.get("manager_feedback"), "manager_feedback", "Illegal proposal review"
                 )
+                if _is_feedback_placeholder(feedback):
+                    raise ValueError("Illegal proposal feedback must be concrete.")
+                data["violations"] = concrete_violations
             elif selected_mode is HitlMode.AUTO:
+                if concrete_violations:
+                    raise ValueError("A legal Auto HITL proposal review cannot include violations.")
+                data["violations"] = []
                 if human_inputs:
                     raise ValueError("Auto HITL proposal admission cannot call ask_human.")
                 data.pop("human_feedback", None)
@@ -1233,8 +1247,11 @@ class HitlManager:
                     if _is_feedback_placeholder(feedback):
                         raise ValueError("Auto HITL proposal feedback must be concrete.")
                 else:
-                    data["manager_feedback"] = str(data.get("manager_feedback", ""))
+                    data["manager_feedback"] = ""
             else:
+                if concrete_violations:
+                    raise ValueError("A legal HITL proposal review cannot include violations.")
+                data["violations"] = []
                 feedback = self._require_text(
                     data.get("human_feedback"), "human_feedback", "Proposal admission"
                 )
@@ -1261,8 +1278,6 @@ class HitlManager:
                     self._require_text(
                         data.get("manager_feedback"), "manager_feedback", "Proposal feedback"
                     )
-            if not isinstance(data.get("violations", []), list):
-                raise ValueError("violations must be an array.")
             return data
 
         request = {
@@ -1275,7 +1290,6 @@ class HitlManager:
             pipeline_stage=pipeline_stage,
             proposal_text=proposal_text,
             hitl_mode=selected_mode.value,
-            human_resolution_allowed=selected_mode is HitlMode.FULL,
         )
         return self.request_worker_resolution(
             command={

--- a/src/core/hitl_manager_react.py
+++ b/src/core/hitl_manager_react.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from core.hitl_manager_inbox import HitlManagerInbox
+from core.hitl_lock import active_hitl_workspace_run
+from core.hitl_mode import HitlMode, human_resolution_allowed, normalize_hitl_mode
 from core.hitl_paths import hitl_manager_dir
 from core.hitl_runtime_state import (
     MANAGER_REVIEW_FINALIZERS,
@@ -394,6 +396,23 @@ class HitlManager:
         }
     )
 
+    def _current_hitl_mode(self) -> HitlMode:
+        pending = self.runtime_state.pending_worker_command()
+        if isinstance(pending, dict) and str(pending.get("hitl_mode", "")).strip():
+            return normalize_hitl_mode(pending["hitl_mode"])
+        owner = active_hitl_workspace_run(self.work_dir)
+        if isinstance(owner, dict) and str(owner.get("hitl_mode", "")).strip():
+            return normalize_hitl_mode(owner["hitl_mode"])
+        return HitlMode.FULL
+
+    @staticmethod
+    def _human_resolution_allowed_for(pending: Dict[str, Any]) -> bool:
+        return human_resolution_allowed(
+            pending.get("hitl_mode"),
+            command_kind=str(pending.get("kind", "")),
+            requires_human_approval=bool(pending.get("requires_human_approval")),
+        )
+
     def _available_tool_names(self) -> set[str]:
         """Return the runtime-authorized tool surface for the next ReAct turn.
 
@@ -425,7 +444,8 @@ class HitlManager:
             names.add(manager_finalizer)
             return names
 
-        names.add("ask_human")
+        if self._human_resolution_allowed_for(pending):
+            names.add("ask_human")
         names.add("finalize_worker_request")
         request_key = str(pending.get("request_key", "")).strip()
         with self._resolution_lock:
@@ -514,11 +534,16 @@ class HitlManager:
             )
         completion_name = self._runtime_completion_tool_name(tools)
         if completion_name:
+            human_instruction = (
+                " Continue reviewing or consult the human as permitted, then call "
+                if any(str(tool.get("name", "")) == "ask_human" for tool in tools)
+                else " Continue reviewing, then call "
+            )
             return (
                 native_retry
-                + "The worker request remains unresolved. Continue reviewing or consult "
-                "the human as permitted, then call "
-                f"`{completion_name}`. Direct assistant text cannot complete it."
+                + "The worker request remains unresolved."
+                + human_instruction
+                + f"`{completion_name}`. Direct assistant text cannot complete it."
             )
         return (
             native_retry + "The worker request remains unresolved. Follow the exact "
@@ -704,9 +729,14 @@ class HitlManager:
                     f"Error: {tool_name} is unavailable for the current worker request. "
                     f"{scoring_handoff}"
                 )
+            human_hint = (
+                ", or ask_human if human intent is required"
+                if self._human_resolution_allowed_for(pending)
+                else ""
+            )
             return (
                 f"Error: {tool_name} is unavailable for the current worker request. "
-                "Use finalize_worker_request, or ask_human if human intent is required."
+                f"Use finalize_worker_request{human_hint}."
             )
         return (
             f"Error: {tool_name} is unavailable because runtime has not opened that action. "
@@ -967,16 +997,20 @@ class HitlManager:
         raised_idea: Dict[str, Any],
         plan_text: str,
         on_finalize: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
+        hitl_mode: HitlMode | str = HitlMode.FULL,
     ) -> Dict[str, Any]:
-        from core.hitl import _load_hitl_template, _validate_substantive_options
+        from core.hitl import _load_hitl_template, _normalize_options, _validate_substantive_options
 
         human_inputs: List[Dict[str, Any]] = []
+        selected_mode = normalize_hitl_mode(hitl_mode)
 
         def validate(data: Dict[str, Any]) -> Dict[str, Any]:
             level = str(data.get("level", "")).strip()
             actor = str(data.get("actor", "")).strip()
             if (level, actor) not in {("B", "manager"), ("A", "human")}:
                 raise ValueError("Resolution must use B/manager or A/human.")
+            if selected_mode is HitlMode.AUTO and (level, actor) != ("B", "manager"):
+                raise ValueError("Auto HITL raised ideas must be resolved by the manager at B level.")
             self._require_text(data.get("context"), "context", "Raised-idea resolution")
             self._require_text(
                 data.get("manager_feedback"), "manager_feedback", "Raised-idea resolution"
@@ -1004,6 +1038,16 @@ class HitlManager:
                     data.get("options", raised_idea.get("options")),
                     error_prefix="Decision resolution",
                 )
+                if selected_mode is HitlMode.AUTO:
+                    expected_options = _normalize_options(raised_idea.get("options"))
+                    submitted_options = _normalize_options(
+                        data.get("options", raised_idea.get("options"))
+                    )
+                    if submitted_options != expected_options:
+                        raise ValueError(
+                            "Auto HITL must select from the worker's existing decision options."
+                        )
+                    data["options"] = raised_idea.get("options", [])
             else:
                 data.pop("options", None)
                 data.pop("decision", None)
@@ -1014,6 +1058,8 @@ class HitlManager:
             pipeline_stage=pipeline_stage,
             plan_text=plan_text,
             raised_idea_json=json.dumps(raised_idea, indent=2, ensure_ascii=False),
+            hitl_mode=selected_mode.value,
+            human_resolution_allowed=selected_mode is HitlMode.FULL,
         )
         return self.request_worker_resolution(
             command={
@@ -1022,6 +1068,7 @@ class HitlManager:
                 "pipeline_stage": pipeline_stage,
                 "hitl_stage": raised_idea.get("hitl_stage", "execution"),
                 "raised_idea": raised_idea,
+                "hitl_mode": selected_mode.value,
             },
             prompt=prompt,
             validate=validate,
@@ -1044,6 +1091,7 @@ class HitlManager:
         scoring_handoff_context: Optional[Dict[str, Any]] = None,
         on_finalize: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
         on_scoring_approval: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
+        hitl_mode: HitlMode | str = HitlMode.FULL,
     ) -> Dict[str, Any]:
         from core.hitl import (
             _is_feedback_placeholder,
@@ -1053,6 +1101,10 @@ class HitlManager:
         )
 
         human_inputs: List[Dict[str, Any]] = []
+        selected_mode = normalize_hitl_mode(hitl_mode)
+        requires_human_approval = (
+            requires_human_approval and selected_mode is HitlMode.FULL
+        )
 
         def validate(data: Dict[str, Any]) -> Dict[str, Any]:
             status = str(data.get("status", "")).strip()
@@ -1121,11 +1173,15 @@ class HitlManager:
             requires_human_approval=requires_human_approval,
             allow_scoring_approval=allow_scoring_approval,
             is_rule_maker=(pipeline_stage == "rule_maker"),
+            hitl_mode=selected_mode.value,
+            human_resolution_allowed=requires_human_approval,
         )
         return self.request_worker_resolution(
             command={
                 "request_key": self._request_key("phase_finish", request),
                 "kind": "phase_finish",
+                "hitl_mode": selected_mode.value,
+                "requires_human_approval": requires_human_approval,
                 **request,
             },
             prompt=prompt,
@@ -1142,6 +1198,7 @@ class HitlManager:
         proposal_text: str,
         on_finalize: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
         request_context: Optional[Dict[str, Any]] = None,
+        hitl_mode: HitlMode | str = HitlMode.FULL,
     ) -> Dict[str, Any]:
         from core.hitl import (
             _is_feedback_placeholder,
@@ -1151,6 +1208,7 @@ class HitlManager:
         )
 
         human_inputs: List[Dict[str, Any]] = []
+        selected_mode = normalize_hitl_mode(hitl_mode)
 
         def validate(data: Dict[str, Any]) -> Dict[str, Any]:
             status = str(data.get("status", "")).strip()
@@ -1163,6 +1221,19 @@ class HitlManager:
                 self._require_text(
                     data.get("manager_feedback"), "manager_feedback", "Illegal proposal review"
                 )
+            elif selected_mode is HitlMode.AUTO:
+                if human_inputs:
+                    raise ValueError("Auto HITL proposal admission cannot call ask_human.")
+                data.pop("human_feedback", None)
+                data.pop("manager_escalation_reason", None)
+                if status == "feedback":
+                    feedback = self._require_text(
+                        data.get("manager_feedback"), "manager_feedback", "Proposal feedback"
+                    )
+                    if _is_feedback_placeholder(feedback):
+                        raise ValueError("Auto HITL proposal feedback must be concrete.")
+                else:
+                    data["manager_feedback"] = str(data.get("manager_feedback", ""))
             else:
                 feedback = self._require_text(
                     data.get("human_feedback"), "human_feedback", "Proposal admission"
@@ -1203,11 +1274,14 @@ class HitlManager:
             "manager_review_proposal.txt",
             pipeline_stage=pipeline_stage,
             proposal_text=proposal_text,
+            hitl_mode=selected_mode.value,
+            human_resolution_allowed=selected_mode is HitlMode.FULL,
         )
         return self.request_worker_resolution(
             command={
                 "request_key": self._request_key("proposal", request),
                 "kind": "proposal",
+                "hitl_mode": selected_mode.value,
                 **request,
             },
             prompt=prompt,
@@ -1430,6 +1504,8 @@ class HitlManager:
         pending = self.runtime_state.pending_worker_command()
         if not isinstance(pending, dict) or pending.get("status") != "pending":
             return "Error: ask_human is available only while runtime has a pending worker command."
+        if not self._human_resolution_allowed_for(pending):
+            return "Error: ask_human is not permitted for this HITL runtime boundary."
         request_key = str(pending["request_key"])
         request_record_id = f"human-request:{request_key}"
         self.conversation.append(
@@ -2063,7 +2139,10 @@ class HitlManager:
         return [
             {
                 "role": "system",
-                "content": _load_hitl_template("interactive_manager_system.txt"),
+                "content": _load_hitl_template(
+                    "interactive_manager_system.txt",
+                    hitl_mode=self._current_hitl_mode().value,
+                ),
             },
             {
                 "role": "system",

--- a/src/core/hitl_mode.py
+++ b/src/core/hitl_mode.py
@@ -1,0 +1,44 @@
+"""Run-scoped policy for HITL research."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+
+class HitlMode(StrEnum):
+    """The authority policy selected for one HITL research run."""
+
+    FULL = "full"
+    AUTO = "auto"
+
+
+def normalize_hitl_mode(value: Any = None) -> HitlMode:
+    """Normalize a persisted or user-supplied HITL mode.
+
+    Missing values intentionally mean Full HITL so existing workspaces and
+    callers retain their current human-approval behavior.
+    """
+
+    if isinstance(value, HitlMode):
+        return value
+    normalized = str(value or HitlMode.FULL.value).strip().lower()
+    try:
+        return HitlMode(normalized)
+    except ValueError as exc:
+        raise ValueError("HITL mode must be 'full' or 'auto'.") from exc
+
+
+def human_resolution_allowed(
+    hitl_mode: Any,
+    *,
+    command_kind: str,
+    requires_human_approval: bool = False,
+) -> bool:
+    """Return whether the current durable boundary may escalate to a human."""
+
+    if normalize_hitl_mode(hitl_mode) is HitlMode.AUTO:
+        return False
+    if command_kind in {"proposal", "raised_idea", "review_proposal", "review_raised_idea"}:
+        return True
+    return command_kind in {"phase_finish", "review_phase_finish"} and requires_human_approval

--- a/src/core/hitl_mode.py
+++ b/src/core/hitl_mode.py
@@ -39,6 +39,6 @@ def human_resolution_allowed(
 
     if normalize_hitl_mode(hitl_mode) is HitlMode.AUTO:
         return False
-    if command_kind in {"proposal", "raised_idea", "review_proposal", "review_raised_idea"}:
+    if command_kind in {"proposal", "raised_idea"}:
         return True
-    return command_kind in {"phase_finish", "review_phase_finish"} and requires_human_approval
+    return command_kind == "phase_finish" and requires_human_approval

--- a/src/core/hitl_run_control.py
+++ b/src/core/hitl_run_control.py
@@ -146,16 +146,19 @@ def request_hitl_run_stop(work_dir: Path, *, requested_by: str) -> Dict[str, Any
         raise RuntimeError("The HITL launch record must be an object.")
     status = str(launch.get("status", "")).strip()
     request_id = str(launch.get("request_id", "")).strip()
-    if status == "stopped":
-        return {"status": "already_stopped", "request_id": request_id}
-    owner = active_hitl_workspace_run(workspace)
-    if owner is None:
-        raise RuntimeError("No HITL AutoResearch run currently owns this workspace.")
     if not request_id:
         raise RuntimeError("The active HITL run has no launch request ID.")
-    owner_request_id = str(owner.get("request_id", "")).strip()
-    if owner_request_id and owner_request_id != request_id:
-        raise RuntimeError("The workspace owner does not match its saved launch request.")
+    if status == "stopped":
+        return {"status": "already_stopped", "request_id": request_id}
+    if status not in {"starting", "running"}:
+        raise RuntimeError("No HITL AutoResearch run is currently active for this workspace.")
+    owner = active_hitl_workspace_run(workspace)
+    if owner is None and status != "starting":
+        raise RuntimeError("No HITL AutoResearch run currently owns this workspace.")
+    if owner is not None:
+        owner_request_id = str(owner.get("request_id", "")).strip()
+        if owner_request_id and owner_request_id != request_id:
+            raise RuntimeError("The workspace owner does not match its saved launch request.")
     control = HitlRunStopControl(workspace, request_id)
     record = control.request(requested_by=requested_by)
     return {

--- a/src/core/hitl_runtime_state.py
+++ b/src/core/hitl_runtime_state.py
@@ -331,24 +331,85 @@ class HitlRuntimeState:
             self._state["worker_continuation"] = None
             self._save_unlocked()
 
-    def mark_plan_approved(self, *, pipeline_stage: str, plan_fingerprint: str) -> None:
+    def mark_plan_approved(
+        self,
+        *,
+        pipeline_stage: str,
+        plan_fingerprint: str,
+        approval_level: str = "A",
+    ) -> None:
         if not pipeline_stage or not plan_fingerprint:
             raise HitlRuntimeStateError(
                 "Plan approval requires pipeline stage and plan fingerprint"
             )
+        if approval_level not in {"A", "B"}:
+            raise HitlRuntimeStateError("Plan approval level must be A or B")
         with self._locked():
             self._state = self._load_unlocked() or self._default()
             approvals = self._state.setdefault("approved_plans", {})
             approvals[str(pipeline_stage)] = {
                 "plan_fingerprint": str(plan_fingerprint),
+                "approval_level": approval_level,
                 "approved_at": _now(),
             }
             self._save_unlocked()
 
-    def has_plan_approval(self, *, pipeline_stage: str, plan_fingerprint: str) -> bool:
+    def has_plan_approval(
+        self,
+        *,
+        pipeline_stage: str,
+        plan_fingerprint: str,
+        approval_levels: tuple[str, ...] = ("A",),
+    ) -> bool:
         approvals = self.snapshot().get("approved_plans", {})
         record = approvals.get(str(pipeline_stage)) if isinstance(approvals, dict) else None
-        return isinstance(record, dict) and record.get("plan_fingerprint") == str(plan_fingerprint)
+        if not isinstance(record, dict):
+            return False
+        level = str(record.get("approval_level") or "A")
+        return (
+            record.get("plan_fingerprint") == str(plan_fingerprint)
+            and level in approval_levels
+        )
+
+    def adopt_hitl_mode(self, hitl_mode: str) -> Dict[str, Any]:
+        """Apply one run's policy to restartable, unresolved HITL state.
+
+        Resolved commands and audit records are historical facts and are never
+        rewritten. Switching to Auto closes any outstanding human-resolution
+        pointer while preserving the request key and worker continuation.
+        """
+
+        from core.hitl_mode import HitlMode, normalize_hitl_mode
+
+        selected = normalize_hitl_mode(hitl_mode)
+        result: Dict[str, Any] = {
+            "hitl_mode": selected.value,
+            "discard_resolution_reply_for": "",
+        }
+        with self._locked():
+            self._state = self._load_unlocked() or self._default()
+            continuation = self._state.get("worker_continuation")
+            if isinstance(continuation, dict):
+                continuation["hitl_mode"] = selected.value
+                continuation["updated_at"] = _now()
+
+            command = self._state.get("pending_worker_command")
+            if isinstance(command, dict) and command.get("status") in {
+                "pending",
+                "scoring_approval_pending",
+                "scoring",
+            }:
+                command["hitl_mode"] = selected.value
+                command["updated_at"] = _now()
+                if selected is HitlMode.AUTO:
+                    request_key = str(command.get("request_key", "")).strip()
+                    # Return this on every adoption so a restart can complete
+                    # inbox cleanup after a crash between the two durable files.
+                    result["discard_resolution_reply_for"] = request_key
+                    command["human_request_record_id"] = None
+                    command["human_reply_record_ids"] = []
+            self._save_unlocked()
+        return result
 
     def pending_worker_command(self) -> Optional[Dict[str, Any]]:
         value = self.snapshot().get("pending_worker_command")

--- a/src/core/hitl_runtime_state.py
+++ b/src/core/hitl_runtime_state.py
@@ -400,6 +400,14 @@ class HitlRuntimeState:
                 "scoring",
             }:
                 command["hitl_mode"] = selected.value
+                if command.get("kind") == "phase_finish":
+                    # Human plan approval is derived from the policy of the
+                    # run that resumes this unresolved command.  Keeping the
+                    # prior run's value would make the validator and manager
+                    # tool surface disagree after an Auto -> Full switch.
+                    command["requires_human_approval"] = bool(
+                        selected is HitlMode.FULL and command.get("hitl_stage") == "plan"
+                    )
                 command["updated_at"] = _now()
                 if selected is HitlMode.AUTO:
                     request_key = str(command.get("request_key", "")).strip()

--- a/src/core/hitl_stage_runtime.py
+++ b/src/core/hitl_stage_runtime.py
@@ -73,11 +73,18 @@ def run_plan_centered_hitl_stage(
     on_failed: StageFailureHandler,
 ) -> Dict[str, Any]:
     """Run the shared plan/execution state machine for ordinary HITL stages."""
-    if not runtime.plan_has_human_approval():
+    plan_approved = getattr(
+        runtime,
+        "plan_has_required_approval",
+        runtime.plan_has_human_approval,
+    )()
+    if not plan_approved:
         runtime.prepare_idea_tool_context(
             hitl_stage="plan",
             actor=actor,
-            requires_human_approval=True,
+            requires_human_approval=getattr(
+                runtime, "requires_human_plan_approval", True
+            ),
             phase_finish_validator=phase_finish_validator,
             worker_prompt_contexts=worker_prompt_contexts,
         )

--- a/src/core/hitl_workspace_view.py
+++ b/src/core/hitl_workspace_view.py
@@ -321,6 +321,12 @@ class HitlWorkspaceView:
         started_at = str((owner or {}).get("started_at") or "").strip()
         provider = str((owner or {}).get("provider") or "").strip()
         mode = str((owner or {}).get("mode") or "").strip()
+        hitl_mode = str(
+            (owner or {}).get("hitl_mode")
+            or active_pending.get("hitl_mode")
+            or continuation.get("hitl_mode")
+            or "full"
+        ).strip().lower()
         latest_phase_event = self._latest_phase_event(runtime, started_at)
         latest_phase_started_at = str(latest_phase_event.get("created_at", "")).strip()
         paper_phase = bool(
@@ -355,6 +361,7 @@ class HitlWorkspaceView:
                 "phase_label": visible_phase,
                 "label": label,
                 "mode": mode,
+                "hitl_mode": hitl_mode if hitl_mode in {"full", "auto"} else "full",
                 "provider": provider,
                 "started_at": started_at,
                 "phase_started_at": (
@@ -394,6 +401,7 @@ class HitlWorkspaceView:
 
         if launch_status:
             mode = str(launch_status.get("mode", mode)).strip()
+            hitl_mode = str(launch_status.get("hitl_mode", hitl_mode)).strip().lower()
             provider = str(launch_status.get("provider", provider)).strip()
             if not started_at:
                 started_at = str(

--- a/src/core/pipeline_orchestrator.py
+++ b/src/core/pipeline_orchestrator.py
@@ -71,6 +71,7 @@ from core.hitl import (
 from core.hitl_git_state import HitlGitSnapshot, HitlGitStateStore
 from core.hitl_git import delete_git_ref
 from core.hitl_run_control import HitlRunStopRequested
+from core.hitl_mode import HitlMode, normalize_hitl_mode
 from core.hitl_stage_runtime import (
     HitlStageRollback,
     run_plan_centered_hitl_stage,
@@ -238,6 +239,7 @@ class ResearchPipelineOrchestrator:
         hitl_channel: Optional[Any] = None,
         hitl_manager_config: Optional[Dict[str, Any]] = None,
         hitl_autoresearch: bool = False,
+        hitl_mode: HitlMode | str = HitlMode.FULL,
     ):
         """
         Initialize pipeline orchestrator.
@@ -257,6 +259,7 @@ class ResearchPipelineOrchestrator:
         self.hitl_channel = hitl_channel
         self.hitl_manager_config = hitl_manager_config or {}
         self.hitl_autoresearch = hitl_autoresearch
+        self.hitl_mode = normalize_hitl_mode(hitl_mode)
 
     def _create_hitl_runtime(self, pipeline_stage: str) -> HitlRuntime:
         whiteboard_mode: Dict[str, bool] = {}
@@ -266,6 +269,7 @@ class ResearchPipelineOrchestrator:
             return HitlRuntime(
                 self.work_dir,
                 pipeline_stage,
+                hitl_mode=self.hitl_mode,
                 **whiteboard_mode,
             )
         return HitlRuntime(
@@ -274,6 +278,7 @@ class ResearchPipelineOrchestrator:
             manager=self.hitl_manager,
             channel=self.hitl_channel,
             config=self.hitl_manager_config,
+            hitl_mode=self.hitl_mode,
             **whiteboard_mode,
         )
 
@@ -1446,13 +1451,13 @@ class ResearchPipelineOrchestrator:
             )
 
         try:
-            plan_approved = runtime.plan_has_human_approval()
+            plan_approved = runtime.plan_has_required_approval()
 
             if not plan_approved:
                 runtime.prepare_idea_tool_context(
                     hitl_stage="plan",
                     actor="experiment_runner",
-                    requires_human_approval=True,
+                    requires_human_approval=runtime.requires_human_plan_approval,
                     allow_scoring_approval=scoring_enabled,
                     phase_finish_validator=artifact_validator,
                     scoring_handler=score_in_background if scoring_enabled else None,

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -48,8 +48,8 @@ from core.compute_backend import (
     normalize_compute_backend,
     without_runtime_compute_backend,
 )
-from core.hitl_run_control import HitlRunStopRequested
 from core.hitl_mode import HitlMode, normalize_hitl_mode
+from core.hitl_run_control import HitlRunStopRequested, raise_if_hitl_run_stop_requested
 from templates.prompt_generator import PromptGenerator
 from templates.research_agent_instructions import generate_instructions
 
@@ -99,6 +99,10 @@ def _with_hitl_workspace_run_ownership(method):
                 "request_id": str(os.environ.get("NEURICO_HITL_REQUEST_ID", "")).strip(),
             },
         ):
+            # A renderer can request stop while the detached worker is still
+            # waiting to acquire this lease. Honor that request before the
+            # runner mutates any research state.
+            raise_if_hitl_run_stop_requested()
             return method(self, *args, **kwargs)
 
     return owned_run

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -49,6 +49,7 @@ from core.compute_backend import (
     without_runtime_compute_backend,
 )
 from core.hitl_run_control import HitlRunStopRequested
+from core.hitl_mode import HitlMode, normalize_hitl_mode
 from templates.prompt_generator import PromptGenerator
 from templates.research_agent_instructions import generate_instructions
 
@@ -86,12 +87,14 @@ def _with_hitl_workspace_run_ownership(method):
             force_fresh=bool(arguments.arguments["force_fresh"]),
         )
         mode = "continue" if arguments.arguments["hitl_continue_autoresearch"] else "fresh"
+        hitl_mode = normalize_hitl_mode(arguments.arguments["hitl_mode"])
         with hitl_workspace_run_lease(
             work_dir,
             owner={
                 "idea_id": idea_id,
                 "interface": str(hitl_interface),
                 "mode": mode,
+                "hitl_mode": hitl_mode.value,
                 "provider": str(arguments.arguments["provider"]),
                 "request_id": str(os.environ.get("NEURICO_HITL_REQUEST_ID", "")).strip(),
             },
@@ -215,6 +218,7 @@ class ResearchRunner:
         hitl_manager_port: int = 7890,
         hitl_manager_no_browser: bool = False,
         hitl_host: Optional[Any] = None,
+        hitl_mode: str = "full",
     ) -> Dict[str, Any]:
         """
         Execute research for a given idea.
@@ -268,6 +272,14 @@ class ResearchRunner:
         if len(selected_hitl_modes) > 1:
             raise ValueError("Choose one HITL entry mode: " + ", ".join(selected_hitl_modes))
         hitl = hitl_autoresearch or hitl_continue_autoresearch
+        selected_hitl_mode = normalize_hitl_mode(hitl_mode)
+        if selected_hitl_mode is HitlMode.AUTO and not hitl:
+            raise ValueError("--auto is valid only with a HITL AutoResearch entry mode.")
+        if selected_hitl_mode is HitlMode.AUTO and pause_after_resources:
+            raise ValueError(
+                "--pause-after-resources is not supported in Auto HITL because it is a "
+                "direct human checkpoint."
+            )
         if hitl and provider not in {"claude", "codex"}:
             raise ValueError(
                 "HITL AutoResearch requires Claude or Codex so its workers and "
@@ -293,6 +305,7 @@ class ResearchRunner:
             continue_autoresearch = True
         if hitl:
             print(f"   HITL: enabled ({hitl})")
+            print(f"   HITL mode: {selected_hitl_mode.value}")
         autoresearch_modes = [
             name
             for name, enabled in (
@@ -491,10 +504,20 @@ class ResearchRunner:
             if not multi_agent:
                 raise ValueError("HITL AutoResearch requires the multi-agent pipeline.")
             from core.hitl_lock import select_hitl_manager_provider
+            from core.hitl_manager_inbox import HitlManagerInbox
+            from core.hitl_runtime_state import HitlRuntimeState
 
             # Recovery may restore an older runtime.json. Record the selected
             # run backend after recovery and before the manager starts.
             select_hitl_manager_provider(work_dir, provider)
+            adoption = HitlRuntimeState(work_dir).adopt_hitl_mode(
+                selected_hitl_mode.value
+            )
+            stale_reply_key = str(
+                adoption.get("discard_resolution_reply_for", "")
+            ).strip()
+            if stale_reply_key:
+                HitlManagerInbox(work_dir).discard_resolution_reply(stale_reply_key)
             if hitl_host is None:
                 from core.hitl_manager_host import HitlManagerHost
                 from interactive.manager import load_config as load_manager_config
@@ -536,6 +559,7 @@ class ResearchRunner:
                         channel=hitl_host.channel,
                         manager_config=hitl_host.manager.config,
                         recovered_attempt=recovered_hitl_attempt,
+                        hitl_mode=selected_hitl_mode,
                     )
                 else:
                     from core.autoresearch import continue_from_current_best
@@ -654,6 +678,7 @@ class ResearchRunner:
                 hitl_manager=hitl_host.manager if hitl_host else None,
                 hitl_channel=hitl_host.channel if hitl_host else None,
                 hitl_manager_config=hitl_host.manager.config if hitl_host else None,
+                hitl_mode=selected_hitl_mode,
             )
             success = False
 
@@ -715,6 +740,7 @@ class ResearchRunner:
                             manager=hitl_host.manager,
                             channel=hitl_host.channel,
                             manager_config=hitl_host.manager.config,
+                            hitl_mode=selected_hitl_mode,
                         )
                     else:
                         initial_result = construct_fresh_initial_node(**initial_args)
@@ -750,6 +776,7 @@ class ResearchRunner:
                                 manager=hitl_host.manager,
                                 channel=hitl_host.channel,
                                 manager_config=hitl_host.manager.config,
+                                hitl_mode=selected_hitl_mode,
                             )
                         else:
                             autoresearch_result = continue_from_current_best(**continuation_args)
@@ -1553,6 +1580,11 @@ def main():
         help="Continue an existing HITL AutoResearch workspace from its selected frontier node.",
     )
     parser.add_argument(
+        "--auto",
+        action="store_true",
+        help="Use manager-resolved Auto HITL for the selected HITL AutoResearch run.",
+    )
+    parser.add_argument(
         "--hitl-manager-port",
         type=int,
         default=7890,
@@ -1644,6 +1676,7 @@ def main():
             hitl_continue_autoresearch=args.hitl_continue_autoresearch,
             hitl_manager_port=args.hitl_manager_port,
             hitl_manager_no_browser=args.hitl_manager_no_browser,
+            hitl_mode="auto" if args.auto else "full",
         )
 
         print()

--- a/src/interactive/hitl_terminal_ui.py
+++ b/src/interactive/hitl_terminal_ui.py
@@ -387,6 +387,9 @@ class HitlTerminalUI:
         elapsed = terminal_safe_text(live.get("elapsed") or "").strip()
         heading = label if not elapsed else f"{label}  ·  {elapsed}"
         lines = [self._style("Research status", "bold"), self._rule(), f"  {self._style(heading, 'bold')}"]
+        if live.get("active"):
+            mode = terminal_safe_text(live.get("hitl_mode") or "full").strip().lower()
+            lines.append(f"  HITL mode: {'Auto' if mode == 'auto' else 'Full'}")
         if detail:
             lines.extend(self._wrap_paragraph(detail, indent="  "))
         if next_action:

--- a/src/interactive/static/hitl/hitl.css
+++ b/src/interactive/static/hitl/hitl.css
@@ -27,3 +27,6 @@
 @media(max-width:900px){.connection.warning{display:inline}}
 
 .portal-workspace-error{align-content:center;justify-items:center;gap:8px;padding:32px;text-align:center}.portal-workspace-error strong{color:var(--text);font-size:18px}.portal-workspace-error p{max-width:720px;margin:0;color:#c6d0cc;line-height:1.5}.portal-workspace-error span{color:var(--muted)}
+
+.status-mode{padding:3px 7px;border:1px solid var(--line);border-radius:999px;color:var(--muted);font-size:11px;white-space:nowrap}
+@media(max-width:740px){.status-mode{display:none}}

--- a/src/interactive/static/hitl/hitl.js
+++ b/src/interactive/static/hitl/hitl.js
@@ -14,7 +14,7 @@
     graphScroll: {}, drawerScroll: {}, sidebarCollapsed: false,
     conversationScroll: { top: 0, nearBottom: true, captured: false },
     managerStatusSeq: -1,
-    runDraft: { hitlMode: "full", iterations: 2, writePaper: true, paperStyle: "auto", github: false },
+    runDraft: { hitlMode: "auto", iterations: 2, writePaper: true, paperStyle: "auto", github: false },
     portal: null, ideas: [], selectedIdeaId: initialIdeaId, catalogBusy: false,
     creatingIdea: false, ideaSchema: null, ideaDraft: {}, ideaSubmitError: "",
     renamingIdeaId: "", draggedIdeaId: "",
@@ -655,7 +655,7 @@
       q("div", { class: "brand" }, [q("span", { class: "workspace-mark", text: "▱" }), q("span", { class: "workspace-title", text: workspace }), q("span", { class: "page-label", text: state.route === "conversation" ? "Conversation" : "Research" })]),
       q("div", { class: "topbar-spacer" }),
       workspaceStatus(),
-      runIsActive ? q("span", { class: "status-mode", title: "Active HITL research mode", text: live.hitl_mode === "auto" ? "Auto HITL" : "Full HITL" }) : null,
+      runIsActive ? q("span", { class: "status-mode", title: "Active research mode", text: live.hitl_mode === "auto" ? "Auto" : "HITL" }) : null,
       q("span", { class: `connection ${state.stale ? "warning" : ""}`, text: state.stale ? "Workspace data unavailable" : "Connected" }),
       state.route === "conversation" ? runControl : null,
       icon(state.route === "conversation" ? "▦" : "←", state.route === "conversation" ? "Research views" : "Back to conversation", () => navigate(state.route === "conversation" ? "research" : "conversation"), "toolbar-action"),
@@ -845,13 +845,13 @@
     const mode = state.snapshot?.autoresearch?.mode === "continue" ? "continue" : "fresh";
     const title = mode === "continue" ? "Continue AutoResearch" : "Fresh AutoResearch";
     const provider = q("select", { id: "run-provider", "data-focus-key": "run-provider" }); [["codex", "Codex"], ["claude", "Claude"]].forEach(([value, label]) => provider.append(q("option", { value, text: label }))); provider.value = state.provider; provider.onchange = () => { state.provider = provider.value; };
-    const hitlMode = q("select", { id: "run-hitl-mode", "data-focus-key": "run-hitl-mode" }); [["full", "Full HITL"], ["auto", "Auto HITL"]].forEach(([value, label]) => hitlMode.append(q("option", { value, text: label }))); hitlMode.value = state.runDraft.hitlMode; hitlMode.onchange = () => { state.runDraft.hitlMode = hitlMode.value; };
+    const hitlMode = q("select", { id: "run-hitl-mode", "data-focus-key": "run-hitl-mode" }); [["full", "No"], ["auto", "Yes"]].forEach(([value, label]) => hitlMode.append(q("option", { value, text: label }))); hitlMode.value = state.runDraft.hitlMode; hitlMode.onchange = () => { state.runDraft.hitlMode = hitlMode.value; };
     const iterations = q("input", { id: "run-iterations", type: "number", min: "1", max: "100", value: state.runDraft.iterations, "data-focus-key": "run-iterations" }); iterations.oninput = () => { state.runDraft.iterations = iterations.value; };
     const paper = q("input", { id: "run-paper", type: "checkbox", "data-focus-key": "run-paper" }); paper.checked = state.runDraft.writePaper; paper.onchange = () => { state.runDraft.writePaper = paper.checked; };
     const github = q("input", { id: "run-github", type: "checkbox", "data-focus-key": "run-github" }); github.checked = state.runDraft.github; github.onchange = () => { state.runDraft.github = github.checked; };
     const style = q("select", { id: "run-style", "data-focus-key": "run-style" }); [["auto", "Automatic"], ["neurips", "NeurIPS"], ["icml", "ICML"], ["acl", "ACL"]].forEach(([value, label]) => style.append(q("option", { value, text: label }))); style.value = state.runDraft.paperStyle; style.onchange = () => { state.runDraft.paperStyle = style.value; };
     const row = (label, control) => q("label", { class: "run-row" }, [q("span", { text: label }), control]);
-    return q("section", { class: "run-panel" }, [q("div", { class: "run-title" }, [q("h2", { text: title }), icon("×", "Close AutoResearch setup", () => { state.runPanel = false; render(); })]), row("Model", provider), row("HITL mode", hitlMode), row("Iterations", iterations), q("label", { class: "check-row" }, [paper, q("span", { text: "Write paper" })]), row("Style", style), q("label", { class: "check-row" }, [github, q("span", { text: "Publish to GitHub" })]), q("div", { class: "run-actions" }, [icon("▶", `Start ${title}`, () => launchRun({ provider: provider.value, hitl_mode: hitlMode.value, iterations: Number(iterations.value), write_paper: paper.checked, paper_style: style.value, github: github.checked }), "run-start")])]);
+    return q("section", { class: "run-panel" }, [q("div", { class: "run-title" }, [q("h2", { text: title }), icon("×", "Close AutoResearch setup", () => { state.runPanel = false; render(); })]), row("Model", provider), row("Auto", hitlMode), row("Iterations", iterations), q("label", { class: "check-row" }, [paper, q("span", { text: "Write paper" })]), row("Style", style), q("label", { class: "check-row" }, [github, q("span", { text: "Publish to GitHub" })]), q("div", { class: "run-actions" }, [icon("▶", `Start ${title}`, () => launchRun({ provider: provider.value, hitl_mode: hitlMode.value, iterations: Number(iterations.value), write_paper: paper.checked, paper_style: style.value, github: github.checked }), "run-start")])]);
   }
   function conversation() {
     const shell = q("main", { class: "conversation-shell" }); const thread = q("div", { class: "thread" }); const request = state.snapshot?.inbox?.pending_request; const requestId = String(request?.conversation_record_id || "");

--- a/src/interactive/static/hitl/hitl.js
+++ b/src/interactive/static/hitl/hitl.js
@@ -846,12 +846,23 @@
     const title = mode === "continue" ? "Continue AutoResearch" : "Fresh AutoResearch";
     const provider = q("select", { id: "run-provider", "data-focus-key": "run-provider" }); [["codex", "Codex"], ["claude", "Claude"]].forEach(([value, label]) => provider.append(q("option", { value, text: label }))); provider.value = state.provider; provider.onchange = () => { state.provider = provider.value; };
     const hitlMode = q("select", { id: "run-hitl-mode", "data-focus-key": "run-hitl-mode" }); [["full", "No"], ["auto", "Yes"]].forEach(([value, label]) => hitlMode.append(q("option", { value, text: label }))); hitlMode.value = state.runDraft.hitlMode; hitlMode.onchange = () => { state.runDraft.hitlMode = hitlMode.value; };
-    const iterations = q("input", { id: "run-iterations", type: "number", min: "1", max: "100", value: state.runDraft.iterations, "data-focus-key": "run-iterations" }); iterations.oninput = () => { state.runDraft.iterations = iterations.value; };
+    const iterations = q("input", { id: "run-iterations", type: "number", min: "1", max: "100", step: "1", required: "required", value: state.runDraft.iterations, "data-focus-key": "run-iterations" }); iterations.oninput = () => { state.runDraft.iterations = iterations.value; iterations.setCustomValidity(""); };
     const paper = q("input", { id: "run-paper", type: "checkbox", "data-focus-key": "run-paper" }); paper.checked = state.runDraft.writePaper; paper.onchange = () => { state.runDraft.writePaper = paper.checked; };
     const github = q("input", { id: "run-github", type: "checkbox", "data-focus-key": "run-github" }); github.checked = state.runDraft.github; github.onchange = () => { state.runDraft.github = github.checked; };
     const style = q("select", { id: "run-style", "data-focus-key": "run-style" }); [["auto", "Automatic"], ["neurips", "NeurIPS"], ["icml", "ICML"], ["acl", "ACL"]].forEach(([value, label]) => style.append(q("option", { value, text: label }))); style.value = state.runDraft.paperStyle; style.onchange = () => { state.runDraft.paperStyle = style.value; };
     const row = (label, control) => q("label", { class: "run-row" }, [q("span", { text: label }), control]);
-    return q("section", { class: "run-panel" }, [q("div", { class: "run-title" }, [q("h2", { text: title }), icon("×", "Close AutoResearch setup", () => { state.runPanel = false; render(); })]), row("Model", provider), row("Auto", hitlMode), row("Iterations", iterations), q("label", { class: "check-row" }, [paper, q("span", { text: "Write paper" })]), row("Style", style), q("label", { class: "check-row" }, [github, q("span", { text: "Publish to GitHub" })]), q("div", { class: "run-actions" }, [icon("▶", `Start ${title}`, () => launchRun({ provider: provider.value, hitl_mode: hitlMode.value, iterations: Number(iterations.value), write_paper: paper.checked, paper_style: style.value, github: github.checked }), "run-start")])]);
+    const start = () => {
+      const iterationValue = Number(iterations.value);
+      if (!iterations.value.trim() || !Number.isInteger(iterationValue) || iterationValue < 1 || iterationValue > 100) {
+        iterations.setCustomValidity("Enter a whole number from 1 to 100.");
+        iterations.reportValidity();
+        iterations.focus();
+        return;
+      }
+      iterations.setCustomValidity("");
+      launchRun({ provider: provider.value, hitl_mode: hitlMode.value, iterations: iterationValue, write_paper: paper.checked, paper_style: style.value, github: github.checked });
+    };
+    return q("section", { class: "run-panel" }, [q("div", { class: "run-title" }, [q("h2", { text: title }), icon("×", "Close AutoResearch setup", () => { state.runPanel = false; render(); })]), row("Model", provider), row("Auto", hitlMode), row("Iterations", iterations), q("label", { class: "check-row" }, [paper, q("span", { text: "Write paper" })]), row("Style", style), q("label", { class: "check-row" }, [github, q("span", { text: "Publish to GitHub" })]), q("div", { class: "run-actions" }, [icon("▶", `Start ${title}`, start, "run-start")])]);
   }
   function conversation() {
     const shell = q("main", { class: "conversation-shell" }); const thread = q("div", { class: "thread" }); const request = state.snapshot?.inbox?.pending_request; const requestId = String(request?.conversation_record_id || "");

--- a/src/interactive/static/hitl/hitl.js
+++ b/src/interactive/static/hitl/hitl.js
@@ -14,7 +14,7 @@
     graphScroll: {}, drawerScroll: {}, sidebarCollapsed: false,
     conversationScroll: { top: 0, nearBottom: true, captured: false },
     managerStatusSeq: -1,
-    runDraft: { iterations: 2, writePaper: true, paperStyle: "auto", github: false },
+    runDraft: { hitlMode: "full", iterations: 2, writePaper: true, paperStyle: "auto", github: false },
     portal: null, ideas: [], selectedIdeaId: initialIdeaId, catalogBusy: false,
     creatingIdea: false, ideaSchema: null, ideaDraft: {}, ideaSubmitError: "",
     renamingIdeaId: "", draggedIdeaId: "",
@@ -655,6 +655,7 @@
       q("div", { class: "brand" }, [q("span", { class: "workspace-mark", text: "▱" }), q("span", { class: "workspace-title", text: workspace }), q("span", { class: "page-label", text: state.route === "conversation" ? "Conversation" : "Research" })]),
       q("div", { class: "topbar-spacer" }),
       workspaceStatus(),
+      runIsActive ? q("span", { class: "status-mode", title: "Active HITL research mode", text: live.hitl_mode === "auto" ? "Auto HITL" : "Full HITL" }) : null,
       q("span", { class: `connection ${state.stale ? "warning" : ""}`, text: state.stale ? "Workspace data unavailable" : "Connected" }),
       state.route === "conversation" ? runControl : null,
       icon(state.route === "conversation" ? "▦" : "←", state.route === "conversation" ? "Research views" : "Back to conversation", () => navigate(state.route === "conversation" ? "research" : "conversation"), "toolbar-action"),
@@ -844,12 +845,13 @@
     const mode = state.snapshot?.autoresearch?.mode === "continue" ? "continue" : "fresh";
     const title = mode === "continue" ? "Continue AutoResearch" : "Fresh AutoResearch";
     const provider = q("select", { id: "run-provider", "data-focus-key": "run-provider" }); [["codex", "Codex"], ["claude", "Claude"]].forEach(([value, label]) => provider.append(q("option", { value, text: label }))); provider.value = state.provider; provider.onchange = () => { state.provider = provider.value; };
+    const hitlMode = q("select", { id: "run-hitl-mode", "data-focus-key": "run-hitl-mode" }); [["full", "Full HITL"], ["auto", "Auto HITL"]].forEach(([value, label]) => hitlMode.append(q("option", { value, text: label }))); hitlMode.value = state.runDraft.hitlMode; hitlMode.onchange = () => { state.runDraft.hitlMode = hitlMode.value; };
     const iterations = q("input", { id: "run-iterations", type: "number", min: "1", max: "100", value: state.runDraft.iterations, "data-focus-key": "run-iterations" }); iterations.oninput = () => { state.runDraft.iterations = iterations.value; };
     const paper = q("input", { id: "run-paper", type: "checkbox", "data-focus-key": "run-paper" }); paper.checked = state.runDraft.writePaper; paper.onchange = () => { state.runDraft.writePaper = paper.checked; };
     const github = q("input", { id: "run-github", type: "checkbox", "data-focus-key": "run-github" }); github.checked = state.runDraft.github; github.onchange = () => { state.runDraft.github = github.checked; };
     const style = q("select", { id: "run-style", "data-focus-key": "run-style" }); [["auto", "Automatic"], ["neurips", "NeurIPS"], ["icml", "ICML"], ["acl", "ACL"]].forEach(([value, label]) => style.append(q("option", { value, text: label }))); style.value = state.runDraft.paperStyle; style.onchange = () => { state.runDraft.paperStyle = style.value; };
     const row = (label, control) => q("label", { class: "run-row" }, [q("span", { text: label }), control]);
-    return q("section", { class: "run-panel" }, [q("div", { class: "run-title" }, [q("h2", { text: title }), icon("×", "Close AutoResearch setup", () => { state.runPanel = false; render(); })]), row("Model", provider), row("Iterations", iterations), q("label", { class: "check-row" }, [paper, q("span", { text: "Write paper" })]), row("Style", style), q("label", { class: "check-row" }, [github, q("span", { text: "Publish to GitHub" })]), q("div", { class: "run-actions" }, [icon("▶", `Start ${title}`, () => launchRun({ provider: provider.value, iterations: Number(iterations.value), write_paper: paper.checked, paper_style: style.value, github: github.checked }), "run-start")])]);
+    return q("section", { class: "run-panel" }, [q("div", { class: "run-title" }, [q("h2", { text: title }), icon("×", "Close AutoResearch setup", () => { state.runPanel = false; render(); })]), row("Model", provider), row("HITL mode", hitlMode), row("Iterations", iterations), q("label", { class: "check-row" }, [paper, q("span", { text: "Write paper" })]), row("Style", style), q("label", { class: "check-row" }, [github, q("span", { text: "Publish to GitHub" })]), q("div", { class: "run-actions" }, [icon("▶", `Start ${title}`, () => launchRun({ provider: provider.value, hitl_mode: hitlMode.value, iterations: Number(iterations.value), write_paper: paper.checked, paper_style: style.value, github: github.checked }), "run-start")])]);
   }
   function conversation() {
     const shell = q("main", { class: "conversation-shell" }); const thread = q("div", { class: "thread" }); const request = state.snapshot?.inbox?.pending_request; const requestId = String(request?.conversation_record_id || "");

--- a/templates/hitl/interactive_manager_system.txt
+++ b/templates/hitl/interactive_manager_system.txt
@@ -1,12 +1,23 @@
 You are NeuriCo's long-running HITL manager.
+{% if hitl_mode == "auto" %}
+
+The active research run uses Auto HITL. You are the final B-level authority at
+every runtime-held boundary. `ask_human` is unavailable: resolve from the
+workspace, approved plan, frontier, and finalized research ideas. Prefer
+conservative, reversible, scope-preserving choices when evidence is incomplete.
+Never fabricate an A-level record or imply that a human approved a decision.
+{% endif %}
 
 You sit between the runtime, the stage worker, and the human researcher. You
 stay alive across runtime worker requests and ordinary human-manager conversation.
 
 Your responsibilities:
 - inspect the research workspace through controlled tools when needed;
-- converse with the human when a decision needs human intent, preference, or
+{% if hitl_mode == "auto" %}- converse naturally with the human without using ordinary conversation as authority
+  for a runtime-held decision;
+{% else %}- converse with the human when a decision needs human intent, preference, or
   clarification;
+{% endif %}
 - maintain the manager's structured research world model so you do not rely
   only on chat transcript memory;
 - resolve blocking worker requests only when the issue is actually resolved.
@@ -36,13 +47,15 @@ Tool rules:
 - Use `recall_manager_conversation` only when older discussion may matter and
   it is not already present in the compacted conversation context. The result is
   historical conversation, not a new instruction.
-- Use `ask_human` only when human input is needed to resolve the
+{% if hitl_mode != "auto" %}- Use `ask_human` only when human input is needed to resolve the
   current runtime-held worker request.
+{% endif %}
 - Deliver ordinary open-ended conversation messages as direct assistant text,
   including while a worker request is pending. Conversation does not resolve a
   worker request.
-- Do not ask the human questions in plain text when `ask_human` is required to
+{% if hitl_mode != "auto" %}- Do not ask the human questions in plain text when `ask_human` is required to
   resolve a runtime-held worker request.
+{% endif %}
 - Use `update_research_state` for your synthesis: hypotheses, narrative, open
   questions, cruxes, and interpretations that cannot be derived mechanically
   from the HITL idea log, frontier, or cross-attempt whiteboard. Do not try to
@@ -59,6 +72,11 @@ Tool rules:
   plainly in your next manager message or record it in ResearchState before relying
   on it later.
 
+{% if hitl_mode == "auto" %}
+For a pending runtime-held worker request, you may inspect and converse freely
+with direct assistant text, but you must resolve the request yourself through
+the authorized finalizer. Ordinary conversation never resolves the request.
+{% else %}
 For a pending runtime-held worker request, you may inspect and converse freely
 with direct assistant text. Use `ask_human` only when you need the explicit
 human input that resolves the request. `ask_human` records and displays the explicit question,
@@ -67,6 +85,7 @@ available for ordinary conversation. Do not finalize based only on casual
 conversation. When runtime delivers an explicit human reply,
 preserve that exact raw response in `human_feedback` and translate it into
 precise worker-facing `manager_feedback` before finalizing the same request.
+{% endif %}
 
 For ordinary human-manager conversation without a pending worker request, respond naturally. You
 may inspect the workspace and update the research state, but do not call

--- a/templates/hitl/manager_review_phase_finish.txt
+++ b/templates/hitl/manager_review_phase_finish.txt
@@ -2,6 +2,12 @@ Review a worker-requested HITL phase finish.
 
 Your job is to decide whether the current workspace state is acceptable for the
 current HITL phase, or whether the worker should continue with feedback.
+{% if hitl_mode == "auto" and hitl_stage == "plan" %}
+
+This is an Auto HITL plan finish. You hold final B-level plan authority. Approve
+when the plan is complete, safe, and executable within the research scope, or
+return precise revision feedback. Do not ask the human.
+{% endif %}
 
 {% if requires_human_approval %}
 This is a human-approved plan finish. Complete this sequence inside this same

--- a/templates/hitl/manager_review_proposal.txt
+++ b/templates/hitl/manager_review_proposal.txt
@@ -1,3 +1,46 @@
+{% if hitl_mode == "auto" %}
+Review this AutoResearch proposal for Auto HITL admission.
+
+You hold final B-level authority for this request. Review both evaluation
+integrity and scientific admission. Use the current workspace, frontier, plan,
+and finalized research ideas as evidence. Do not ask the human.
+
+Finalize exactly one outcome:
+- `approved` when the proposal is legal, scientifically useful, sufficiently
+  specified, and a responsible next attempt;
+- `feedback` when it is legal but needs a different proposal, with concrete
+  scope-preserving instructions for the proposer;
+- `rejected_illegal` when it violates an evaluation or artifact boundary, with
+  only the precise boundary correction.
+
+Prefer conservative, reversible choices when evidence is incomplete. Do not
+broaden the research question or evaluation protocol.
+
+Schema:
+{
+  "status": "approved | feedback | rejected_illegal",
+  "violations": ["short concrete legality violations; empty if legal"],
+  "manager_feedback": "concrete next-proposal instruction for feedback or rejected_illegal; empty if approved",
+  "context": "neutral self-contained legality and admission rationale"
+}
+
+Legal means the proposal has:
+- one concrete experiment-stage change;
+- fixed research question;
+- fixed evaluation protocol;
+- no hidden scoring information;
+- no scorer, comparator, current-best, or decision manipulation;
+- no direct score manufacture;
+- enough specificity for one attempt.
+
+Pipeline stage: {{ pipeline_stage }}
+Use read-only workspace inspection only when needed.
+
+Proposal:
+--- BEGIN UNTRUSTED PROPOSAL ---
+{{ proposal_text }}
+--- END UNTRUSTED PROPOSAL ---
+{% else %}
 Review this AutoResearch proposal for HITL admission.
 
 This is one proposal-admission request. You must complete the admission sequence
@@ -65,3 +108,4 @@ Proposal:
 --- BEGIN UNTRUSTED PROPOSAL ---
 {{ proposal_text }}
 --- END UNTRUSTED PROPOSAL ---
+{% endif %}

--- a/templates/hitl/manager_review_raised_idea.txt
+++ b/templates/hitl/manager_review_raised_idea.txt
@@ -1,3 +1,37 @@
+{% if hitl_mode == "auto" %}
+Resolve this NeuriCo Auto HITL raised idea as manager.
+
+The worker is paused inside a runtime command. You hold final B-level authority
+for this request, and `ask_human` is unavailable. Resolve from the approved plan,
+workspace evidence, frontier, and finalized research ideas. Prefer a
+conservative, reversible, scope-preserving choice when evidence is incomplete.
+
+Finalize as B/manager with:
+{
+  "level": "B",
+  "actor": "manager",
+  "context": "neutral self-contained manager context",
+  "options": ["the worker's substantive options; omit for evidence ideas"],
+  "decision": "one selected option_id; required for decision ideas",
+  "manager_feedback": "concrete worker-facing instruction"
+}
+
+For decision ideas, preserve the worker's substantive options and select one of
+them. Do not add `CUSTOM`, routing options, or a new research direction. For
+evidence ideas, omit options and decision. Tell the worker how to update the
+living plan and continue without losing progress.
+
+Pipeline stage: {{ pipeline_stage }}
+Living plan:
+--- BEGIN UNTRUSTED PLAN ---
+{{ plan_text }}
+--- END UNTRUSTED PLAN ---
+
+Raised idea:
+--- BEGIN UNTRUSTED RAISED IDEA ---
+{{ raised_idea_json }}
+--- END UNTRUSTED RAISED IDEA ---
+{% else %}
 Resolve this NeuriCo HITL raised idea as manager.
 
 The worker is paused inside a runtime command. It cannot proceed until this
@@ -78,3 +112,4 @@ Raised idea:
 --- BEGIN UNTRUSTED RAISED IDEA ---
 {{ raised_idea_json }}
 --- END UNTRUSTED RAISED IDEA ---
+{% endif %}

--- a/templates/hitl/worker_autonomous_idea_contract.txt
+++ b/templates/hitl/worker_autonomous_idea_contract.txt
@@ -95,8 +95,8 @@ Rule-maker reminders:
   thresholds, split/aggregation rules, required runner artifacts, or an
   anti-gaming check within the approved plan;
 - raise rather than decide autonomously when a choice would redefine scientific
-  success, invalidate the research claim, or depend on the human's intended
-  tradeoff between competing evaluation goals.
+  success, invalidate the research claim, or depend on {% if hitl_mode == "auto" %}a manager-level
+  tradeoff{% else %}the human's intended tradeoff{% endif %} between competing evaluation goals.
 {% endif %}
 
 Evidence categories:
@@ -175,11 +175,11 @@ formatting/editing detail, or temporary scratch step, do not log it.
 
 Do not log routine reading, formatting, ordinary commands, minor edits, or
 micro-steps. Do not log the same idea again unless new evidence materially
-changes it. Do not log manager/human feedback, approval, or the act of following
+changes it. Do not log manager{% if hitl_mode != "auto" %}/human{% endif %} feedback, approval, or the act of following
 that feedback as a new C-level idea.
 
 {% if allow_raised_ideas %}
-For issues that need manager or human input, use `hitl-raise-idea` and wait for
+For issues that need manager{% if hitl_mode != "auto" %} or human{% endif %} input, use `hitl-raise-idea` and wait for
 the returned feedback.
 
 Raised evidence idea:
@@ -189,7 +189,7 @@ hitl-raise-idea evidence \
   --category "dataset_property" \
   --context "what situation produced this evidence" \
   --evidence "the evidence idea" \
-  --reason-for-escalation "why manager or human input is required"
+  --reason-for-escalation "why manager{% if hitl_mode != "auto" %} or human{% endif %} input is required"
 ```
 
 Raised decision idea:
@@ -201,11 +201,11 @@ hitl-raise-idea decision \
   --decision-needed "the question being decided" \
   --option "one substantive option" \
   --option "another substantive option" \
-  --reason-for-escalation "why manager or human input is required"
+  --reason-for-escalation "why manager{% if hitl_mode != "auto" %} or human{% endif %} input is required"
 ```
 
 For raised decision ideas, include every substantive option that should be
-available for manager/human resolution using repeated `--option`. The command
+available for manager{% if hitl_mode != "auto" %}/human{% endif %} resolution using repeated `--option`. The command
 blocks until runtime resolves the idea, then prints `HITL_RESOLVED` and
 worker-facing feedback. Read that feedback, update the living plan, and continue
 in the same session.

--- a/templates/hitl/worker_escalation_policy.txt
+++ b/templates/hitl/worker_escalation_policy.txt
@@ -6,4 +6,8 @@ Escalation policy:
 - Raise an idea only when you cannot proceed within the approved plan
   without changing research scope, evaluation meaning, protected artifact
   boundaries, substantial budget/risk, access or licensing assumptions, or
-  another choice that genuinely depends on human intent.
+{% if hitl_mode == "auto" %}  another non-routine choice outside your C-level authority.
+- In Auto HITL, the manager is the final authority for every raised idea. Do not
+  wait for or request human input.
+{% else %}  another choice that genuinely depends on human intent.
+{% endif %}

--- a/templates/hitl/worker_execution.txt
+++ b/templates/hitl/worker_execution.txt
@@ -56,7 +56,7 @@ Idea protocol:
 - Evidence idea: important information discovered during the stage.
 - Decision idea: a choice/action under a specific context.
 - C-level autonomous ideas may be recorded without blocking.
-- Raised ideas must pause through `hitl-raise-idea` until manager/human feedback
+- Raised ideas must pause through `hitl-raise-idea` until manager{% if hitl_mode != "auto" %}/human{% endif %} feedback
   is returned.
 {% include "hitl/worker_escalation_policy.txt" %}
 

--- a/templates/hitl/worker_plan.txt
+++ b/templates/hitl/worker_plan.txt
@@ -24,11 +24,13 @@ Required plan content:
 - intended artifacts to create or update
 - step-by-step execution plan
 - decision/evidence criteria for ideas that can be handled autonomously
-- escalation criteria for ideas that require manager or human feedback,
+- escalation criteria for ideas that require manager{% if hitl_mode != "auto" %} or human{% endif %} feedback,
   only when the worker cannot proceed within the approved plan without changing
   research scope, evaluation meaning, protected artifact boundaries, substantial
   budget/risk, access or licensing assumptions, or another choice that genuinely
-  depends on human intent
+{% if hitl_mode == "auto" %}  exceeds the worker's C-level authority
+{% else %}  depends on human intent
+{% endif %}
 - known risks, gaps, and stop conditions
 - current progress section, initially marking planning as complete
 {% if pipeline_stage == "rule_maker" %}
@@ -72,4 +74,4 @@ Hard constraints:
 {% include "hitl/worker_finish_phase_contract.txt" %}
 
 The manager will review this plan. If it is good enough,
-{% if requires_human_approval %}the human will approve or provide feedback before execution starts.{% else %}execution may begin without another human approval because the relevant proposal has already been approved.{% endif %}
+{% if hitl_mode == "auto" %}the manager will approve it at B level and execution may begin without human review.{% elif requires_human_approval %}the human will approve or provide feedback before execution starts.{% else %}execution may begin without another human approval because the relevant proposal has already been approved.{% endif %}

--- a/templates/hitl/worker_plan_revision.txt
+++ b/templates/hitl/worker_plan_revision.txt
@@ -9,11 +9,11 @@ This is plan revision only. Do not perform stage work.
 Required behavior:
 1. Read the existing plan and current workspace state.
 2. Preserve useful completed reasoning and progress.
-3. Apply only the manager/human feedback below.
+3. Apply only the manager{% if hitl_mode != "auto" %}/human{% endif %} feedback below.
 4. Make the plan concrete enough for another manager review.
 5. Update the progress section to explain what changed.
 
-Manager/human feedback to apply:
+Manager{% if hitl_mode != "auto" %}/human{% endif %} feedback to apply:
 
 {{ feedback }}
 

--- a/templates/hitl/worker_review_revision.txt
+++ b/templates/hitl/worker_review_revision.txt
@@ -26,7 +26,7 @@ Revalidate the approved rule-maker deliverables after the revision:
 sealing only after final approval.
 {% endif %}
 
-If another idea requires manager/human feedback, update `{{ plan_path }}`, call
+If another idea requires manager{% if hitl_mode != "auto" %}/human{% endif %} feedback, update `{{ plan_path }}`, call
 `hitl-raise-idea`, wait for returned feedback, apply only that feedback, and
 continue in this same session.
 

--- a/templates/hitl/worker_terminal_contract.txt
+++ b/templates/hitl/worker_terminal_contract.txt
@@ -10,7 +10,7 @@ Before requesting finish review, COMPLETE should hold:
 
 {% include "hitl/worker_finish_phase_contract.txt" %}
 
-If manager/human input is needed before completion, call `hitl-raise-idea` and
+If manager{% if hitl_mode != "auto" %}/human{% endif %} input is needed before completion, call `hitl-raise-idea` and
 wait for the returned feedback instead of requesting finish review. If a HITL
 command prints `HITL_COMMAND_ERROR` or `HITL_ERROR`, follow its printed
 instruction and retry it in this same worker session. If it prints


### PR DESCRIPTION
## Summary

This PR introduces Auto as a second operating mode for HITL AutoResearch. This work is stacked on PR164, which has not been merged. The changes should be reviewed against `hitl-web-idea-submit`.

Full HITL and Auto use the same research pipeline, manager, workers, workspace history, scoring, checkpoints, recovery, and interfaces. The difference is who holds final decision authority during a run.

| Research boundary | Full HITL | Auto |
|---|---|---|
| Proposal admission | The manager reviews the proposal before it is presented to the user. The user decides whether the proposal may proceed. | The manager reviews the proposal and makes the admission decision. |
| Plan approval | The manager reviews the plan, followed by the required human approval. | The manager gives the final plan approval. |
| Worker-raised decisions | The manager may send the decision to the user and wait for a response. | The manager resolves the decision using the options provided by the worker. |
| Phase review | A phase can pause when human intent or approval is required. | The manager approves the phase or returns concrete revision instructions. |
| Human inbox | Human requests may be created and remain active until resolved. | Human requests are disabled for the duration of the run. |
| Decision records | Human decisions are recorded at A level. | Manager decisions are recorded at B level. |

Auto therefore preserves the HITL research structure while allowing a run to continue without waiting for user participation.

## Auto decision behavior

Auto does not treat manager review as a formality. The manager still evaluates the evidence at every existing HITL boundary.

A proposal can be rejected with feedback and returned to the proposer. A plan can be returned for revision. A completed phase can be sent back for repair. A successfully scored candidate can still be rejected when its result is weaker than the current frontier or introduces an unacceptable tradeoff.

Worker-raised decisions also remain explicit. The worker records the question, evidence, and available options through the existing HITL mechanism. In Auto, the manager must select from those options and persist its reasoning before the worker continues.

The runtime disables `ask_human` while Auto is active. This prevents an Auto run from entering a waiting state through a prompt mistake or an unexpected manager action.

## Switching between Auto and full HITL

The mode belongs to an individual run and is stored in durable workspace state. It is carried through launch, worker continuation, pending commands, recovery, stop handling, and final status.

A workspace can be started in Auto and later continued in full HITL. The reverse is also supported. Changing modes affects future and unresolved decisions; completed decisions remain unchanged in the workspace history.

Plan approvals retain their authority level. A manager-approved Auto plan is recognized when Auto resumes, while full HITL continues to require the human approval level expected by that workflow.

Launch records without a saved mode continue to use full HITL.

## Run configuration

CLI and web setup expose the mode as `Auto: Yes/No`, with Auto selected by default. The active workspace is labeled Auto or HITL so both renderers show the policy governing the current run.

The setting is part of research launch configuration. CLI and web remain interchangeable views of the same workspace.

Run setup can also be cancelled before launch. Provider, iteration count, paper selection, and paper style are validated before the launch request is created.