### PR TITLE
fix(hitl): prevent unattended worker background jobs

### DIFF
--- a/src/core/hitl.py
+++ b/src/core/hitl.py
@@ -1446,11 +1446,26 @@ class HitlRuntime:
         response = pending.get("response")
         return dict(response) if isinstance(response, dict) else None
 
+    def _replacement_prompt_after_worker_exit(
+        self,
+        prompt_block: str,
+        result: Dict[str, Any],
+    ) -> str:
+        """Report prior job cleanup only when runtime actually performed it."""
+        prompt = str(prompt_block).strip()
+        if not result.get("background_processes_terminated"):
+            return prompt
+        notice = _load_hitl_template(
+            "worker_previous_background_jobs_terminated.txt"
+        ).strip()
+        return f"{notice}\n\n{prompt}"
+
     def _pending_worker_request_replacement(
         self,
         *,
         phase: str,
         worker_name: str,
+        result: Dict[str, Any],
     ) -> Optional[Dict[str, Any]]:
         """Reconnect a replacement worker to one durable held command."""
         from core.hitl_runtime_state import HitlRuntimeState, worker_command_requires_resume
@@ -1463,7 +1478,10 @@ class HitlRuntime:
         if not str(continuation.get("prompt_block", "")).strip():
             return None
 
-        prompt_block = _load_hitl_template("worker_resume_pending_request.txt")
+        prompt_block = self._replacement_prompt_after_worker_exit(
+            _load_hitl_template("worker_resume_pending_request.txt"),
+            result,
+        )
         self._update_worker_continuation(
             prompt_block=prompt_block,
             hitl_stage=str(continuation.get("hitl_stage", "")).strip() or None,
@@ -1913,6 +1931,10 @@ class HitlRuntime:
             continuation = self.worker_continuation()
             prompt_block = str((continuation or {}).get("prompt_block", "")).strip()
             if prompt_block:
+                prompt_block = self._replacement_prompt_after_worker_exit(
+                    prompt_block,
+                    result,
+                )
                 self._update_worker_continuation(status="replacement_pending")
                 from core.hitl_runtime_state import HitlRuntimeState
 
@@ -1939,6 +1961,7 @@ class HitlRuntime:
         pending_replacement = self._pending_worker_request_replacement(
             phase="proposal",
             worker_name=worker_name,
+            result=result,
         )
         if pending_replacement is not None:
             return pending_replacement
@@ -1957,6 +1980,10 @@ class HitlRuntime:
         continuation = HitlRuntime.worker_continuation(self)
         prompt_block = str((continuation or {}).get("prompt_block", "")).strip()
         if prompt_block:
+            prompt_block = self._replacement_prompt_after_worker_exit(
+                prompt_block,
+                result,
+            )
             self._update_worker_continuation(status="replacement_pending")
             from core.hitl_runtime_state import HitlRuntimeState
 
@@ -3340,6 +3367,7 @@ class HitlRuntime:
         pending_replacement = self._pending_worker_request_replacement(
             phase=phase,
             worker_name=worker_name,
+            result=result,
         )
         if pending_replacement is not None:
             return pending_replacement
@@ -3363,6 +3391,10 @@ class HitlRuntime:
                 (finish or {}).get("prompt_block") or continuation.get("prompt_block", "")
             ).strip()
             if prompt_block:
+                prompt_block = self._replacement_prompt_after_worker_exit(
+                    prompt_block,
+                    result,
+                )
                 self._update_worker_continuation(
                     prompt_block=prompt_block,
                     hitl_stage=str(

--- a/templates/agents/autoresearch_proposer.txt
+++ b/templates/agents/autoresearch_proposer.txt
@@ -1,5 +1,9 @@
 You are the AutoResearch proposal generator for NeuriCo.
 
+{% if hitl_idea_reporting %}
+{% include "hitl/worker_background_job_contract.txt" %}
+{% endif %}
+
 Your job is to prepare one structured proposal for the next experiment-stage
 attempt. You are a planner only. Do not modify public research-workspace files.
 {% if hitl_submission %}Submit the complete proposal through the runtime HITL command described below.{% else %}You must write the proposal artifact at the required proposal output path below.{% endif %}

--- a/templates/hitl/worker_background_job_contract.txt
+++ b/templates/hitl/worker_background_job_contract.txt
@@ -1,0 +1,5 @@
+It is illegal to end the session or request phase completion while any job you
+started is running in the background. You must monitor all jobs that you start
+until they complete successfully, and you must verify their outputs before
+proceeding. Any background job you leave behind unattended is considered
+illegal and dangerous, and it will be terminated.

--- a/templates/hitl/worker_execution.txt
+++ b/templates/hitl/worker_execution.txt
@@ -3,6 +3,8 @@
 ═══════════════════════════════════════════════════════════════════════════════
 
 You are the stage worker for `{{ pipeline_stage }}` in HITL `{{ mode }}` mode.
+
+{% include "hitl/worker_background_job_contract.txt" %}
 {% if autoresearch_attempt %}
 
 {% include "hitl/worker_autoresearch_candidate_boundary.txt" %}

--- a/templates/hitl/worker_plan.txt
+++ b/templates/hitl/worker_plan.txt
@@ -4,6 +4,8 @@
 
 You are the stage worker for `{{ pipeline_stage }}`. This invocation is only for
 planning. The output is a living control artifact, not a final report.
+
+{% include "hitl/worker_background_job_contract.txt" %}
 {% if autoresearch_attempt %}
 
 {% include "hitl/worker_autoresearch_candidate_boundary.txt" %}

--- a/templates/hitl/worker_plan_revision.txt
+++ b/templates/hitl/worker_plan_revision.txt
@@ -4,6 +4,8 @@
 
 You are revising your own `{{ pipeline_stage }}` living plan at `{{ plan_path }}`.
 
+{% include "hitl/worker_background_job_contract.txt" %}
+
 This is plan revision only. Do not perform stage work.
 {% if autoresearch_attempt %}
 

--- a/templates/hitl/worker_previous_background_jobs_terminated.txt
+++ b/templates/hitl/worker_previous_background_jobs_terminated.txt
@@ -1,0 +1,5 @@
+The previous worker left behind background jobs when it ended its session,
+which is considered illegal and dangerous. Therefore, all background jobs it
+left behind have been terminated, and it is illegal for you to rely on those
+jobs as well. You must continue working independently based on the current
+workspace and finish all tasks required of you.

--- a/templates/hitl/worker_resume_pending_request.txt
+++ b/templates/hitl/worker_resume_pending_request.txt
@@ -1,5 +1,7 @@
 Runtime restarted after the earlier worker session ended unexpectedly.
 
+{% include "hitl/worker_background_job_contract.txt" %}
+
 Do not change the workspace yet. Run `hitl-resume-worker-request` and wait for
 runtime's result. Follow the returned instruction exactly. If runtime returns
 feedback, apply it in this same session. If runtime returns approval, follow

--- a/templates/hitl/worker_review_revision.txt
+++ b/templates/hitl/worker_review_revision.txt
@@ -3,6 +3,8 @@
 ═══════════════════════════════════════════════════════════════════════════════
 
 You are revising `{{ pipeline_stage }}` artifacts after manager review.
+
+{% include "hitl/worker_background_job_contract.txt" %}
 {% if autoresearch_attempt %}
 
 {% include "hitl/worker_autoresearch_candidate_boundary.txt" %}

--- a/templates/hitl/worker_terminal_contract.txt
+++ b/templates/hitl/worker_terminal_contract.txt
@@ -18,7 +18,6 @@ instruction and retry it in this same worker session. If it prints
 in this worker session. Only if an external non-HITL blocker prevents that retry,
 record the current progress and blocker in the plan.
 
-Do not leave required work running unattended in the background.
 Do not state that you will return later.
 Do not create or modify `scoring/results.json`.
 Do not read or modify hidden scoring files.

--- a/tests/test_hitl_provider_failure_propagation.py
+++ b/tests/test_hitl_provider_failure_propagation.py
@@ -12,10 +12,18 @@ import agents.resource_finder as resource_finder  # noqa: E402
 import agents.rule_maker as rule_maker  # noqa: E402
 import core.agent_runner as agent_runner  # noqa: E402
 import core.pipeline_orchestrator as pipeline  # noqa: E402
-from core.hitl import HitlRuntime  # noqa: E402
+from core.hitl import HitlRuntime, _load_hitl_template  # noqa: E402
 from core.hitl_run_control import HitlRunStopRequested  # noqa: E402
 from core.hitl_runtime_state import HitlRuntimeState  # noqa: E402
 from core.hitl_stage_runtime import run_worker_with_replacements  # noqa: E402
+
+
+BACKGROUND_JOB_RULE = (
+    "It is illegal to end the session or request phase completion while any job you"
+)
+TERMINATED_BACKGROUND_JOB_NOTICE = (
+    "The previous worker left behind background jobs when it ended its session"
+)
 
 
 def _launch_result(*, failed: bool, return_code: int) -> dict:
@@ -179,3 +187,138 @@ def test_finalized_result_wins_over_late_provider_process_failure(tmp_path):
 
     assert result["approved"] is True
     assert HitlRuntimeState(tmp_path).worker_continuation() is None
+
+
+def test_all_stage_worker_prompts_include_background_job_rule(tmp_path):
+    runtime = HitlRuntime(
+        tmp_path,
+        "rule_maker",
+        channel=object(),
+        manager=object(),
+    )
+
+    prompts = [
+        runtime.plan_prompt_block(),
+        runtime.execution_prompt_block(),
+        runtime.plan_revision_prompt_block("revise"),
+        runtime.review_prompt_block("revise"),
+        _load_hitl_template("worker_resume_pending_request.txt"),
+    ]
+
+    assert all(BACKGROUND_JOB_RULE in prompt for prompt in prompts)
+
+
+def test_hitl_proposer_prompt_includes_background_job_rule(tmp_path):
+    attempt_dir = tmp_path / "attempt"
+    attempt_dir.mkdir()
+
+    prompt = proposer.generate_autoresearch_proposal_prompt(
+        {"idea": {"title": "Test"}},
+        tmp_path,
+        parent_sha="abc123",
+        attempt_dir=attempt_dir,
+        templates_dir=Path(__file__).resolve().parents[1] / "templates",
+        hitl_idea_reporting=True,
+        hitl_submission=True,
+    )
+    ordinary_prompt = proposer.generate_autoresearch_proposal_prompt(
+        {"idea": {"title": "Test"}},
+        tmp_path,
+        parent_sha="abc123",
+        attempt_dir=attempt_dir,
+        templates_dir=Path(__file__).resolve().parents[1] / "templates",
+    )
+
+    assert BACKGROUND_JOB_RULE in prompt
+    assert BACKGROUND_JOB_RULE not in ordinary_prompt
+
+
+def test_replacement_prompt_reports_only_actual_background_job_cleanup(tmp_path):
+    runtime = HitlRuntime(
+        tmp_path,
+        "rule_maker",
+        channel=object(),
+        manager=object(),
+    )
+    clean_result = _launch_result(failed=False, return_code=0)
+    background_result = {
+        **clean_result,
+        "success": False,
+        "background_processes_terminated": True,
+    }
+
+    clean_prompt = runtime._replacement_prompt_after_worker_exit(
+        "Continue the phase.",
+        clean_result,
+    )
+    replacement_prompt = runtime._replacement_prompt_after_worker_exit(
+        "Continue the phase.",
+        background_result,
+    )
+
+    assert clean_prompt == "Continue the phase."
+    assert TERMINATED_BACKGROUND_JOB_NOTICE not in clean_prompt
+    assert replacement_prompt.startswith(TERMINATED_BACKGROUND_JOB_NOTICE)
+    assert replacement_prompt.endswith("Continue the phase.")
+
+
+def test_pending_request_replacement_receives_background_job_notice(tmp_path):
+    runtime = HitlRuntime(
+        tmp_path,
+        "rule_maker",
+        channel=object(),
+        manager=object(),
+    )
+    runtime.paths.tool_bin_dir.mkdir(parents=True, exist_ok=True)
+    runtime.register_worker_prompt("Continue the phase.")
+    HitlRuntimeState(tmp_path).begin_worker_command(
+        {
+            "request_key": "request-1",
+            "kind": "phase_finish",
+            "hitl_stage": "execution",
+            "status": "pending",
+        }
+    )
+    result = {
+        **_launch_result(failed=False, return_code=0),
+        "success": False,
+        "background_processes_terminated": True,
+    }
+
+    replacement = runtime.handle_worker_exit_after_finish(
+        result,
+        phase="execute",
+        worker_name="rule maker",
+    )
+
+    assert replacement["replacement"] is True
+    assert replacement["prompt_block"].startswith(TERMINATED_BACKGROUND_JOB_NOTICE)
+    assert BACKGROUND_JOB_RULE in replacement["prompt_block"]
+
+
+def test_proposal_feedback_replacement_receives_background_job_notice(tmp_path):
+    runtime = HitlRuntime(
+        tmp_path,
+        "experiment_runner",
+        channel=object(),
+        manager=object(),
+    )
+    runtime.register_worker_prompt("Create the replacement proposal.")
+    runtime._proposal_submit_result = {
+        "status": "feedback",
+        "feedback": "Revise the proposal.",
+    }
+    result = {
+        **_launch_result(failed=False, return_code=0),
+        "success": False,
+        "background_processes_terminated": True,
+    }
+
+    replacement = runtime.proposal_submit_result_after_worker_exit(
+        result,
+        worker_name="proposal generator",
+    )
+
+    assert replacement["replacement"] is True
+    assert replacement["prompt_block"].startswith(TERMINATED_BACKGROUND_JOB_NOTICE)
+    assert replacement["prompt_block"].endswith("Create the replacement proposal.")


### PR DESCRIPTION
## Summary

This PR prevents workers from abandoning required background jobs before they finish.

A worker could start a long-running command, end its session, and leave the command behind. NeuriCo would correctly terminate the remaining process, but the replacement worker was not told what happened and could repeat the same behavior indefinitely.

## Changes

- Added a shared rule requiring workers to monitor every job they start until it completes and its outputs are verified.
- Applied the rule to all Full and AutoResearch worker prompts, including replacement workers and proposal generation.
- Added replacement-specific context when NeuriCo terminated jobs left by the previous worker.
- Kept the existing process cleanup and worker-replacement behavior unchanged.