### PR TITLE
fix: sanitize staged files before GitHub upload

### DIFF
--- a/src/core/github_manager.py
+++ b/src/core/github_manager.py
@@ -15,7 +15,12 @@ import subprocess
 import shlex
 from datetime import datetime
 
-from core.security import sanitize_logs_directory
+from core.security import (
+    SanitizationError,
+    contains_sensitive_data,
+    sanitize_file,
+    sanitize_logs_directory,
+)
 
 try:
     from github import Github, GithubException, Auth
@@ -289,6 +294,11 @@ class GitHubManager:
             # Add all files
             repo.git.add(A=True)
 
+            sanitized_files = self._sanitize_staged_files(repo, repo_path)
+            if sanitized_files:
+                print(f"   ✓ Sanitized {len(sanitized_files)} staged file(s)")
+            self._verify_staged_files_sanitized(repo)
+
             # Unstage files exceeding GitHub's 100MB file size limit
             large_files = self._unstage_large_files(repo, repo_path)
             if large_files:
@@ -325,6 +335,57 @@ class GitHubManager:
 
         except GitCommandError as e:
             raise RuntimeError(f"Failed to commit and push: {e}")
+        except SanitizationError as e:
+            raise RuntimeError(f"Refusing to commit unsafe staged content: {e}") from e
+
+    def _staged_paths(self, repo: 'Repo') -> list:
+        """Return staged paths, excluding deleted entries."""
+        staged_output = repo.git.diff('--cached', '--name-only', '--diff-filter=ACMR')
+        if not staged_output.strip():
+            return []
+        return [path for path in staged_output.splitlines() if path.strip()]
+
+    def _sanitize_staged_files(self, repo: 'Repo', repo_path: Path) -> list:
+        """
+        Sanitize staged text files and re-stage files modified by the sanitizer.
+
+        This is the GitHub commit boundary: if a staged file cannot be safely
+        read or rewritten, fail closed instead of committing possibly unsafe
+        content.
+        """
+        sanitized_files = []
+
+        for relative_path in self._staged_paths(repo):
+            full_path = Path(repo_path) / relative_path
+
+            if sanitize_file(full_path, strict=True):
+                repo.git.add('--', relative_path)
+                sanitized_files.append(relative_path)
+
+        return sanitized_files
+
+    def _verify_staged_files_sanitized(self, repo: 'Repo') -> None:
+        """Fail if any recognized secret remains in staged textual content."""
+        for relative_path in self._staged_paths(repo):
+            try:
+                result = subprocess.run(
+                    ["git", "show", f":{relative_path}"],
+                    cwd=repo.working_tree_dir,
+                    capture_output=True,
+                    check=True,
+                )
+                staged_content = result.stdout.decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+            except (GitCommandError, subprocess.CalledProcessError) as e:
+                raise SanitizationError(
+                    f"Could not inspect staged content for {relative_path}: {e}"
+                ) from e
+
+            if contains_sensitive_data(staged_content):
+                raise SanitizationError(
+                    f"Recognized credential remains staged in {relative_path}"
+                )
 
     def _unstage_large_files(self, repo: 'Repo', repo_path: Path) -> list:
         """

--- a/src/core/github_manager.py
+++ b/src/core/github_manager.py
@@ -16,7 +16,11 @@ import subprocess
 import shlex
 from datetime import datetime
 
-from core.security import sanitize_logs_directory
+from core.security import (
+    SanitizationError,
+    contains_sensitive_data_bytes,
+    sanitize_text,
+)
 
 try:
     from github import Github, GithubException, Auth
@@ -159,7 +163,7 @@ class GitHubManager:
             - repo_name: Name of created repository
             - repo_url: HTTPS URL for the repository
             - clone_url: URL for cloning
-            - local_path: Local path where repo will be cloned
+            - local_path: Path where repo will be cloned
         """
         # First-time repositories receive the established generated name. A
         # deleted publication destination must instead be reconstructed with
@@ -338,17 +342,12 @@ class GitHubManager:
                     git_config.set_value("user", "name", "NeuriCo")
                     git_config.set_value("user", "email", "noreply@neurico.dev")
 
-            # Sanitize log files before adding (remove any leaked API keys)
-            logs_dir = Path(repo_path) / "logs"
-            if logs_dir.exists():
-                sanitized_count = sanitize_logs_directory(logs_dir)
-                if sanitized_count > 0:
-                    print(f"   ✓ Sanitized {sanitized_count} log file(s)")
-
-            # Add all files
+            # Stage first. The Git index is the single authoritative publication
+            # boundary; real-time output redaction and other safeguards remain
+            # independent layers but are not duplicated here.
             repo.git.add(A=True)
 
-            # Unstage files exceeding GitHub's 100MB file size limit
+            # Exclude oversized staged blobs before any staged content is read.
             large_files = self._unstage_large_files(repo, repo_path)
             if large_files:
                 for lf_path, lf_size in large_files:
@@ -357,12 +356,16 @@ class GitHubManager:
                 print(f"   ⚠️  {len(large_files)} file(s) excluded from commit due to GitHub's 100MB file size limit.")
                 print(f"      These files remain in your local workspace but are not pushed to GitHub.")
 
-            # Check if there are changes to commit. HITL checkpoints may have
-            # already committed the complete workspace, but that existing HEAD
-            # still needs to reach its external storage remote.
-            has_changes = repo.is_dirty(untracked_files=True)
+            sanitized_files = self._sanitize_staged_files(repo, repo_path)
+            if sanitized_files:
+                print(f"   ✓ Sanitized {len(sanitized_files)} staged file(s)")
+            self._verify_staged_files_sanitized(repo)
+
+            # Only staged changes belong in the commit. Files intentionally
+            # unstaged above (for example oversized artifacts) must not trigger
+            # an empty commit merely because they remain in the working tree.
+            has_changes = bool(repo.git.diff('--cached', '--name-only').strip())
             if has_changes:
-                # Commit
                 repo.index.commit(commit_message)
                 print(f"   ✓ Committed: {commit_message}")
 
@@ -414,49 +417,182 @@ class GitHubManager:
                 print("   ℹ️  No changes to commit")
                 return False
 
+        except SanitizationError as e:
+            raise RuntimeError(f"Refusing to commit unsafe staged content: {e}") from e
         except GitCommandError as e:
             raise RuntimeError(f"Failed to commit and push: {e}")
 
+    def _run_git_bytes(self, repo: 'Repo', args: list, *, input_bytes: Optional[bytes] = None) -> bytes:
+        """Run a Git plumbing command and return exact bytes, failing closed."""
+        try:
+            result = subprocess.run(
+                ["git", *args],
+                cwd=repo.working_tree_dir,
+                input=input_bytes,
+                capture_output=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            detail = e.stderr.decode("utf-8", errors="replace").strip()
+            raise SanitizationError(
+                f"Git inspection command failed ({' '.join(args)}): {detail or e}"
+            ) from e
+        return result.stdout
+
+    def _staged_paths(self, repo: 'Repo') -> list:
+        """Return staged added/copied/modified/renamed paths, excluding deletions."""
+        raw = self._run_git_bytes(
+            repo,
+            ["diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z"],
+        )
+        return [os.fsdecode(path) for path in raw.split(b"\0") if path]
+
+    def _staged_entry(self, repo: 'Repo', relative_path: str) -> tuple:
+        """Return (mode, object_sha) for the stage-0 index entry."""
+        raw = self._run_git_bytes(
+            repo,
+            ["ls-files", "--stage", "-z", "--", relative_path],
+        )
+        for entry in raw.split(b"\0"):
+            if not entry:
+                continue
+            metadata, separator, _ = entry.partition(b"\t")
+            if not separator:
+                continue
+            parts = metadata.split()
+            if len(parts) == 3 and parts[2] == b"0":
+                return parts[0].decode("ascii"), parts[1].decode("ascii")
+        raise SanitizationError(
+            f"Could not resolve stage-0 Git index entry for {relative_path}"
+        )
+
+    def _staged_blob_size(self, repo: 'Repo', object_sha: str) -> int:
+        """Read Git object size without loading the object's content."""
+        raw = self._run_git_bytes(repo, ["cat-file", "-s", object_sha])
+        try:
+            return int(raw.strip())
+        except ValueError as e:
+            raise SanitizationError(
+                f"Could not determine staged Git object size for {object_sha}"
+            ) from e
+
+    def _read_staged_blob(self, repo: 'Repo', relative_path: str) -> tuple:
+        """Return (mode, bytes) for a bounded staged blob, never the worktree file."""
+        mode, object_sha = self._staged_entry(repo, relative_path)
+
+        # Gitlinks point at commits rather than blobs. They contain no artifact
+        # bytes to sanitize and are verified by their object identity instead.
+        if mode == "160000":
+            return mode, b""
+
+        size = self._staged_blob_size(repo, object_sha)
+        if size > MAX_FILE_SIZE:
+            raise SanitizationError(
+                f"Oversized staged blob reached sanitizer for {relative_path} "
+                f"({size} bytes > {MAX_FILE_SIZE})"
+            )
+
+        return mode, self._run_git_bytes(repo, ["cat-file", "blob", object_sha])
+
+    def _write_staged_blob(self, repo: 'Repo', relative_path: str, mode: str, content: bytes) -> None:
+        """Write sanitized bytes to the Git index without touching the worktree."""
+        object_sha = self._run_git_bytes(
+            repo,
+            ["hash-object", "-w", "--stdin"],
+            input_bytes=content,
+        ).strip().decode("ascii")
+        self._run_git_bytes(
+            repo,
+            ["update-index", "--cacheinfo", mode, object_sha, relative_path],
+        )
+
+    def _sanitize_staged_files(self, repo: 'Repo', repo_path: Path) -> list:
+        """
+        Sanitize staged UTF-8 text blobs directly in the Git index.
+
+        The worktree is never opened or rewritten here. Symbolic links therefore
+        cannot redirect sanitization outside the repository. Binary/non-UTF-8
+        blobs are preserved only when their raw bytes contain no recognized
+        credential pattern; otherwise publication fails closed.
+        """
+        _ = repo_path  # Kept for backward-compatible call sites.
+        sanitized_files = []
+
+        for relative_path in self._staged_paths(repo):
+            mode, raw_content = self._read_staged_blob(repo, relative_path)
+
+            if mode == "160000":
+                continue
+
+            # A symlink's staged blob is only its link target. Inspect that blob,
+            # but never follow or rewrite the filesystem target.
+            if mode == "120000":
+                if contains_sensitive_data_bytes(raw_content):
+                    raise SanitizationError(
+                        f"Recognized credential remains in staged symbolic-link blob {relative_path}"
+                    )
+                continue
+
+            is_binary = b"\0" in raw_content
+            try:
+                text = raw_content.decode("utf-8")
+            except UnicodeDecodeError:
+                text = None
+
+            if is_binary or text is None:
+                if contains_sensitive_data_bytes(raw_content):
+                    raise SanitizationError(
+                        f"Recognized credential found in binary or non-UTF-8 staged file {relative_path}"
+                    )
+                continue
+
+            sanitized = sanitize_text(text)
+            if sanitized != text:
+                self._write_staged_blob(
+                    repo,
+                    relative_path,
+                    mode,
+                    sanitized.encode("utf-8"),
+                )
+                sanitized_files.append(relative_path)
+
+        return sanitized_files
+
+    def _verify_staged_files_sanitized(self, repo: 'Repo') -> None:
+        """Fail if any recognized credential remains in any bounded staged blob."""
+        for relative_path in self._staged_paths(repo):
+            mode, raw_content = self._read_staged_blob(repo, relative_path)
+            if mode == "160000":
+                continue
+            if contains_sensitive_data_bytes(raw_content):
+                raise SanitizationError(
+                    f"Recognized credential remains staged in {relative_path}"
+                )
+
     def _unstage_large_files(self, repo: 'Repo', repo_path: Path) -> list:
         """
-        Check staged files and unstage any exceeding GitHub's 100MB limit.
+        Unstage blobs exceeding GitHub's 100MB limit before reading content.
 
-        Args:
-            repo: GitPython Repo object
-            repo_path: Path to local repository
-
-        Returns:
-            List of (relative_path, size_bytes) tuples for unstaged files
+        Size is taken from the staged Git object, not the working-tree path, so
+        symbolic links are never followed and the publication boundary reflects
+        exactly what would be committed.
         """
+        _ = repo_path  # Kept for backward-compatible call sites.
         large_files = []
 
-        try:
-            # Get list of all staged files (relative paths)
-            staged_output = repo.git.diff('--cached', '--name-only')
-            if not staged_output.strip():
-                return large_files
-
-            staged_files = staged_output.strip().split('\n')
-
-            for filepath in staged_files:
-                filepath = filepath.strip()
-                if not filepath:
-                    continue
-
-                full_path = Path(repo_path) / filepath
-
-                # Skip deleted files (they appear in diff but don't exist on disk)
-                if not full_path.exists():
-                    continue
-
-                file_size = full_path.stat().st_size
-                if file_size > MAX_FILE_SIZE:
-                    # Unstage this file (does not delete it from working directory)
-                    repo.git.reset('--', filepath)
-                    large_files.append((filepath, file_size))
-
-        except Exception as e:
-            print(f"   ⚠️  Error checking staged file sizes: {e}")
+        for relative_path in self._staged_paths(repo):
+            mode, object_sha = self._staged_entry(repo, relative_path)
+            if mode == "160000":
+                continue
+            file_size = self._staged_blob_size(repo, object_sha)
+            if file_size > MAX_FILE_SIZE:
+                try:
+                    repo.git.reset('--', relative_path)
+                except GitCommandError as e:
+                    raise SanitizationError(
+                        f"Could not unstage oversized file {relative_path}: {e}"
+                    ) from e
+                large_files.append((relative_path, file_size))
 
         return large_files
 

--- a/src/core/security.py
+++ b/src/core/security.py
@@ -72,6 +72,8 @@ API_KEY_PATTERNS = [
 
     # Google/Gemini API keys
     (r'AIza[A-Za-z0-9_-]{35,}', '[REDACTED_GOOGLE_KEY]'),
+    (r'ya29\.[A-Za-z0-9_-]{20,}', '[REDACTED_GOOGLE_OAUTH_ACCESS]'),
+    (r'1//0[A-Za-z0-9_-]{20,}', '[REDACTED_GOOGLE_OAUTH_REFRESH]'),
 
     # AWS keys
     (r'AKIA[A-Z0-9]{16}', '[REDACTED_AWS_ACCESS_KEY]'),

--- a/src/core/security.py
+++ b/src/core/security.py
@@ -7,8 +7,8 @@ This module provides:
 3. API key pattern detection and redaction
 """
 
-import re
 import os
+import re
 from typing import Dict, Set, Optional
 from pathlib import Path
 
@@ -90,6 +90,10 @@ _COMPILED_PATTERNS = [(re.compile(pattern), replacement)
                        for pattern, replacement in API_KEY_PATTERNS]
 
 
+class SanitizationError(RuntimeError):
+    """Raised when a security-boundary file cannot be safely inspected."""
+
+
 def sanitize_text(text: str) -> str:
     """
     Sanitize text by redacting API keys and sensitive values.
@@ -106,6 +110,55 @@ def sanitize_text(text: str) -> str:
     return result
 
 
+def contains_sensitive_data(text: str) -> bool:
+    """Return True if text contains a recognized sensitive credential."""
+    return any(pattern.search(text) for pattern, _ in _COMPILED_PATTERNS)
+
+
+def _is_within_git_dir(file_path: Path) -> bool:
+    return ".git" in file_path.parts
+
+
+def sanitize_file(file_path: Path, *, strict: bool = False) -> bool:
+    """
+    Sanitize an arbitrary text file in-place by redacting API keys.
+
+    Binary or non-UTF-8 files are skipped without modification. Missing files
+    are skipped to support deleted staged paths.
+    """
+    file_path = Path(file_path)
+
+    if _is_within_git_dir(file_path) or not file_path.exists() or not file_path.is_file():
+        return False
+
+    try:
+        raw_content = file_path.read_bytes()
+    except Exception as e:
+        if strict:
+            raise SanitizationError(f"Could not read {file_path}: {e}") from e
+        print(f"Warning: Could not sanitize {file_path}: {e}")
+        return False
+
+    try:
+        content = raw_content.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+
+    sanitized = sanitize_text(content)
+    if sanitized == content:
+        return False
+
+    try:
+        file_path.write_text(sanitized, encoding="utf-8")
+    except Exception as e:
+        if strict:
+            raise SanitizationError(f"Could not write sanitized {file_path}: {e}") from e
+        print(f"Warning: Could not sanitize {file_path}: {e}")
+        return False
+
+    return True
+
+
 def sanitize_log_file(file_path: Path) -> bool:
     """
     Sanitize a log file in-place by redacting API keys.
@@ -117,16 +170,7 @@ def sanitize_log_file(file_path: Path) -> bool:
         True if file was modified, False otherwise
     """
     try:
-        with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
-            content = f.read()
-
-        sanitized = sanitize_text(content)
-
-        if sanitized != content:
-            with open(file_path, 'w', encoding='utf-8') as f:
-                f.write(sanitized)
-            return True
-        return False
+        return sanitize_file(file_path, strict=False)
 
     except Exception as e:
         print(f"Warning: Could not sanitize {file_path}: {e}")

--- a/src/core/security.py
+++ b/src/core/security.py
@@ -13,7 +13,6 @@ from typing import Dict, MutableMapping, Set, Optional
 from pathlib import Path
 
 
-
 # These are sensitive credentials that could be echoed in logs
 SENSITIVE_ENV_VARS: Set[str] = {
     # OpenAI
@@ -98,9 +97,16 @@ API_KEY_PATTERNS = [
      r'\1\2=[REDACTED]'),
 ]
 
-# Compile patterns once for performance
+# Compile patterns once for performance. The byte variants let the final Git
+# publication boundary inspect arbitrary staged blobs without a UTF-8 bypass.
 _COMPILED_PATTERNS = [(re.compile(pattern), replacement)
                        for pattern, replacement in API_KEY_PATTERNS]
+_COMPILED_BYTE_PATTERNS = [re.compile(pattern.encode("ascii"))
+                           for pattern, _ in API_KEY_PATTERNS]
+
+
+class SanitizationError(RuntimeError):
+    """Raised when staged content cannot be safely inspected or published."""
 
 
 def sanitize_text(text: str) -> str:
@@ -117,6 +123,16 @@ def sanitize_text(text: str) -> str:
     for pattern, replacement in _COMPILED_PATTERNS:
         result = pattern.sub(replacement, result)
     return result
+
+
+def contains_sensitive_data(text: str) -> bool:
+    """Return True when text contains a recognized credential pattern."""
+    return any(pattern.search(text) for pattern, _ in _COMPILED_PATTERNS)
+
+
+def contains_sensitive_data_bytes(data: bytes) -> bool:
+    """Return True when arbitrary bytes contain a recognized credential."""
+    return any(pattern.search(data) for pattern in _COMPILED_BYTE_PATTERNS)
 
 
 def sanitize_log_file(file_path: Path) -> bool:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,4 +1,13 @@
-from core.security import sanitize_text
+from pathlib import Path
+import sys
+
+import pytest
+from git import Repo
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from core.github_manager import GitHubManager
+from core.security import SanitizationError, sanitize_file, sanitize_text
 
 
 def test_redacts_google_oauth_access_token():
@@ -28,3 +37,154 @@ def test_redacts_google_oauth_tokens_embedded_in_log_text():
 def test_does_not_redact_short_google_oauth_like_strings():
     text = "ya29.short 1//0short"
     assert sanitize_text(text) == text
+
+
+def _fake_openai_project_key() -> str:
+    return "sk-proj-" + "A" * 30
+
+
+def _init_repo(tmp_path: Path) -> Repo:
+    repo = Repo.init(tmp_path)
+    with repo.config_writer() as git_config:
+        git_config.set_value("user", "name", "Test User")
+        git_config.set_value("user", "email", "test@example.com")
+    return repo
+
+
+def _manager() -> GitHubManager:
+    manager = GitHubManager.__new__(GitHubManager)
+    manager.token = "fake-token"
+    return manager
+
+
+def _staged_content(repo: Repo, path: str) -> str:
+    return repo.git.show(f":{path}")
+
+
+def test_sanitize_file_preserves_existing_google_oauth_behavior(tmp_path):
+    token = "ya29." + "A" * 30
+    log_file = tmp_path / "agent.log"
+    log_file.write_text(f"access_token={token}", encoding="utf-8")
+
+    assert sanitize_file(log_file) is True
+
+    sanitized = log_file.read_text(encoding="utf-8")
+    assert token not in sanitized
+    assert "[REDACTED_GOOGLE_OAUTH_ACCESS]" in sanitized
+
+
+def test_staged_file_outside_logs_is_sanitized_and_restaged(tmp_path):
+    repo = _init_repo(tmp_path)
+    secret = _fake_openai_project_key()
+    path = tmp_path / "results" / "debug.txt"
+    path.parent.mkdir()
+    path.write_text(f"token={secret}\n", encoding="utf-8")
+    repo.git.add("results/debug.txt")
+
+    sanitized = _manager()._sanitize_staged_files(repo, tmp_path)
+
+    assert sanitized == ["results/debug.txt"]
+    working_tree = path.read_text(encoding="utf-8")
+    staged = _staged_content(repo, "results/debug.txt")
+    assert secret not in working_tree
+    assert secret not in staged
+    assert "[REDACTED_OPENAI_PROJECT_KEY]" in working_tree
+    assert "[REDACTED_OPENAI_PROJECT_KEY]" in staged
+
+
+def test_stale_index_is_replaced_after_working_tree_sanitization(tmp_path):
+    repo = _init_repo(tmp_path)
+    secret = _fake_openai_project_key()
+    path = tmp_path / "debug.txt"
+    path.write_text(secret, encoding="utf-8")
+    repo.git.add("debug.txt")
+    assert secret in _staged_content(repo, "debug.txt")
+
+    _manager()._sanitize_staged_files(repo, tmp_path)
+
+    staged = _staged_content(repo, "debug.txt")
+    assert secret not in staged
+    assert "[REDACTED_OPENAI_PROJECT_KEY]" in staged
+
+
+def test_commit_boundary_sanitizes_interrupted_agent_artifact_before_commit(tmp_path):
+    repo = _init_repo(tmp_path)
+    bare_remote = tmp_path / "remote.git"
+    Repo.init(bare_remote, bare=True)
+    repo.create_remote("origin", str(bare_remote))
+
+    secret = _fake_openai_project_key()
+    artifact = tmp_path / "agent_trace.json"
+    artifact.write_text(f'{{"token": "{secret}"}}', encoding="utf-8")
+
+    assert _manager().commit_and_push(tmp_path, "commit sanitized artifact") is True
+
+    committed = repo.git.show("HEAD:agent_trace.json")
+    assert secret not in committed
+    assert "[REDACTED_OPENAI_PROJECT_KEY]" in committed
+
+
+def test_text_artifact_outside_old_log_extensions_is_protected(tmp_path):
+    repo = _init_repo(tmp_path)
+    secret = _fake_openai_project_key()
+    path = tmp_path / "generated.py"
+    path.write_text(f'API_KEY = "{secret}"\n', encoding="utf-8")
+    repo.git.add("generated.py")
+
+    _manager()._sanitize_staged_files(repo, tmp_path)
+
+    staged = _staged_content(repo, "generated.py")
+    assert secret not in staged
+    assert "[REDACTED_OPENAI_PROJECT_KEY]" in staged
+
+
+def test_binary_file_is_skipped_and_unchanged(tmp_path):
+    repo = _init_repo(tmp_path)
+    path = tmp_path / "artifact.bin"
+    original = b"\xff\xfe\x00sk-proj-" + (b"A" * 30)
+    path.write_bytes(original)
+    repo.git.add("artifact.bin")
+
+    assert _manager()._sanitize_staged_files(repo, tmp_path) == []
+    _manager()._verify_staged_files_sanitized(repo)
+
+    assert path.read_bytes() == original
+    assert repo.git.show(":artifact.bin", "--binary").encode("latin1", errors="ignore")
+
+
+def test_normal_text_file_is_unchanged(tmp_path):
+    repo = _init_repo(tmp_path)
+    path = tmp_path / "README.md"
+    original = "# Notes\nNo credentials here.\n"
+    path.write_text(original, encoding="utf-8")
+    repo.git.add("README.md")
+
+    assert _manager()._sanitize_staged_files(repo, tmp_path) == []
+
+    assert path.read_text(encoding="utf-8") == original
+    assert _staged_content(repo, "README.md") == original.rstrip("\n")
+
+
+def test_deleted_staged_file_is_ignored_without_crash(tmp_path):
+    repo = _init_repo(tmp_path)
+    path = tmp_path / "old.txt"
+    path.write_text("delete me\n", encoding="utf-8")
+    repo.git.add("old.txt")
+    repo.index.commit("initial")
+
+    path.unlink()
+    repo.git.add(A=True)
+
+    assert _manager()._sanitize_staged_files(repo, tmp_path) == []
+    assert "D\told.txt" in repo.git.diff("--cached", "--name-status")
+
+
+def test_staged_verification_fails_closed_when_secret_remains(tmp_path):
+    repo = _init_repo(tmp_path)
+    secret = _fake_openai_project_key()
+    path = tmp_path / "unsafe.txt"
+    path.write_text(secret, encoding="utf-8")
+    repo.git.add("unsafe.txt")
+
+    with pytest.raises(SanitizationError):
+        _manager()._verify_staged_files_sanitized(repo)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,30 @@
+from core.security import sanitize_text
+
+
+def test_redacts_google_oauth_access_token():
+    token = "ya29." + "A" * 30
+    assert sanitize_text(token) == "[REDACTED_GOOGLE_OAUTH_ACCESS]"
+
+
+def test_redacts_google_oauth_refresh_token():
+    token = "1//0" + "A" * 30
+    assert sanitize_text(token) == "[REDACTED_GOOGLE_OAUTH_REFRESH]"
+
+
+def test_redacts_google_oauth_tokens_embedded_in_log_text():
+    access = "ya29." + "A" * 30
+    refresh = "1//0" + "B" * 30
+
+    text = f"access_token={access} refresh_token={refresh}"
+
+    sanitized = sanitize_text(text)
+
+    assert access not in sanitized
+    assert refresh not in sanitized
+    assert "[REDACTED_GOOGLE_OAUTH_ACCESS]" in sanitized
+    assert "[REDACTED_GOOGLE_OAUTH_REFRESH]" in sanitized
+
+
+def test_does_not_redact_short_google_oauth_like_strings():
+    text = "ya29.short 1//0short"
+    assert sanitize_text(text) == text

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,4 +1,20 @@
-from core.security import sanitize_text
+from pathlib import Path
+import inspect
+import subprocess
+import sys
+
+import pytest
+from git import Repo
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import core.github_manager as github_manager_module
+from core.github_manager import GitHubManager
+from core.security import (
+    SanitizationError,
+    contains_sensitive_data_bytes,
+    sanitize_text,
+)
 
 
 def test_redacts_google_oauth_access_token():
@@ -16,7 +32,6 @@ def test_redacts_google_oauth_tokens_embedded_in_log_text():
     refresh = "1//0" + "B" * 30
 
     text = f"access_token={access} refresh_token={refresh}"
-
     sanitized = sanitize_text(text)
 
     assert access not in sanitized
@@ -28,3 +43,187 @@ def test_redacts_google_oauth_tokens_embedded_in_log_text():
 def test_does_not_redact_short_google_oauth_like_strings():
     text = "ya29.short 1//0short"
     assert sanitize_text(text) == text
+
+
+def _fake_openai_project_key() -> str:
+    return "sk-proj-" + "A" * 30
+
+
+def _init_repo(tmp_path: Path) -> Repo:
+    repo = Repo.init(tmp_path)
+    with repo.config_writer() as git_config:
+        git_config.set_value("user", "name", "Test User")
+        git_config.set_value("user", "email", "test@example.com")
+
+    seed = tmp_path / "seed.txt"
+    seed.write_text("seed\n", encoding="utf-8")
+    repo.git.add("seed.txt")
+    repo.index.commit("initial")
+    return repo
+
+
+def _manager() -> GitHubManager:
+    manager = GitHubManager.__new__(GitHubManager)
+    manager.token = "fake-token"
+    return manager
+
+
+def _staged_bytes(repo: Repo, path: str) -> bytes:
+    return subprocess.run(
+        ["git", "show", f":{path}"],
+        cwd=repo.working_tree_dir,
+        capture_output=True,
+        check=True,
+    ).stdout
+
+
+def test_staged_text_is_sanitized_in_index_without_touching_worktree(tmp_path):
+    repo = _init_repo(tmp_path)
+    secret = _fake_openai_project_key()
+    path = tmp_path / "results" / "debug.txt"
+    path.parent.mkdir()
+    path.write_text(f"token={secret}\n", encoding="utf-8")
+    repo.git.add("results/debug.txt")
+
+    sanitized = _manager()._sanitize_staged_files(repo, tmp_path)
+
+    assert sanitized == ["results/debug.txt"]
+    assert secret in path.read_text(encoding="utf-8")
+    staged = _staged_bytes(repo, "results/debug.txt").decode("utf-8")
+    assert secret not in staged
+    assert "[REDACTED_OPENAI_PROJECT_KEY]" in staged
+    _manager()._verify_staged_files_sanitized(repo)
+
+
+def test_text_artifact_outside_old_log_extensions_is_protected(tmp_path):
+    repo = _init_repo(tmp_path)
+    secret = _fake_openai_project_key()
+    path = tmp_path / "generated.py"
+    path.write_text(f'API_KEY = "{secret}"\n', encoding="utf-8")
+    repo.git.add("generated.py")
+
+    _manager()._sanitize_staged_files(repo, tmp_path)
+
+    staged = _staged_bytes(repo, "generated.py").decode("utf-8")
+    assert secret not in staged
+    assert "[REDACTED_OPENAI_PROJECT_KEY]" in staged
+
+
+def test_staged_verification_fails_closed_when_secret_remains(tmp_path):
+    repo = _init_repo(tmp_path)
+    secret = _fake_openai_project_key()
+    path = tmp_path / "unsafe.txt"
+    path.write_text(secret, encoding="utf-8")
+    repo.git.add("unsafe.txt")
+
+    with pytest.raises(SanitizationError):
+        _manager()._verify_staged_files_sanitized(repo)
+
+
+def test_non_utf8_binary_secret_is_rejected(tmp_path):
+    repo = _init_repo(tmp_path)
+    path = tmp_path / "artifact.bin"
+    original = b"\xff\xfe\x00sk-proj-" + (b"A" * 30)
+    path.write_bytes(original)
+    repo.git.add("artifact.bin")
+
+    assert contains_sensitive_data_bytes(original)
+    with pytest.raises(SanitizationError):
+        _manager()._sanitize_staged_files(repo, tmp_path)
+
+    assert path.read_bytes() == original
+    assert _staged_bytes(repo, "artifact.bin") == original
+
+
+def test_non_utf8_binary_without_secret_is_preserved(tmp_path):
+    repo = _init_repo(tmp_path)
+    path = tmp_path / "artifact.bin"
+    original = b"\xff\xfe\x00\x01ordinary-binary"
+    path.write_bytes(original)
+    repo.git.add("artifact.bin")
+
+    assert _manager()._sanitize_staged_files(repo, tmp_path) == []
+    _manager()._verify_staged_files_sanitized(repo)
+
+    assert path.read_bytes() == original
+    assert _staged_bytes(repo, "artifact.bin") == original
+
+
+def test_symlink_target_outside_repo_is_not_followed_or_modified(tmp_path):
+    repo = _init_repo(tmp_path)
+    secret = _fake_openai_project_key()
+    outside = tmp_path.parent / f"{tmp_path.name}-outside-secret.txt"
+    outside.write_text(secret, encoding="utf-8")
+    link = tmp_path / "external-link"
+
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are unavailable in this environment")
+
+    repo.git.add("external-link")
+    assert _manager()._sanitize_staged_files(repo, tmp_path) == []
+    _manager()._verify_staged_files_sanitized(repo)
+
+    assert outside.read_text(encoding="utf-8") == secret
+    mode, _ = _manager()._staged_entry(repo, "external-link")
+    assert mode == "120000"
+
+
+def test_credential_inside_staged_symlink_blob_is_rejected(tmp_path):
+    repo = _init_repo(tmp_path)
+    secret = _fake_openai_project_key().encode("ascii")
+    blob_sha = subprocess.run(
+        ["git", "hash-object", "-w", "--stdin"],
+        cwd=repo.working_tree_dir,
+        input=secret,
+        capture_output=True,
+        check=True,
+    ).stdout.strip().decode("ascii")
+    subprocess.run(
+        ["git", "update-index", "--add", "--cacheinfo", "120000", blob_sha, "secret-link"],
+        cwd=repo.working_tree_dir,
+        check=True,
+    )
+
+    with pytest.raises(SanitizationError):
+        _manager()._sanitize_staged_files(repo, tmp_path)
+
+
+def test_oversized_blob_is_unstaged_before_sanitizer_can_read_it(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    path = tmp_path / "large.bin"
+    path.write_bytes(b"x" * 32)
+    repo.git.add("large.bin")
+
+    monkeypatch.setattr(github_manager_module, "MAX_FILE_SIZE", 8)
+    manager = _manager()
+    large_files = manager._unstage_large_files(repo, tmp_path)
+
+    assert large_files == [("large.bin", 32)]
+    assert "large.bin" not in manager._staged_paths(repo)
+
+    def forbidden_read(*args, **kwargs):
+        raise AssertionError("sanitizer attempted to read an unstaged oversized blob")
+
+    monkeypatch.setattr(manager, "_read_staged_blob", forbidden_read)
+    assert manager._sanitize_staged_files(repo, tmp_path) == []
+
+
+def test_deleted_staged_file_is_ignored_without_crash(tmp_path):
+    repo = _init_repo(tmp_path)
+    path = tmp_path / "old.txt"
+    path.write_text("delete me\n", encoding="utf-8")
+    repo.git.add("old.txt")
+    repo.index.commit("add old file")
+
+    path.unlink()
+    repo.git.add(A=True)
+
+    assert _manager()._sanitize_staged_files(repo, tmp_path) == []
+    assert "D\told.txt" in repo.git.diff("--cached", "--name-status")
+
+
+def test_push_if_clean_api_is_preserved_after_rebase():
+    parameter = inspect.signature(GitHubManager.commit_and_push).parameters["push_if_clean"]
+    assert parameter.default is False


### PR DESCRIPTION
## Summary

- sanitize staged textual artifacts at the GitHub commit boundary
- re-stage sanitized files so stale secrets cannot remain in the Git index
- verify staged blobs before commit and fail closed if recognized credentials remain
- preserve binary files and safely handle staged deletions

Closes #153.

## Dependency

Depends on #169.

The first commit in this branch (`90d67f5`) is already under review in #169.
The new change introduced by this PR is `6fe92e0`.

Once #169 is merged, I will rebase this branch onto the updated `main` so this PR contains only the #153 change.

## Why

Previously, sanitization only covered selected files under `logs/` before `git add`.
Secrets written to other artifacts could therefore enter the Git index.

Also, sanitizing only the working-tree file after staging is insufficient because the Git index may still retain the original secret-containing blob.

The new boundary is:

agent artifacts
→ git staging
→ staged-file sanitization
→ re-stage sanitized files
→ staged-content verification
→ commit
→ push

## Testing

- `python -m pytest -q tests/test_security.py` — 13 passed
- `python -m py_compile src/core/security.py src/core/github_manager.py tests/test_security.py` — passed
- manual local Git acceptance test — fake secret absent from working tree, Git index, and committed blob

Full `tests/`: 178 passed, 3 unrelated existing Windows path assertion failures.