### PR TITLE
fix: redact Google OAuth tokens from logs

### DIFF
--- a/src/core/security.py
+++ b/src/core/security.py
@@ -72,6 +72,8 @@ API_KEY_PATTERNS = [
 
     # Google/Gemini API keys
     (r'AIza[A-Za-z0-9_-]{35,}', '[REDACTED_GOOGLE_KEY]'),
+    (r'ya29\.[A-Za-z0-9_-]{20,}', '[REDACTED_GOOGLE_OAUTH_ACCESS]'),
+    (r'1//0[A-Za-z0-9_-]{20,}', '[REDACTED_GOOGLE_OAUTH_REFRESH]'),
 
     # AWS keys
     (r'AKIA[A-Z0-9]{16}', '[REDACTED_AWS_ACCESS_KEY]'),

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,30 @@
+from core.security import sanitize_text
+
+
+def test_redacts_google_oauth_access_token():
+    token = "ya29." + "A" * 30
+    assert sanitize_text(token) == "[REDACTED_GOOGLE_OAUTH_ACCESS]"
+
+
+def test_redacts_google_oauth_refresh_token():
+    token = "1//0" + "A" * 30
+    assert sanitize_text(token) == "[REDACTED_GOOGLE_OAUTH_REFRESH]"
+
+
+def test_redacts_google_oauth_tokens_embedded_in_log_text():
+    access = "ya29." + "A" * 30
+    refresh = "1//0" + "B" * 30
+
+    text = f"access_token={access} refresh_token={refresh}"
+
+    sanitized = sanitize_text(text)
+
+    assert access not in sanitized
+    assert refresh not in sanitized
+    assert "[REDACTED_GOOGLE_OAUTH_ACCESS]" in sanitized
+    assert "[REDACTED_GOOGLE_OAUTH_REFRESH]" in sanitized
+
+
+def test_does_not_redact_short_google_oauth_like_strings():
+    text = "ya29.short 1//0short"
+    assert sanitize_text(text) == text


### PR DESCRIPTION
## Summary
- redact Google OAuth access tokens beginning with `ya29.`
- redact Google OAuth refresh tokens beginning with `1//0`
- add regression tests for both token formats and short non-matching strings

Closes #92.

## Testing
- `uv run pytest tests/ -v`
- 172 passed