### PR TITLE
fix(autoresearch): Correct GitHub storage and publication behavior

### DIFF
--- a/src/cli/fetch_from_ideahub.py
+++ b/src/cli/fetch_from_ideahub.py
@@ -657,6 +657,7 @@ def main():
                 idea['idea']['metadata'] = idea['idea'].get('metadata', {})
                 idea['idea']['metadata']['github_repo_name'] = repo_name
                 idea['idea']['metadata']['github_repo_url'] = github_repo_url
+                idea['idea']['metadata']['github_repo_private'] = repo_info['private']
 
                 # Save updated metadata
                 idea_path = manager.ideas_dir / "submitted" / f"{idea_id}.yaml"

--- a/src/cli/hitl_launcher.py
+++ b/src/cli/hitl_launcher.py
@@ -43,9 +43,6 @@ def workspace_for_idea(project_root: Path, idea_id: str) -> Path:
     local_workspace = str(metadata.get("local_workspace", "")).strip()
     if local_workspace:
         candidates.append(Path(local_workspace).expanduser())
-    repository_name = str(metadata.get("github_repo_name", "")).strip()
-    if repository_name:
-        candidates.append(workspace_root / repository_name)
     candidates.append(workspace_root / idea_id)
 
     for candidate in candidates:

--- a/src/cli/hitl_run_worker.py
+++ b/src/cli/hitl_run_worker.py
@@ -276,6 +276,7 @@ def main() -> int:
                 hitl_launch_status_path(Path(str(request["work_dir"]))),
                 {
                     "status": "failed",
+                    "request_id": request.get("request_id", ""),
                     "failed_at": failed_at,
                     "updated_at": failed_at,
                     "mode": request.get("mode", ""),

--- a/src/cli/hitl_run_worker.py
+++ b/src/cli/hitl_run_worker.py
@@ -258,8 +258,6 @@ def main() -> int:
             completed_status,
         )
         control.clear()
-        if isinstance(publication, dict) and publication.get("status") == "failed":
-            return 1
         return 0
     except HitlRunStopRequested:
         if request.get("work_dir") and control is not None:

--- a/src/cli/hitl_run_worker.py
+++ b/src/cli/hitl_run_worker.py
@@ -233,21 +233,27 @@ def main() -> int:
                 control=control,
             )
         finished_at = utc_now()
+        publication = result.get("github_publication")
+        completed_status: Dict[str, Any] = {
+            "status": "completed",
+            "request_id": request["request_id"],
+            "started_at": started_at,
+            "completed_at": finished_at,
+            "updated_at": finished_at,
+            "mode": request["mode"],
+            "hitl_mode": hitl_mode,
+            "provider": request["provider"],
+            "success": bool(result.get("success", False)),
+        }
+        if isinstance(publication, dict):
+            completed_status["github_publication"] = publication
         atomic_write_json(
             hitl_launch_status_path(work_dir),
-            {
-                "status": "completed",
-                "request_id": request["request_id"],
-                "started_at": started_at,
-                "completed_at": finished_at,
-                "updated_at": finished_at,
-                "mode": request["mode"],
-                "hitl_mode": hitl_mode,
-                "provider": request["provider"],
-                "success": bool(result.get("success", False)),
-            },
+            completed_status,
         )
         control.clear()
+        if isinstance(publication, dict) and publication.get("status") == "failed":
+            return 1
         return 0
     except HitlRunStopRequested:
         if request.get("work_dir") and control is not None:

--- a/src/cli/hitl_run_worker.py
+++ b/src/cli/hitl_run_worker.py
@@ -35,6 +35,18 @@ _REQUEST_NAME = re.compile(
 )
 
 
+def _load_project_environment(project_root: Path) -> None:
+    """Load the same project environment used by the ordinary runner CLI."""
+    from dotenv import load_dotenv
+
+    env_local = project_root / ".env.local"
+    env_file = project_root / ".env"
+    if env_local.exists():
+        load_dotenv(env_local, override=False)
+    elif env_file.exists():
+        load_dotenv(env_file, override=False)
+
+
 def _claim_request(path: Path) -> Path:
     expected_parent = hitl_launch_requests_dir(ConfigLoader().get_workspace_parent_dir()).resolve()
     path = path.resolve()
@@ -162,6 +174,7 @@ def main() -> int:
         hitl_mode = normalize_hitl_mode(request.get("hitl_mode")).value
         request["hitl_mode"] = hitl_mode
         project_root = PROJECT_ROOT.resolve()
+        _load_project_environment(project_root)
         request_id = str(request["request_id"])
         control = HitlRunStopControl(work_dir, request_id)
         os.environ["NEURICO_HITL_REQUEST_ID"] = request_id
@@ -194,9 +207,12 @@ def main() -> int:
             )
             with log_path.open("a", encoding="utf-8") as output:
                 with redirect_stdout(output), redirect_stderr(output):
+                    github_requested = bool(request.get("github", False))
                     result = ResearchRunner(
                         project_root=project_root,
-                        use_github=bool(request.get("github", False)),
+                        use_github=github_requested,
+                        github_org=os.getenv("GITHUB_ORG", ""),
+                        github_required=github_requested,
                     ).run_research(
                         str(request["idea_id"]),
                         provider=str(request["provider"]),

--- a/src/cli/hitl_run_worker.py
+++ b/src/cli/hitl_run_worker.py
@@ -208,6 +208,7 @@ def main() -> int:
                             str(request["interface"]) if continuation else None
                         ),
                         hitl_mode=hitl_mode,
+                        hitl_work_dir=work_dir,
                     )
         if control.requested() and not bool(result.get("success", False)):
             return _finalize_stopped_run(

--- a/src/cli/hitl_run_worker.py
+++ b/src/cli/hitl_run_worker.py
@@ -25,6 +25,7 @@ from core.hitl_run_control import (  # noqa: E402
     activate_hitl_run_stop_control,
 )
 from core.hitl_util import atomic_write_json, utc_now  # noqa: E402
+from core.security import remove_github_credentials  # noqa: E402
 from core.runner import ResearchRunner  # noqa: E402
 from cli.hitl_launcher import workspace_for_idea  # noqa: E402
 
@@ -208,12 +209,17 @@ def main() -> int:
             with log_path.open("a", encoding="utf-8") as output:
                 with redirect_stdout(output), redirect_stderr(output):
                     github_requested = bool(request.get("github", False))
-                    result = ResearchRunner(
+                    runner = ResearchRunner(
                         project_root=project_root,
                         use_github=github_requested,
                         github_org=os.getenv("GITHUB_ORG", ""),
                         github_required=github_requested,
-                    ).run_research(
+                    )
+                    # The runtime-owned GitHub manager has captured its
+                    # credential. Everything launched by this dedicated run
+                    # process inherits the credential-free environment below.
+                    remove_github_credentials(os.environ)
+                    result = runner.run_research(
                         str(request["idea_id"]),
                         provider=str(request["provider"]),
                         write_paper=bool(request.get("write_paper", False)),

--- a/src/cli/hitl_web_portal.py
+++ b/src/cli/hitl_web_portal.py
@@ -189,9 +189,6 @@ class HitlWebWorkspaceRegistry:
         local = str(metadata.get("local_workspace", "")).strip()
         if local:
             return Path(local).expanduser()
-        repository = str(metadata.get("github_repo_name", "")).strip()
-        if repository:
-            return self.workspace_root / repository
         return self.workspace_root / idea_id
 
     def catalog(self) -> Dict[str, Any]:

--- a/src/cli/submit.py
+++ b/src/cli/submit.py
@@ -160,6 +160,7 @@ def main():
                     idea['idea']['metadata'] = idea['idea'].get('metadata', {})
                     idea['idea']['metadata']['github_repo_name'] = repo_name
                     idea['idea']['metadata']['github_repo_url'] = github_repo_url
+                    idea['idea']['metadata']['github_repo_private'] = repo_info['private']
 
                     # Save updated metadata
                     idea_path = manager.ideas_dir / "submitted" / f"{idea_id}.yaml"

--- a/src/cli/submit_local.py
+++ b/src/cli/submit_local.py
@@ -688,6 +688,7 @@ def main():
                 idea['idea']['metadata'] = idea['idea'].get('metadata', {})
                 idea['idea']['metadata']['github_repo_name'] = repo_name
                 idea['idea']['metadata']['github_repo_url'] = github_repo_url
+                idea['idea']['metadata']['github_repo_private'] = repo_info['private']
 
                 # Save updated metadata
                 idea_path = manager.ideas_dir / "submitted" / f"{idea_id}.yaml"

--- a/src/core/agent_cli.py
+++ b/src/core/agent_cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 from typing import Mapping, Optional
 
+from core.security import remove_github_credentials
+
 
 CLI_COMMANDS = {
     "claude": "claude -p",
@@ -66,6 +68,7 @@ def build_agent_environment(
         env.update({str(key): str(value) for key, value in env_extra.items()})
     if provider == "gemini":
         env["GEMINI_CLI_IDE_DISABLE"] = "1"
+    remove_github_credentials(env)
     return env
 
 

--- a/src/core/agent_runner.py
+++ b/src/core/agent_runner.py
@@ -42,7 +42,7 @@ from core.agent_cli import (
     build_agent_command,
     build_agent_environment,
 )
-from core.security import sanitize_text
+from core.security import remove_github_credentials, sanitize_text
 from core.hitl_util import utc_now
 
 
@@ -248,6 +248,8 @@ def run_prebuilt_cli_agent(
     stopped = False
     background_processes_terminated = False
     return_code: Optional[int] = None
+    process_env = dict(env)
+    remove_github_credentials(process_env)
 
     with (
         open(log_file, "w", encoding="utf-8") as log_f,
@@ -259,7 +261,7 @@ def run_prebuilt_cli_agent(
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                env=env,
+                env=process_env,
                 text=True,
                 encoding="utf-8",
                 bufsize=1,

--- a/src/core/github_manager.py
+++ b/src/core/github_manager.py
@@ -123,7 +123,8 @@ class GitHubManager:
                            domain: Optional[str] = None,
                            provider: Optional[str] = None,
                            no_hash: bool = False,
-                           hypothesis: Optional[str] = None) -> Dict[str, Any]:
+                           hypothesis: Optional[str] = None,
+                           auto_init: bool = True) -> Dict[str, Any]:
         """
         Create a new repository in the organization for research.
 
@@ -136,6 +137,8 @@ class GitHubManager:
             provider: AI provider (claude, gemini, codex)
             no_hash: If True, skip random hash in repo name (use when only one person runs the idea)
             hypothesis: Research hypothesis (fallback for naming when the title is unusable)
+            auto_init: Whether GitHub should create an initial commit. Disable when
+                attaching an existing local workspace to the new repository.
 
         Returns:
             Dictionary with repo information:
@@ -166,16 +169,18 @@ class GitHubManager:
         print(f"   Visibility: {'Private' if private else 'Public'}")
 
         try:
-            # auto_init=True creates an initial commit with README, ensuring the
-            # 'main' branch exists. The agent will overwrite README.md later.
-            # gitignore_template="Python" adds a Python .gitignore in that initial commit.
-            repo = self.owner.create_repo(
+            create_options = dict(
                 name=repo_name,
                 description=description,
                 private=private,
-                auto_init=True,
-                gitignore_template="Python",
+                auto_init=auto_init,
             )
+            # A gitignore template requires GitHub to create an initial commit.
+            # Existing HITL workspaces instead attach to an empty remote so their
+            # established history remains authoritative.
+            if auto_init:
+                create_options["gitignore_template"] = "Python"
+            repo = self.owner.create_repo(**create_options)
 
             print(f"✅ Repository created: {repo.html_url}")
 
@@ -211,6 +216,31 @@ class GitHubManager:
                 error_msg += f"  Status: {e.status}\n"
                 error_msg += f"  Message: {e.data if hasattr(e, 'data') else 'N/A'}"
                 raise RuntimeError(error_msg)
+
+    def attach_remote(self, repo_path: Path, clone_url: str) -> None:
+        """Attach a GitHub remote to an existing repository without fetching it."""
+        if not GITPYTHON_AVAILABLE:
+            raise ImportError("GitPython is required. Install with: pip install GitPython")
+
+        repo = Repo(repo_path)
+        try:
+            origin = repo.remote("origin")
+        except ValueError:
+            repo.create_remote("origin", clone_url)
+        else:
+            origin.set_url(clone_url)
+
+    def get_research_repo(self, repo_name: str) -> Dict[str, Any]:
+        """Return repository metadata without cloning or fetching its contents."""
+        repo = self.owner.get_repo(repo_name)
+        return {
+            "repo_name": repo_name,
+            "repo_url": repo.html_url,
+            "clone_url": repo.clone_url,
+            "ssh_url": repo.ssh_url,
+            "local_path": self.workspace_dir / repo_name,
+            "repo_object": repo,
+        }
 
     def clone_repo(self, clone_url: str, local_path: Path) -> 'Repo':
         """
@@ -250,7 +280,8 @@ class GitHubManager:
     def commit_and_push(self,
                        repo_path: Path,
                        commit_message: str,
-                       branch: str = "main") -> bool:
+                       branch: str = "main",
+                       push_if_clean: bool = False) -> bool:
         """
         Commit all changes and push to GitHub.
 
@@ -258,6 +289,9 @@ class GitHubManager:
             repo_path: Path to local repository
             commit_message: Commit message
             branch: Branch name (default: main)
+            push_if_clean: Push the existing HEAD even when there is no new
+                commit. Used when publishing an independently checkpointed
+                HITL workspace.
 
         Returns:
             True if successful
@@ -298,12 +332,16 @@ class GitHubManager:
                 print(f"   ⚠️  {len(large_files)} file(s) excluded from commit due to GitHub's 100MB file size limit.")
                 print(f"      These files remain in your local workspace but are not pushed to GitHub.")
 
-            # Check if there are changes to commit
-            if repo.is_dirty(untracked_files=True):
+            # Check if there are changes to commit. HITL checkpoints may have
+            # already committed the complete workspace, but that existing HEAD
+            # still needs to reach its external storage remote.
+            has_changes = repo.is_dirty(untracked_files=True)
+            if has_changes:
                 # Commit
                 repo.index.commit(commit_message)
                 print(f"   ✓ Committed: {commit_message}")
 
+            if has_changes or push_if_clean:
                 # Configure remote with authentication
                 origin = repo.remote('origin')
                 origin_url = list(repo.remote('origin').urls)[0]

--- a/src/core/github_manager.py
+++ b/src/core/github_manager.py
@@ -47,7 +47,8 @@ class GitHubManager:
     def __init__(self,
                  org_name: Optional[str] = None,
                  token: Optional[str] = None,
-                 workspace_dir: Optional[Path] = None):
+                 workspace_dir: Optional[Path] = None,
+                 require_org: bool = False):
         """
         Initialize GitHub manager.
 
@@ -55,8 +56,11 @@ class GitHubManager:
             org_name: GitHub organization name. If None/empty, uses personal account.
             token: GitHub personal access token. If None, reads from GITHUB_TOKEN env var.
             workspace_dir: Directory for cloning repos (default: project_root/workspace)
+            require_org: Fail instead of falling back to the personal account
+                when an explicitly configured organization is inaccessible.
         """
         self.org_name = org_name or None  # Normalize empty string to None
+        self.require_org = require_org
 
         # Get token from parameter or environment
         self.token = token or os.getenv('GITHUB_TOKEN')
@@ -98,6 +102,11 @@ class GitHubManager:
                 self.owner_name = self.org_name
                 print(f"✓ Connected to GitHub organization: {self.org_name}")
             except GithubException as e:
+                if self.require_org:
+                    raise ValueError(
+                        f"Failed to access configured GitHub organization "
+                        f"'{self.org_name}': {e}"
+                    ) from e
                 print(f"⚠️  Cannot access organization '{self.org_name}': {e}")
                 print(f"   Falling back to your personal GitHub account...")
                 self._setup_personal_account()

--- a/src/core/github_manager.py
+++ b/src/core/github_manager.py
@@ -10,6 +10,7 @@ This module manages:
 
 from pathlib import Path
 from typing import Optional, Dict, Any
+import base64
 import os
 import subprocess
 import shlex
@@ -356,14 +357,23 @@ class GitHubManager:
                 origin = repo.remote('origin')
                 origin_url = list(repo.remote('origin').urls)[0]
 
-                # Inject token for push
-                if 'https://' in origin_url and self.token not in origin_url:
-                    auth_url = origin_url.replace('https://', f'https://{self.token}@')
-                    origin.set_url(auth_url)
+                # Authenticate only the Git process. Never persist a token in
+                # the workspace's remote URL where a later agent could read it.
+                git_environment = {"GIT_TERMINAL_PROMPT": "0"}
+                if origin_url.startswith("https://"):
+                    basic_auth = base64.b64encode(
+                        f"x-access-token:{self.token}".encode("utf-8")
+                    ).decode("ascii")
+                    git_environment.update(
+                        GIT_CONFIG_COUNT="1",
+                        GIT_CONFIG_KEY_0="http.extraHeader",
+                        GIT_CONFIG_VALUE_0=f"Authorization: Basic {basic_auth}",
+                    )
 
                 # Push using refspec HEAD:refs/heads/{branch} so it works even if
                 # the local branch name differs (e.g., "master" vs "main" on older git)
-                push_results = origin.push(f"HEAD:refs/heads/{branch}")
+                with repo.git.custom_environment(**git_environment):
+                    push_results = origin.push(f"HEAD:refs/heads/{branch}")
                 if not push_results:
                     raise RuntimeError("GitHub push returned no status.")
 

--- a/src/core/github_manager.py
+++ b/src/core/github_manager.py
@@ -135,7 +135,8 @@ class GitHubManager:
                            provider: Optional[str] = None,
                            no_hash: bool = False,
                            hypothesis: Optional[str] = None,
-                           auto_init: bool = True) -> Dict[str, Any]:
+                           auto_init: bool = True,
+                           exact_repo_name: Optional[str] = None) -> Dict[str, Any]:
         """
         Create a new repository in the organization for research.
 
@@ -150,6 +151,8 @@ class GitHubManager:
             hypothesis: Research hypothesis (fallback for naming when the title is unusable)
             auto_init: Whether GitHub should create an initial commit. Disable when
                 attaching an existing local workspace to the new repository.
+            exact_repo_name: Reuse this exact name instead of generating one. Used
+                only when restoring a previously recorded publication destination.
 
         Returns:
             Dictionary with repo information:
@@ -158,9 +161,17 @@ class GitHubManager:
             - clone_url: URL for cloning
             - local_path: Local path where repo will be cloned
         """
-        # Generate a concise repo name mechanically from the idea content
-        repo_name = self._generate_repo_name(title, domain, idea_id, provider=provider,
-                                             no_hash=no_hash, hypothesis=hypothesis)
+        # First-time repositories receive the established generated name. A
+        # deleted publication destination must instead be reconstructed with
+        # its exact recorded name.
+        repo_name = exact_repo_name or self._generate_repo_name(
+            title,
+            domain,
+            idea_id,
+            provider=provider,
+            no_hash=no_hash,
+            hypothesis=hypothesis,
+        )
 
         # Create description (must be single line, no newlines allowed by GitHub)
         if description is None:
@@ -205,7 +216,8 @@ class GitHubManager:
                 'clone_url': repo.clone_url,
                 'ssh_url': repo.ssh_url,
                 'local_path': self.workspace_dir / repo_name,
-                'repo_object': repo
+                'repo_object': repo,
+                'private': bool(repo.private),
             }
 
         except GithubException as e:
@@ -219,7 +231,8 @@ class GitHubManager:
                     'clone_url': repo.clone_url,
                     'ssh_url': repo.ssh_url,
                     'local_path': self.workspace_dir / repo_name,
-                    'repo_object': repo
+                    'repo_object': repo,
+                    'private': bool(repo.private),
                 }
             else:
                 # Provide detailed error information
@@ -251,6 +264,7 @@ class GitHubManager:
             "ssh_url": repo.ssh_url,
             "local_path": self.workspace_dir / repo_name,
             "repo_object": repo,
+            "private": bool(repo.private),
         }
 
     def clone_repo(self, clone_url: str, local_path: Path) -> 'Repo':

--- a/src/core/github_manager.py
+++ b/src/core/github_manager.py
@@ -26,6 +26,7 @@ except ImportError:
 
 try:
     from git import Repo, GitCommandError
+    from git.remote import PushInfo
     GITPYTHON_AVAILABLE = True
 except ImportError:
     GITPYTHON_AVAILABLE = False
@@ -362,7 +363,26 @@ class GitHubManager:
 
                 # Push using refspec HEAD:refs/heads/{branch} so it works even if
                 # the local branch name differs (e.g., "master" vs "main" on older git)
-                origin.push(f"HEAD:refs/heads/{branch}")
+                push_results = origin.push(f"HEAD:refs/heads/{branch}")
+                if not push_results:
+                    raise RuntimeError("GitHub push returned no status.")
+
+                failure_flags = (
+                    PushInfo.ERROR
+                    | PushInfo.REJECTED
+                    | PushInfo.REMOTE_REJECTED
+                    | PushInfo.REMOTE_FAILURE
+                    | PushInfo.NO_MATCH
+                )
+                failures = [
+                    result for result in push_results if result.flags & failure_flags
+                ]
+                if failures:
+                    details = "; ".join(
+                        str(result.summary).strip() or "GitHub rejected the push."
+                        for result in failures
+                    )
+                    raise RuntimeError(f"GitHub push failed: {details}")
                 print(f"   ✓ Pushed to {branch}")
 
                 return True

--- a/src/core/hitl_workspace_view.py
+++ b/src/core/hitl_workspace_view.py
@@ -71,9 +71,10 @@ class HitlWorkspaceView:
         whiteboard = self._whiteboard()
         research = self._research_state()
         runtime = self._runtime_state()
+        launch_status = self._launch_status()
         inbox = self._inbox(runtime)
         conversation = self._conversation(inbox)
-        notifications = self._notifications(runtime, ideas)
+        notifications = self._notifications(runtime, ideas, launch_status)
         return {
             "workspace": self.work_dir.name,
             "autoresearch": self._autoresearch_status(),
@@ -104,7 +105,7 @@ class HitlWorkspaceView:
     def notifications(self) -> List[Dict[str, Any]]:
         """Return the shared, user-facing projection of durable interface events."""
         runtime = self._runtime_state()
-        return self._notifications(runtime, self._ideas())
+        return self._notifications(runtime, self._ideas(), self._launch_status())
 
     def interface_projection(self) -> Dict[str, Any]:
         """Return cached live status and notifications for passive UI refreshes."""
@@ -134,7 +135,11 @@ class HitlWorkspaceView:
             self._idea_revision = idea_revision
         projection = {
             "live": self._live_status(runtime, owner=owner, owner_checked=True),
-            "notifications": self._notifications(runtime, self._projected_ideas),
+            "notifications": self._notifications(
+                runtime,
+                self._projected_ideas,
+                self._launch_status(),
+            ),
         }
         self._interface_revision = revision
         self._interface_projection = projection
@@ -899,14 +904,36 @@ class HitlWorkspaceView:
             "summary": summaries.get(outcome, "Response recorded. Research continues."),
         }
 
+    def _launch_failure_notification(
+        self,
+        launch_status: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        if str(launch_status.get("status", "")).strip() != "failed":
+            return None
+        created_at = str(
+            launch_status.get("failed_at") or launch_status.get("updated_at") or ""
+        ).strip()
+        request_id = str(launch_status.get("request_id", "")).strip()
+        return {
+            "id": f"launch_failed:{request_id or created_at}",
+            "kind": "run",
+            "created_at": created_at,
+            "tone": "error",
+            "title": "Research could not start",
+            "summary": self._compact_notification_text(
+                launch_status.get("message") or "Research could not start."
+            ),
+        }
+
     def _notifications(
         self,
         runtime: Dict[str, Any],
         ideas: List[Dict[str, Any]],
+        launch_status: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
         events = runtime.get("interface_events", [])
         if not isinstance(events, list):
-            return []
+            events = []
         ideas_by_id = {str(idea.get("idea_id", "")): idea for idea in ideas}
         projected: List[Dict[str, Any]] = []
         last_phase_signature: Optional[tuple[str, str]] = None
@@ -957,6 +984,9 @@ class HitlWorkspaceView:
             elif event.get("kind") == "request_resolved":
                 if bool(event.get("human_involved")):
                     projected.append(self._request_notification(event))
+        launch_notification = self._launch_failure_notification(launch_status or {})
+        if launch_notification is not None:
+            projected.append(launch_notification)
         return sorted(projected, key=lambda item: str(item.get("created_at", "")))
 
     def _ideas(self) -> List[Dict[str, Any]]:

--- a/src/core/hitl_workspace_view.py
+++ b/src/core/hitl_workspace_view.py
@@ -386,6 +386,10 @@ class HitlWorkspaceView:
         continuation_status = str(continuation.get("status", "")).strip()
         launch_status = self._launch_status()
         launch_state = str(launch_status.get("status", "")).strip()
+        github_publication = launch_status.get("github_publication")
+        github_publication = (
+            github_publication if isinstance(github_publication, dict) else {}
+        )
         launch_request_id = str(launch_status.get("request_id", "")).strip()
         launch_updated_at = self._parse_timestamp(
             launch_status.get("updated_at") or launch_status.get("created_at")
@@ -512,6 +516,24 @@ class HitlWorkspaceView:
                     active=False,
                     display_stage="Start failed",
                     display_phase="",
+                )
+            if (
+                launch_state == "completed"
+                and github_publication.get("status") == "failed"
+            ):
+                publication_error = str(github_publication.get("message", "")).strip()
+                detail = "Research completed locally, but GitHub publication failed."
+                if publication_error:
+                    detail = f"{detail} {publication_error}"
+                return projected(
+                    "publication_failed",
+                    "GitHub publication failed",
+                    detail,
+                    next_step="Fix the GitHub issue, then publish the saved checkpoint again.",
+                    record=launch_status,
+                    active=False,
+                    display_stage="Complete",
+                    display_phase="GitHub publication failed",
                 )
             if has_pending_work:
                 if unresolved:

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -19,6 +19,7 @@ import shlex
 import sys
 import os
 import yaml
+from urllib.parse import urlparse
 
 # Force UTF-8 stdout/stderr on Windows where the default is cp1252.
 # Claude CLI output contains Unicode characters that cp1252 cannot represent,
@@ -63,6 +64,51 @@ try:
     GITHUB_AVAILABLE = True
 except ImportError:
     GITHUB_AVAILABLE = False
+
+
+def _recorded_github_repository(metadata: Dict[str, Any]) -> Optional[tuple[str, str]]:
+    """Return the exact owner/name encoded by a recorded GitHub URL."""
+    repo_url = str(metadata.get("github_repo_url", "")).strip()
+    if not repo_url:
+        return None
+    parsed = urlparse(repo_url)
+    if parsed.scheme != "https" or parsed.netloc.casefold() not in {
+        "github.com",
+        "www.github.com",
+    }:
+        raise RuntimeError("The recorded GitHub repository URL is invalid.")
+    parts = [part for part in parsed.path.strip("/").split("/") if part]
+    if len(parts) != 2:
+        raise RuntimeError("The recorded GitHub repository URL is invalid.")
+    owner, url_name = parts
+    if url_name.endswith(".git"):
+        url_name = url_name[:-4]
+    recorded_name = str(metadata.get("github_repo_name", "")).strip()
+    if recorded_name and recorded_name.casefold() != url_name.casefold():
+        raise RuntimeError(
+            "The recorded GitHub repository name does not match its URL."
+        )
+    return owner, url_name
+
+
+def _github_repository_private(repo_info: Dict[str, Any]) -> bool:
+    """Return GitHub's actual visibility from one resolved repository."""
+    private = repo_info.get("private")
+    if not isinstance(private, bool):
+        repo = repo_info.get("repo_object")
+        private = getattr(repo, "private", None)
+    if not isinstance(private, bool):
+        raise RuntimeError("GitHub did not report the repository visibility.")
+    return private
+
+
+def _record_github_repository(
+    metadata: Dict[str, Any], repo_info: Dict[str, Any]
+) -> None:
+    """Persist the complete publication destination returned by GitHub."""
+    metadata["github_repo_name"] = repo_info["repo_name"]
+    metadata["github_repo_url"] = repo_info["repo_url"]
+    metadata["github_repo_private"] = _github_repository_private(repo_info)
 
 
 def _with_hitl_workspace_run_ownership(method):
@@ -396,12 +442,49 @@ class ResearchRunner:
                     metadata = idea_spec.setdefault("metadata", {})
                     repo_name = str(metadata.get("github_repo_name", "")).strip()
                     repo_info = None
-                    if repo_name:
+                    recorded_repo = _recorded_github_repository(metadata)
+                    if recorded_repo is not None:
+                        recorded_owner, repo_name = recorded_repo
+                        configured_owner = str(self.github_manager.owner_name or "").strip()
+                        if configured_owner.casefold() != recorded_owner.casefold():
+                            raise RuntimeError(
+                                "The recorded GitHub repository belongs to "
+                                f"'{recorded_owner}', but NeuriCo is configured for "
+                                f"'{configured_owner or '<unknown>'}'."
+                            )
                         try:
                             repo_info = self.github_manager.get_research_repo(repo_name)
                         except UnknownObjectException as e:
                             if e.status != 404:
                                 raise
+                            recorded_private = metadata.get("github_repo_private")
+                            if not isinstance(recorded_private, bool):
+                                raise RuntimeError(
+                                    "The recorded GitHub repository is unavailable and "
+                                    "its previous visibility was not recorded."
+                                ) from e
+                            repo_info = self.github_manager.create_research_repo(
+                                idea_id=idea_id,
+                                title=title,
+                                description=idea_spec.get("hypothesis", ""),
+                                private=recorded_private,
+                                domain=idea_spec.get("domain", "research"),
+                                provider=provider,
+                                no_hash=no_hash,
+                                hypothesis=idea_spec.get("hypothesis", ""),
+                                auto_init=False,
+                                exact_repo_name=repo_name,
+                            )
+                    elif repo_name:
+                        try:
+                            repo_info = self.github_manager.get_research_repo(repo_name)
+                        except UnknownObjectException as e:
+                            if e.status != 404:
+                                raise
+                            raise RuntimeError(
+                                "The recorded GitHub repository is unavailable and "
+                                "has no canonical repository URL."
+                            ) from e
                     if repo_info is None:
                         repo_info = self.github_manager.create_research_repo(
                             idea_id=idea_id,
@@ -415,8 +498,7 @@ class ResearchRunner:
                             auto_init=False,
                         )
                     github_url = repo_info["repo_url"]
-                    metadata["github_repo_name"] = repo_info["repo_name"]
-                    metadata["github_repo_url"] = github_url
+                    _record_github_repository(metadata, repo_info)
                     idea_path = self.idea_manager.get_idea_path(idea_id)
                     with open(idea_path, "w", encoding="utf-8") as f:
                         yaml.dump(
@@ -495,8 +577,7 @@ class ResearchRunner:
 
                     # Store repo_name in idea metadata
                     idea["idea"]["metadata"] = idea["idea"].get("metadata", {})
-                    idea["idea"]["metadata"]["github_repo_name"] = repo_info["repo_name"]
-                    idea["idea"]["metadata"]["github_repo_url"] = github_url
+                    _record_github_repository(idea["idea"]["metadata"], repo_info)
 
                     # Save updated metadata
                     idea_path = self.idea_manager.get_idea_path(idea_id)

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -125,7 +125,11 @@ class ResearchRunner:
     """
 
     def __init__(
-        self, project_root: Optional[Path] = None, use_github: bool = True, github_org: str = ""
+        self,
+        project_root: Optional[Path] = None,
+        use_github: bool = True,
+        github_org: str = "",
+        github_required: bool = False,
     ):
         """
         Initialize research runner.
@@ -135,7 +139,11 @@ class ResearchRunner:
                          Defaults to parent of src/
             use_github: Whether to create GitHub repos for experiments (default: True)
             github_org: GitHub organization name (empty string = personal account)
+            github_required: Fail instead of falling back when requested GitHub
+                storage is unavailable. Used by detached HITL launches.
         """
+        if github_required and not use_github:
+            raise ValueError("github_required requires use_github=True.")
         if project_root is None:
             project_root = Path(__file__).parent.parent.parent
 
@@ -152,26 +160,38 @@ class ResearchRunner:
 
         # GitHub integration
         self.use_github = use_github
+        self.github_required = github_required
         self.github_manager = None
 
         if use_github:
             if not GITHUB_AVAILABLE:
+                if github_required:
+                    raise RuntimeError("GitHub storage is unavailable: dependencies are missing.")
                 print("⚠️  GitHub integration disabled: GitHubManager not available")
                 print("   Install dependencies: pip install PyGithub GitPython")
                 self.use_github = False
             elif not os.getenv("GITHUB_TOKEN"):
+                if github_required:
+                    raise RuntimeError("GitHub storage is unavailable: GITHUB_TOKEN is not set.")
                 print("⚠️  GitHub integration disabled: GITHUB_TOKEN not set")
                 print("   Set GITHUB_TOKEN environment variable or create .env file")
                 self.use_github = False
             else:
                 try:
-                    self.github_manager = GitHubManager(org_name=github_org or None)
+                    self.github_manager = GitHubManager(
+                        org_name=github_org or None,
+                        require_org=github_required,
+                    )
                     account_label = self.github_manager.owner_name
                     if self.github_manager.use_personal_account:
                         print(f"✅ GitHub integration enabled (personal account: {account_label})")
                     else:
                         print(f"✅ GitHub integration enabled (org: {account_label})")
                 except Exception as e:
+                    if github_required:
+                        raise RuntimeError(
+                            f"GitHub storage initialization failed: {e}"
+                        ) from e
                     print(f"⚠️  GitHub integration failed: {e}")
                     self.use_github = False
 
@@ -388,7 +408,6 @@ class ResearchRunner:
                             hypothesis=idea_spec.get("hypothesis", ""),
                             auto_init=False,
                         )
-                    self.github_manager.attach_remote(work_dir, repo_info["clone_url"])
                     github_url = repo_info["repo_url"]
                     metadata["github_repo_name"] = repo_info["repo_name"]
                     metadata["github_repo_url"] = github_url
@@ -400,9 +419,12 @@ class ResearchRunner:
                             default_flow_style=False,
                             sort_keys=False,
                         )
+                    self.github_manager.attach_remote(work_dir, repo_info["clone_url"])
                     print("✅ GitHub storage attached to the HITL workspace")
                     print(f"   URL: {github_url}\n")
                 except Exception as e:
+                    if self.github_required:
+                        raise RuntimeError(f"GitHub storage setup failed: {e}") from e
                     print(f"\n⚠️  GitHub storage setup failed: {e}")
                     print("   Continuing in the authoritative HITL workspace\n")
                     self.use_github = False

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -82,10 +82,15 @@ def _with_hitl_workspace_run_ownership(method):
         from core.hitl_lock import hitl_workspace_run_lease
 
         idea_id = str(arguments.arguments["idea_id"])
-        work_dir = self._hitl_workspace_for_run_ownership(
-            idea_id,
-            force_fresh=bool(arguments.arguments["force_fresh"]),
-        )
+        requested_work_dir = arguments.arguments.get("hitl_work_dir")
+        if requested_work_dir is None:
+            work_dir = self._hitl_workspace_for_run_ownership(
+                idea_id,
+                force_fresh=bool(arguments.arguments["force_fresh"]),
+            )
+        else:
+            work_dir = Path(requested_work_dir).resolve()
+        arguments.arguments["hitl_work_dir"] = work_dir
         mode = "continue" if arguments.arguments["hitl_continue_autoresearch"] else "fresh"
         hitl_mode = normalize_hitl_mode(arguments.arguments["hitl_mode"])
         with hitl_workspace_run_lease(
@@ -103,7 +108,7 @@ def _with_hitl_workspace_run_ownership(method):
             # waiting to acquire this lease. Honor that request before the
             # runner mutates any research state.
             raise_if_hitl_run_stop_requested()
-            return method(self, *args, **kwargs)
+            return method(*arguments.args, **arguments.kwargs)
 
     return owned_run
 
@@ -170,15 +175,6 @@ class ResearchRunner:
         if idea is None:
             raise ValueError(f"Idea not found: {idea_id}")
         metadata = dict(idea.get("idea", {}).get("metadata", {}) or {})
-
-        if self.use_github and self.github_manager is not None:
-            repo_name = str(metadata.get("github_repo_name", "")).strip() or None
-            existing = self.github_manager.get_workspace_path(idea_id, repo_name)
-            if existing is not None:
-                return Path(existing).resolve()
-            if repo_name:
-                return (Path(self.github_manager.workspace_dir) / repo_name).resolve()
-
         local_workspace = str(metadata.get("local_workspace", "")).strip()
         if not force_fresh and local_workspace:
             candidate = Path(local_workspace).expanduser()
@@ -224,6 +220,7 @@ class ResearchRunner:
         hitl_manager_no_browser: bool = False,
         hitl_host: Optional[Any] = None,
         hitl_mode: str = "full",
+        hitl_work_dir: Optional[Path] = None,
     ) -> Dict[str, Any]:
         """
         Execute research for a given idea.
@@ -249,6 +246,8 @@ class ResearchRunner:
                 ``web`` or ``cli``.
             hitl_continue_autoresearch: Human interface for continuing an
                 existing HITL AutoResearch workspace: ``web`` or ``cli``.
+            hitl_work_dir: Authoritative workspace selected by the HITL launcher.
+                Internal to HITL execution; GitHub publication cannot replace it.
 
         Returns:
             Dictionary with:
@@ -277,6 +276,8 @@ class ResearchRunner:
         if len(selected_hitl_modes) > 1:
             raise ValueError("Choose one HITL entry mode: " + ", ".join(selected_hitl_modes))
         hitl = hitl_autoresearch or hitl_continue_autoresearch
+        if hitl_work_dir is not None and not hitl:
+            raise ValueError("hitl_work_dir is valid only with a HITL AutoResearch entry mode.")
         selected_hitl_mode = normalize_hitl_mode(hitl_mode)
         if selected_hitl_mode is HitlMode.AUTO and not hitl:
             raise ValueError("--auto is valid only with a HITL AutoResearch entry mode.")
@@ -352,11 +353,56 @@ class ResearchRunner:
         # Update status
         self.idea_manager.update_status(idea_id, "in_progress")
 
-        # Setup working directory (GitHub repo or local runs/)
+        # Setup working directory. HITL launchers select the authoritative local
+        # workspace before the run; GitHub is only an optional publication target.
         github_url = None
         github_repo = None
 
-        if self.use_github and self.github_manager:
+        if hitl_work_dir is not None:
+            work_dir = Path(hitl_work_dir).resolve()
+            if not work_dir.exists() or not work_dir.is_dir():
+                raise ValueError(f"HITL workspace does not exist: {work_dir}")
+            is_resuming = (work_dir / ".neurico" / "pipeline_state.json").exists()
+            print(f"\n✅ Using authoritative HITL workspace: {work_dir}\n")
+
+            if self.use_github and self.github_manager:
+                try:
+                    metadata = idea_spec.setdefault("metadata", {})
+                    repo_name = str(metadata.get("github_repo_name", "")).strip()
+                    if repo_name:
+                        repo_info = self.github_manager.get_research_repo(repo_name)
+                    else:
+                        repo_info = self.github_manager.create_research_repo(
+                            idea_id=idea_id,
+                            title=title,
+                            description=idea_spec.get("hypothesis", ""),
+                            private=private,
+                            domain=idea_spec.get("domain", "research"),
+                            provider=provider,
+                            no_hash=no_hash,
+                            hypothesis=idea_spec.get("hypothesis", ""),
+                            auto_init=False,
+                        )
+                    self.github_manager.attach_remote(work_dir, repo_info["clone_url"])
+                    github_url = repo_info["repo_url"]
+                    metadata["github_repo_name"] = repo_info["repo_name"]
+                    metadata["github_repo_url"] = github_url
+                    idea_path = self.idea_manager.get_idea_path(idea_id)
+                    with open(idea_path, "w", encoding="utf-8") as f:
+                        yaml.dump(
+                            without_runtime_compute_backend(idea),
+                            f,
+                            default_flow_style=False,
+                            sort_keys=False,
+                        )
+                    print("✅ GitHub storage attached to the HITL workspace")
+                    print(f"   URL: {github_url}\n")
+                except Exception as e:
+                    print(f"\n⚠️  GitHub storage setup failed: {e}")
+                    print("   Continuing in the authoritative HITL workspace\n")
+                    self.use_github = False
+
+        elif self.use_github and self.github_manager:
             # Check if workspace already exists from submission
             # Try to get repo_name from metadata (new method with short names)
             repo_name = idea_spec.get("metadata", {}).get("github_repo_name")
@@ -454,7 +500,7 @@ class ResearchRunner:
                     self.use_github = False
                     # Fall through to local setup below
 
-        if not self.use_github:
+        if hitl_work_dir is None and not self.use_github:
             existing_workspace = idea.get("idea", {}).get("metadata", {}).get("local_workspace")
 
             if not force_fresh and existing_workspace and Path(existing_workspace).exists():
@@ -602,7 +648,15 @@ class ResearchRunner:
                 print(f"\n❌ Continue AutoResearch error: {e}")
                 success = False
             finally:
-                self._finalize_research(idea_id, work_dir, github_url, title, provider, success)
+                self._finalize_research(
+                    idea_id,
+                    work_dir,
+                    github_url,
+                    title,
+                    provider,
+                    success,
+                    push_existing=hitl_work_dir is not None,
+                )
                 if owns_hitl_host:
                     hitl_host.stop()
 
@@ -655,7 +709,15 @@ class ResearchRunner:
                 print(f"\n❌ Bootstrap AutoResearch baseline error: {e}")
                 success = False
             finally:
-                self._finalize_research(idea_id, work_dir, github_url, title, provider, success)
+                self._finalize_research(
+                    idea_id,
+                    work_dir,
+                    github_url,
+                    title,
+                    provider,
+                    success,
+                    push_existing=hitl_work_dir is not None,
+                )
                 if owns_hitl_host:
                     hitl_host.stop()
 
@@ -843,7 +905,15 @@ class ResearchRunner:
                 # Don't raise - let finally block handle cleanup
             finally:
                 # GitHub integration and status updates
-                self._finalize_research(idea_id, work_dir, github_url, title, provider, success)
+                self._finalize_research(
+                    idea_id,
+                    work_dir,
+                    github_url,
+                    title,
+                    provider,
+                    success,
+                    push_existing=hitl_work_dir is not None,
+                )
                 if owns_hitl_host:
                     hitl_host.stop()
 
@@ -1339,6 +1409,7 @@ https://github.com/ChicagoHAI/neurico
         title: str,
         provider: str,
         success: bool,
+        push_existing: bool = False,
     ):
         """
         Finalize research execution: commit to GitHub and update status.
@@ -1350,6 +1421,8 @@ https://github.com/ChicagoHAI/neurico
             title: Research title
             provider: AI provider used
             success: Whether research succeeded
+            push_existing: Push an already committed HITL checkpoint even when
+                finalization has no new working-tree changes.
         """
         # Commit and push to GitHub if enabled
         if self.use_github and self.github_manager:
@@ -1370,7 +1443,11 @@ https://github.com/ChicagoHAI/neurico
 """
 
                 # Commit and push
-                self.github_manager.commit_and_push(work_dir, commit_msg)
+                self.github_manager.commit_and_push(
+                    work_dir,
+                    commit_msg,
+                    push_if_clean=push_existing,
+                )
 
                 print(f"\n🎉 Results published to GitHub!")
                 if github_url:

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -419,6 +419,9 @@ class ResearchRunner:
                             default_flow_style=False,
                             sort_keys=False,
                         )
+                    from core.autoresearch import CheckpointManager
+
+                    CheckpointManager(work_dir)
                     self.github_manager.attach_remote(work_dir, repo_info["clone_url"])
                     print("✅ GitHub storage attached to the HITL workspace")
                     print(f"   URL: {github_url}\n")

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -58,6 +58,7 @@ LOGGER = logging.getLogger(__name__)
 
 try:
     from core.github_manager import GitHubManager
+    from github.GithubException import UnknownObjectException
 
     GITHUB_AVAILABLE = True
 except ImportError:
@@ -394,9 +395,14 @@ class ResearchRunner:
                 try:
                     metadata = idea_spec.setdefault("metadata", {})
                     repo_name = str(metadata.get("github_repo_name", "")).strip()
+                    repo_info = None
                     if repo_name:
-                        repo_info = self.github_manager.get_research_repo(repo_name)
-                    else:
+                        try:
+                            repo_info = self.github_manager.get_research_repo(repo_name)
+                        except UnknownObjectException as e:
+                            if e.status != 404:
+                                raise
+                    if repo_info is None:
                         repo_info = self.github_manager.create_research_repo(
                             idea_id=idea_id,
                             title=title,

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -619,6 +619,7 @@ class ResearchRunner:
             success = False
             hitl_stop_requested = False
             pipeline_result: Dict[str, Any] = {}
+            github_publication: Optional[Dict[str, Any]] = None
             try:
                 if hitl:
                     from core.hitl_autoresearch import continue_hitl_autoresearch
@@ -677,7 +678,7 @@ class ResearchRunner:
                 print(f"\n❌ Continue AutoResearch error: {e}")
                 success = False
             finally:
-                self._finalize_research(
+                github_publication = self._finalize_research(
                     idea_id,
                     work_dir,
                     github_url,
@@ -690,16 +691,20 @@ class ResearchRunner:
                 if owns_hitl_host:
                     hitl_host.stop()
 
-            return {
+            result = {
                 "work_dir": work_dir,
                 "github_url": github_url,
                 "success": success,
                 "autoresearch": pipeline_result.get("autoresearch"),
             }
+            if hitl:
+                result["github_publication"] = github_publication
+            return result
 
         if bootstrap_autoresearch_baseline or hitl_bootstrap_autoresearch_baseline:
             success = False
             baseline_result: Dict[str, Any] = {}
+            github_publication: Optional[Dict[str, Any]] = None
             try:
                 bootstrap_args = dict(
                     idea=idea,
@@ -739,7 +744,7 @@ class ResearchRunner:
                 print(f"\n❌ Bootstrap AutoResearch baseline error: {e}")
                 success = False
             finally:
-                self._finalize_research(
+                github_publication = self._finalize_research(
                     idea_id,
                     work_dir,
                     github_url,
@@ -751,12 +756,15 @@ class ResearchRunner:
                 if owns_hitl_host:
                     hitl_host.stop()
 
-            return {
+            result = {
                 "work_dir": work_dir,
                 "github_url": github_url,
                 "success": success,
                 "bootstrap_autoresearch_baseline": baseline_result,
             }
+            if hitl:
+                result["github_publication"] = github_publication
+            return result
 
         # Choose execution mode: multi-agent pipeline or legacy monolithic
         if multi_agent:
@@ -795,6 +803,7 @@ class ResearchRunner:
             )
             success = False
             hitl_stop_requested = False
+            github_publication: Optional[Dict[str, Any]] = None
 
             # If resuming into an existing workspace, check which stages already completed
             # and skip them — read pipeline_state.json directly rather than relying on
@@ -937,7 +946,7 @@ class ResearchRunner:
                 # Don't raise - let finally block handle cleanup
             finally:
                 # GitHub integration and status updates
-                self._finalize_research(
+                github_publication = self._finalize_research(
                     idea_id,
                     work_dir,
                     github_url,
@@ -957,6 +966,8 @@ class ResearchRunner:
                 "success": success,
                 "pipeline_result": pipeline_result,
             }
+            if hitl:
+                result["github_publication"] = github_publication
             if "autoresearch_initial_node" in pipeline_result:
                 result["autoresearch_initial_node"] = pipeline_result["autoresearch_initial_node"]
             if "autoresearch" in pipeline_result:
@@ -1444,7 +1455,7 @@ https://github.com/ChicagoHAI/neurico
         success: bool,
         push_existing: bool = False,
         publish_github: bool = True,
-    ):
+    ) -> Optional[Dict[str, Any]]:
         """
         Finalize research execution: commit to GitHub and update status.
 
@@ -1460,8 +1471,11 @@ https://github.com/ChicagoHAI/neurico
             publish_github: Whether this finalization may publish the workspace.
                 Disabled while a HITL stop is awaiting rollback.
         """
+        publication: Optional[Dict[str, Any]] = None
+
         # Commit and push to GitHub if enabled
         if publish_github and self.use_github and self.github_manager:
+            publication = {"requested": True, "status": "pending"}
             try:
                 print()
                 print("📤 Pushing results to GitHub...")
@@ -1479,18 +1493,32 @@ https://github.com/ChicagoHAI/neurico
 """
 
                 # Commit and push
-                self.github_manager.commit_and_push(
+                pushed = self.github_manager.commit_and_push(
                     work_dir,
                     commit_msg,
                     push_if_clean=push_existing,
                 )
 
-                print(f"\n🎉 Results published to GitHub!")
-                if github_url:
-                    print(f"   {github_url}")
+                if not pushed:
+                    if getattr(self, "github_required", False):
+                        raise RuntimeError("GitHub publication did not push a checkpoint.")
+                    publication["status"] = "unchanged"
+                else:
+                    from git import Repo as GitRepo
+
+                    publication.update(
+                        status="succeeded",
+                        commit_sha=GitRepo(work_dir).head.commit.hexsha,
+                    )
+
+                    print(f"\n🎉 Results published to GitHub!")
+                    if github_url:
+                        print(f"   {github_url}")
 
             except Exception as e:
-                print(f"\n⚠️  Failed to push to GitHub: {e}")
+                message = sanitize_text(str(e).strip() or e.__class__.__name__)
+                publication.update(status="failed", message=message)
+                print(f"\n⚠️  Failed to push to GitHub: {message}")
                 print("   Results are available locally")
 
         # Update idea status
@@ -1504,6 +1532,8 @@ https://github.com/ChicagoHAI/neurico
         print(f"   Location: {work_dir}")
         if github_url:
             print(f"   GitHub: {github_url}")
+
+        return publication
 
 
 def main():

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -468,7 +468,7 @@ class ResearchRunner:
                     idea["idea"]["metadata"]["github_repo_url"] = github_url
 
                     # Save updated metadata
-                    idea_path = self.idea_manager.ideas_dir / "submitted" / f"{idea_id}.yaml"
+                    idea_path = self.idea_manager.get_idea_path(idea_id)
                     with open(idea_path, "w", encoding="utf-8") as f:
                         yaml.dump(
                             without_runtime_compute_backend(idea),

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -82,14 +82,19 @@ def _with_hitl_workspace_run_ownership(method):
         from core.hitl_lock import hitl_workspace_run_lease
 
         idea_id = str(arguments.arguments["idea_id"])
+        expected_work_dir = self._hitl_workspace_for_run_ownership(
+            idea_id,
+            force_fresh=bool(arguments.arguments["force_fresh"]),
+        )
         requested_work_dir = arguments.arguments.get("hitl_work_dir")
-        if requested_work_dir is None:
-            work_dir = self._hitl_workspace_for_run_ownership(
-                idea_id,
-                force_fresh=bool(arguments.arguments["force_fresh"]),
-            )
-        else:
-            work_dir = Path(requested_work_dir).resolve()
+        if requested_work_dir is not None:
+            requested_work_dir = Path(requested_work_dir).expanduser().resolve()
+            if requested_work_dir != expected_work_dir:
+                raise ValueError(
+                    "HITL workspace does not match the workspace registered for "
+                    f"idea {idea_id}."
+                )
+        work_dir = expected_work_dir
         arguments.arguments["hitl_work_dir"] = work_dir
         mode = "continue" if arguments.arguments["hitl_continue_autoresearch"] else "fresh"
         hitl_mode = normalize_hitl_mode(arguments.arguments["hitl_mode"])

--- a/src/core/runner.py
+++ b/src/core/runner.py
@@ -595,6 +595,7 @@ class ResearchRunner:
 
         if continue_autoresearch:
             success = False
+            hitl_stop_requested = False
             pipeline_result: Dict[str, Any] = {}
             try:
                 if hitl:
@@ -648,6 +649,7 @@ class ResearchRunner:
                         hitl_enabled=bool(hitl),
                     )
             except HitlRunStopRequested:
+                hitl_stop_requested = True
                 raise
             except Exception as e:
                 print(f"\n❌ Continue AutoResearch error: {e}")
@@ -661,6 +663,7 @@ class ResearchRunner:
                     provider,
                     success,
                     push_existing=hitl_work_dir is not None,
+                    publish_github=not hitl_stop_requested,
                 )
                 if owns_hitl_host:
                     hitl_host.stop()
@@ -769,6 +772,7 @@ class ResearchRunner:
                 hitl_mode=selected_hitl_mode,
             )
             success = False
+            hitl_stop_requested = False
 
             # If resuming into an existing workspace, check which stages already completed
             # and skip them — read pipeline_state.json directly rather than relying on
@@ -903,6 +907,7 @@ class ResearchRunner:
                     )
 
             except HitlRunStopRequested:
+                hitl_stop_requested = True
                 raise
             except Exception as e:
                 print(f"\n❌ Pipeline error: {e}")
@@ -918,6 +923,7 @@ class ResearchRunner:
                     provider,
                     success,
                     push_existing=hitl_work_dir is not None,
+                    publish_github=not hitl_stop_requested,
                 )
                 if owns_hitl_host:
                     hitl_host.stop()
@@ -1415,6 +1421,7 @@ https://github.com/ChicagoHAI/neurico
         provider: str,
         success: bool,
         push_existing: bool = False,
+        publish_github: bool = True,
     ):
         """
         Finalize research execution: commit to GitHub and update status.
@@ -1428,9 +1435,11 @@ https://github.com/ChicagoHAI/neurico
             success: Whether research succeeded
             push_existing: Push an already committed HITL checkpoint even when
                 finalization has no new working-tree changes.
+            publish_github: Whether this finalization may publish the workspace.
+                Disabled while a HITL stop is awaiting rollback.
         """
         # Commit and push to GitHub if enabled
-        if self.use_github and self.github_manager:
+        if publish_github and self.use_github and self.github_manager:
             try:
                 print()
                 print("📤 Pushing results to GitHub...")

--- a/src/core/security.py
+++ b/src/core/security.py
@@ -9,7 +9,7 @@ This module provides:
 
 import re
 import os
-from typing import Dict, Set, Optional
+from typing import Dict, MutableMapping, Set, Optional
 from pathlib import Path
 
 
@@ -49,6 +49,19 @@ SENSITIVE_ENV_VARS: Set[str] = {
     'COMET_API_KEY',
     'REPLICATE_API_TOKEN',
 }
+
+GITHUB_CREDENTIAL_ENV_VARS = frozenset({
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_PAT",
+})
+
+
+def remove_github_credentials(environment: MutableMapping[str, str]) -> None:
+    """Keep runtime-owned GitHub credentials out of research subprocesses."""
+    for name in GITHUB_CREDENTIAL_ENV_VARS:
+        environment.pop(name, None)
+
 
 # Regex patterns for detecting API keys in text
 # Each tuple is (pattern, replacement)

--- a/src/interactive/llm_backend.py
+++ b/src/interactive/llm_backend.py
@@ -18,6 +18,8 @@ import subprocess
 import threading
 import time
 
+from core.security import remove_github_credentials
+
 
 @dataclass
 class ToolCall:
@@ -75,6 +77,13 @@ class LLMBackend:
         with self._process_lock:
             if self._active_process is process:
                 self._active_process = None
+
+    @staticmethod
+    def _manager_process_environment() -> Dict[str, str]:
+        """Return provider environment without runtime-owned GitHub credentials."""
+        environment = os.environ.copy()
+        remove_github_credentials(environment)
+        return environment
 
     def send(
         self,
@@ -168,6 +177,7 @@ class LLMBackend:
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
+            env=self._manager_process_environment(),
             start_new_session=(os.name == "posix"),
         )
         self._set_active_process(process)
@@ -388,6 +398,11 @@ class LLMBackend:
             # Safe mode also suppresses local hooks and project instructions,
             # while preserving OAuth/keychain authentication for Claude Code.
             cmd.extend(["--safe-mode", "--tools", ""])
+
+        if process_env is None:
+            process_env = self._manager_process_environment()
+        else:
+            remove_github_credentials(process_env)
 
         process = subprocess.Popen(
             cmd,

--- a/src/interactive/static/hitl/hitl.css
+++ b/src/interactive/static/hitl/hitl.css
@@ -29,4 +29,6 @@
 .portal-workspace-error{align-content:center;justify-items:center;gap:8px;padding:32px;text-align:center}.portal-workspace-error strong{color:var(--text);font-size:18px}.portal-workspace-error p{max-width:720px;margin:0;color:#c6d0cc;line-height:1.5}.portal-workspace-error span{color:var(--muted)}
 
 .status-mode{padding:3px 7px;border:1px solid var(--line);border-radius:999px;color:var(--muted);font-size:11px;white-space:nowrap}
+.workspace-state.publication_failed{color:var(--coral)}
+.portal-status.publication_failed{background:var(--coral)}
 @media(max-width:740px){.status-mode{display:none}}


### PR DESCRIPTION
## Summary

This PR fixes GitHub publishing for AutoResearch. The local workspace is now the source of truth throughout the run, and GitHub is treated as an optional storage destination.

Previously, enabling GitHub could change which workspace NeuriCo opened, create ownership against a different path, or pull remote state into the local run. Startup and publication failures could also be hidden, leaving the interface unable to explain why a run did not start or why its results were not published.

## Workspace and repository setup

The AutoResearch launcher now passes its selected workspace directly into the research runner. The runner validates that workspace before acquiring run ownership and uses the same path for fresh and continued runs.

When GitHub publishing is enabled, NeuriCo attaches the workspace to the configured repository without cloning, pulling, or replacing local state. If the repository recorded by the idea has been deleted, NeuriCo creates a new empty repository and publishes the existing local history to it. Repository metadata is written back to the idea’s current registration file.

The detached run worker now loads the project environment before GitHub setup. Selecting GitHub publishing therefore requires valid credentials and organization configuration. Setup failures stop startup and are shown in the interface instead of silently changing the run to local-only mode.

## Publication

A stopped run is no longer published before rollback completes. Successful runs publish the final local checkpoint, including cases where AutoResearch already committed the result and the working tree is clean.

GitHub push results are now checked rather than treating the push call itself as success. Rejected and failed pushes are recorded in the durable launch status, returned as run failures, and presented in the web interface with the underlying sanitized error. The completed local workspace remains available when publication fails.

## Credential boundary

GitHub credentials are now owned by the runtime publishing path. They are removed before starting the manager, coding agents, and provider subprocesses, and are supplied only to the Git process performing the push. The token is no longer written into the workspace’s remote URL.